### PR TITLE
Adding .npmrc and publishConfig

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -95,5 +95,8 @@
     "makeup-roving-tabindex": "^0.0.3",
     "marko-dynamic-tag": "^1.0.0",
     "nodelist-foreach-polyfill": "^1.2.0"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
   }
 }


### PR DESCRIPTION
## Description
We need to enforce the publishing of the registry.

## Context
Closes #31 

## References
https://docs.npmjs.com/files/npmrc
https://docs.npmjs.com/files/package.json#publishconfig
Adding it to publishConfig cannot be overridden: https://github.com/npm/npm/issues/10117#issuecomment-221056942