### PR TITLE
Fixes for IE - Array.prototype.find not supported

### DIFF
--- a/src/components/ebay-select/index.js
+++ b/src/components/ebay-select/index.js
@@ -28,7 +28,7 @@ function getInitialState(input) {
         };
     });
 
-    const selectedOption = options.find(option => option.selected) || options[0];
+    const selectedOption = options.filter(option => option.selected)[0] || options[0];
 
     if (options.length > 0 && selectedOption.value === options[0].value) {
         options[0].selected = true;

--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -11,7 +11,7 @@
             readonly
             role='combobox'
             aria-haspopup='listbox'
-            aria-owns=`${widget.elId('listbox__options')}`
+            aria-owns=widget.elId('listbox__options')
             aria-expanded='false'
             w-on-keydown='handleListboxKeyDown'
             w-preserve-attrs="aria-expanded"/>


### PR DESCRIPTION
## Description

IE doesn't support the `Array.prototype.find` (even though it's in the spec!), so this change is an equivalent which will allow IE to work.

In addition, during testing, I found that some IE versions don't like backticks (imagine that!), so I removed them in the Marko template. (naughty me)

P.S. Please ignore the branch name as that was _before_ the issue numbers were changed around.

## References

Closes #50 