### PR TITLE
Carousel: add brand styling to examples

### DIFF
--- a/src/components/ebay-carousel/examples/1-continuous/template.marko
+++ b/src/components/ebay-carousel/examples/1-continuous/template.marko
@@ -1,6 +1,9 @@
 <style>
     .demo1-card {
-        background: pink;
+        color: #0a1c6b;
+        background: #c2f5ff;
+        font-size: 24px;
+        font-weight: bold;
         width: 200px;
         height: 120px;
         line-height: 120px;

--- a/src/components/ebay-carousel/examples/2-discrete/template.marko
+++ b/src/components/ebay-carousel/examples/2-discrete/template.marko
@@ -1,6 +1,9 @@
 <style>
     .demo2-card {
-        background: lightblue;
+        color: #cdf4fd;
+        background: #a1208b;
+        font-size: 36px;
+        font-weight: bold;
         height: 200px;
         line-height: 200px;
         text-align: center;

--- a/src/components/ebay-carousel/examples/3-starting-index/template.marko
+++ b/src/components/ebay-carousel/examples/3-starting-index/template.marko
@@ -1,6 +1,9 @@
 <style>
     .demo3-card {
-        background: lightgreen;
+        color: #ffef75;
+        background: #077574;
+        font-size: 24px;
+        font-weight: bold;
         width: 250px;
         height: 150px;
         line-height: 150px;


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- adds eBay brand styling to the current carousel examples

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
Closes https://github.com/eBay/ebayui-core/issues/39

## Screenshots
<!-- Upload screenshots if appropriate-->
<img width="888" alt="screen shot 2018-03-09 at 10 05 49 am" src="https://user-images.githubusercontent.com/3595986/37222346-88bed9fa-2381-11e8-8b2c-9131e4233af1.png">
<img width="892" alt="screen shot 2018-03-09 at 10 06 07 am" src="https://user-images.githubusercontent.com/3595986/37222344-886927c6-2381-11e8-8b97-637b3e9386f3.png">
<img width="890" alt="screen shot 2018-03-09 at 10 05 55 am" src="https://user-images.githubusercontent.com/3595986/37222345-88930f14-2381-11e8-8a8f-ece89cb9aa25.png">


