### PR TITLE
Added ebay-notice component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist
 .browser-refresh
 integration/template.marko
 integration/browser.json
+/.vscode
+.yarnclean

--- a/demo/browser.json
+++ b/demo/browser.json
@@ -9,6 +9,7 @@
         "../src/components/ebay-button",
         "../src/components/ebay-carousel",
         "../src/components/ebay-menu",
-        "../src/components/ebay-listbox"
+        "../src/components/ebay-listbox",
+        "../src/components/ebay-notice"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "marko-components"
   ],
   "devDependencies": {
-    "@ebay/skin": "^3.3.0-0",
+    "@ebay/skin": "^3.4.0-0",
     "@lasso/marko-taglib": "^1.0.9",
     "async": "^2.6.0",
     "babel-cli": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@ebay/skin@^3.3.0-0":
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-3.3.2.tgz#67577533fe143390b6ab5ab3d95cf21dd10e2ab1"
+"@ebay/skin@^3.4.0-0":
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-3.4.0.tgz#67e6504a1dc239ad05f13cb07c48a1711b3e1893"
 
 "@lasso/marko-taglib@^1.0.9":
   version "1.0.10"


### PR DESCRIPTION
## Description
Contains a new component `ebay-notice` which constructs page and inline alerts. 

## Context

- As the alerts can be page or inline alerts ([see ebay/skin](https://github.com/eBay/skin/releases/tag/v3.4.0)) we want to get that as an input for customisation. Default is set to `page` when no input is provided.

- For a page alert we have a heading tag in the icon that provides it is ordering with a11y users. To provide that customisation we take the heading-tag as an input for customisation. Default is set to `h2` when no input is provided.

- As the alerts are differentiated into 3 types: `confirmation`, `priority` and `information`, we take the type as an input for the customisation. Default is set to `priority`  when no input is provided.

## References
This will complete issue #5 

## Screenshots
Page notice with type: priority
<img width="1617" alt="screen shot 2018-03-06 at 5 39 39 pm" src="https://user-images.githubusercontent.com/6751429/37068810-6de48490-2165-11e8-8cc0-0f2872461331.png">

Inline notice with type: confirmation
<img width="444" alt="screen shot 2018-03-06 at 5 39 56 pm" src="https://user-images.githubusercontent.com/6751429/37068872-bf240f88-2165-11e8-86a9-34c0a0069fb5.png">


