### PR TITLE
Fixed notice README

### DIFF
--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -15,7 +15,7 @@ The `<ebay-notice>` is a tag used to create a custom-designed notice element. Th
 Name | Type | Stateful | Description
 --- | --- | --- | ---
 `class` | String | No | custom class
-`type` | String | No | "inline" or "page"
-`status`  | String | No | "priority", "confirmation" or "information"
+`type` | String | No | "inline" or "page" (default)
+`status`  | String | No | "priority" (default), "confirmation" or "information"
 `aria-text` | String | No | adding description for the notice for a11y users
 `heading-level` | String | No| used in case of "page" level notices to specify the heading tag according to the notice's placement

--- a/src/components/ebay-notice/examples/1-page-notice/template.marko
+++ b/src/components/ebay-notice/examples/1-page-notice/template.marko
@@ -1,9 +1,7 @@
-<span>
-    <ebay-notice
-        status="priority"
-        type="page"
-        aria-text="Priority">
-        <p><strong>Error:</strong> Please take another look at the following:</p>
-        <p><a href="#">Card number</a>, <a href="#">Expiration date</a> &amp; <a href="#">Security code</a></p>
-    </ebay-notice>
-</span>
+<ebay-notice
+    status="priority"
+    type="page"
+    aria-text="Priority">
+    <p><strong>Error:</strong> Please take another look at the following:</p>
+    <p><a href="#">Card number</a>, <a href="#">Expiration date</a> &amp; <a href="#">Security code</a></p>
+</ebay-notice>

--- a/src/components/ebay-notice/examples/2-inline-notice/template.marko
+++ b/src/components/ebay-notice/examples/2-inline-notice/template.marko
@@ -1,8 +1,7 @@
-<span>
-    <ebay-notice
-        status="confirmation"
-        type="inline"
-        aria-text="Confirmation">
-        <p><strong>Success:</strong> Loaded all the items successfully.</p>
-    </ebay-notice>
-</span>
+<ebay-notice
+    status="confirmation"
+    type="inline"
+    aria-text="Confirmation">
+    <p><strong>Success:</strong> Loaded all the items successfully.</p>
+</ebay-notice>
+

--- a/src/components/ebay-notice/examples/3-custom-heading/template.marko
+++ b/src/components/ebay-notice/examples/3-custom-heading/template.marko
@@ -1,9 +1,7 @@
-<span>
-    <ebay-notice
-        heading-level="3"
-        status="information"
-        type="page"
-        aria-text="Information">
-        <p><strong>Congrats!</strong> You just listed <a href="#">"Spam and Eggs from Crow's perspective"</a></p>
-    </ebay-notice>
-</span>
+<ebay-notice
+    heading-level="3"
+    status="information"
+    type="page"
+    aria-text="Information">
+    <p><strong>Congrats!</strong> You just listed <a href="#">"Spam and Eggs from Crow's perspective"</a></p>
+</ebay-notice>


### PR DESCRIPTION
## Description
Fixed README to provide defaults, and removed extra `<span>` tags

## Context
Less confusion for the user with the`<span>` tags
