### PR TITLE
Button: set priority to secondary by default

### DIFF
--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -10,7 +10,7 @@
 Name | Type | Stateful | Description
 --- | --- | --- | ---
 `class` | String | No | custom class
-`priority` | String | No | "primary" or "secondary"
+`priority` | String | No | "primary" / "secondary" (default) / "none"
 `size` | String | No | "small" or "large" (default: medium)
 `href` | String | No | for link that looks like a button
 `fluid` | Boolean | No |

--- a/src/components/ebay-button/examples/2-raw/template.marko
+++ b/src/components/ebay-button/examples/2-raw/template.marko
@@ -1,0 +1,1 @@
+<ebay-button priority="none">label</ebay-button>

--- a/src/components/ebay-button/examples/2-secondary/template.marko
+++ b/src/components/ebay-button/examples/2-secondary/template.marko
@@ -1,1 +1,0 @@
-<ebay-button priority="secondary">label</ebay-button>

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -12,7 +12,7 @@ function getInitialState(input) {
 
 function getTemplateData(state, input) {
     const href = input.href;
-    const priority = input.priority;
+    const priority = input.priority || 'secondary';
     const size = input.size;
     const fluid = input.fluid;
     const classes = [input.class];
@@ -28,7 +28,7 @@ function getTemplateData(state, input) {
         classes.push('btn');
     }
 
-    if (priority === 'primary' || priority === 'secondary') {
+    if (priority === 'primary' || priority === 'secondary' || priority === 'none') {
         classes.push(`btn--${priority}`);
     }
 

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -15,20 +15,11 @@ function getTemplateData(state, input) {
     const priority = input.priority || 'secondary';
     const size = input.size;
     const fluid = input.fluid;
-    const classes = [input.class];
+    let classes = ['btn'];
     const model = {};
     let tag;
 
-    if (href) {
-        tag = 'a';
-        model.href = href;
-        classes.push('fake-btn');
-    } else {
-        tag = 'button';
-        classes.push('btn');
-    }
-
-    if (priority === 'primary' || priority === 'secondary' || priority === 'none') {
+    if (priority === 'primary' || priority === 'secondary') {
         classes.push(`btn--${priority}`);
     }
 
@@ -38,6 +29,19 @@ function getTemplateData(state, input) {
 
     if (fluid) {
         classes.push('btn--fluid');
+    }
+
+    if (href) {
+        tag = 'a';
+        model.href = href;
+        classes = classes.map(c => `fake-${c}`); // assumes all classes use the skin btn prefix
+    } else {
+        tag = 'button';
+    }
+
+    // must be after other class processing
+    if (input.class) {
+        classes.push(input.class);
     }
 
     model.tag = tag;

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -2,7 +2,7 @@ const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/server');
 
 const properties = {
-    priority: ['primary', 'secondary', 'none'],
+    priority: ['primary', 'secondary'],
     size: ['small', 'large']
 };
 
@@ -33,15 +33,22 @@ test('renders secondary version by default', context => {
 });
 
 test('does not apply priority class for unsupported value', context => {
-    const input = { priority: 'wrong' };
+    const input = { priority: 'none' };
     const $ = testUtils.getCheerio(context.render(input));
-    expect($(`button.btn.btn--wrong`).length).to.equal(0);
+    expect($(`button.btn`).length).to.equal(1);
+    expect($(`button.btn.btn--none`).length).to.equal(0);
 });
 
 test('renders fake version', context => {
     const input = { href: '#' };
     const $ = testUtils.getCheerio(context.render(input));
     expect($('a.fake-btn[href=#]').length).to.equal(1);
+});
+
+test('renders fake version with other attributes', context => {
+    const input = { href: '#', priority: 'primary', size: 'small' };
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($('a.fake-btn.fake-btn--small.fake-btn--primary[href=#]').length).to.equal(1);
 });
 
 test('renders disabled version', context => {

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -2,7 +2,7 @@ const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/server');
 
 const properties = {
-    priority: ['primary', 'secondary'],
+    priority: ['primary', 'secondary', 'none'],
     size: ['small', 'large']
 };
 
@@ -24,6 +24,18 @@ Object.keys(properties).forEach(property => {
         const $ = testUtils.getCheerio(context.render(input));
         expect($('button.btn.btn--fluid').length).to.equal(i);
     });
+});
+
+test('renders secondary version by default', context => {
+    const input = {};
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($(`button.btn.btn--secondary`).length).to.equal(1);
+});
+
+test('does not apply priority class for unsupported value', context => {
+    const input = { priority: 'wrong' };
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($(`button.btn.btn--wrong`).length).to.equal(0);
 });
 
 test('renders fake version', context => {


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- make `priority` default to `secondary`
- change `secondary` example to show `raw` instead
- fix `fake` button cases
- add tests

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
Closes https://github.com/eBay/ebayui-core/issues/35

## Screenshots
<!-- Upload screenshots if appropriate-->
<img width="571" alt="screen shot 2018-03-08 at 5 00 04 pm" src="https://user-images.githubusercontent.com/3595986/37184822-33e07f86-22f2-11e8-87ca-5f249d031dae.png">
