### PR TITLE
Improve tag transformer to support both dash and colon syntax.

### DIFF
--- a/src/common/transformer/index.js
+++ b/src/common/transformer/index.js
@@ -7,11 +7,13 @@
  * @param {Object} context
  */
 function transform(el, context) {
+    const parentTag = el.tagName;
     el.body.forEach(child => {
+        const childTag = child.tagName;
         // find the matching tag based on the child tag name of
         // the children matching the given tagName
-        if (child.tagName) {
-            const outputTag = child.tagName.replace(/(.*?)\-(?=[^-]*$)(.*)$/g, '$1:$2');
+        if (childTag && childTag.indexOf(`${parentTag}-`) === 0) {
+            const outputTag = `${parentTag}:${childTag.slice(parentTag.length + 1)}`;
             const nestedTag = context.createNodeForEl(outputTag, child.getAttributes());
             nestedTag.body = child.body;
             child.replaceWith(nestedTag);

--- a/src/common/transformer/test/test.server.js
+++ b/src/common/transformer/test/test.server.js
@@ -61,3 +61,20 @@ describe('when the ebay-menu-item tag is transformed', () => {
         expect(outputTemplate).to.deep.equal(tagString.after);
     });
 });
+
+describe('when the ebay-menu:item tag is transformed', () => {
+    let tagString;
+    let outputTemplate;
+
+    beforeEach(() => {
+        const rootTag = 'ebay-menu';
+        const nestedTag = 'item';
+        const templatePath = `../../../components/${rootTag}/template.marko`;
+        tagString = getTagString(rootTag, nestedTag);
+        outputTemplate = getTransformedTemplate(tagString.after, templatePath);
+    });
+
+    test('leaves tag as is', () => {
+        expect(outputTemplate).to.deep.equal(tagString.after);
+    });
+});


### PR DESCRIPTION
## Description
Previously child elements using the `colon` syntax were transformed incorrectly.
Now they are left as is and both dash and colon syntax is supported.

## Context
Now checks for an exact match based on the parent tag.

Previously:
`ebay-menu:item` => `ebay:menu:item`

## References
Issue #14
