### PR TITLE
Move marko-dynamic-tag to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "lasso-marko": "^2.4.0",
     "marko": "^3",
     "marko-cli": "^2.2.2",
+    "marko-dynamic-tag": "^1.0.0",
     "marko-prettyprint": "^1.4.1",
     "marko-widgets": "^6",
     "mocha": "^4.1.0",
@@ -93,7 +94,6 @@
     "makeup-key-emitter": "^0.0.2",
     "makeup-prevent-scroll-keys": "^0.0.1",
     "makeup-roving-tabindex": "^0.0.3",
-    "marko-dynamic-tag": "^1.0.0",
     "nodelist-foreach-polyfill": "^1.2.0"
   },
   "publishConfig": {


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
`marko-dynamic-tag` is only used in the demo, so I'm moving it from `dependencies` to `devDependencies`. There's no `yarn.lock` change.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
Closes https://github.com/eBay/ebayui-core/issues/33

