### PR TITLE
Notice: fix clientside content rendering

### DIFF
--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -8,7 +8,5 @@
             id="${data.status}-status-${widget.elId()}">
                 <span aria-label="${data.ariaText}" role="img"></span>
         </${data.headingTag}>
-        <${data.contentTag} class=data.contentClass>
-            <invoke data.renderBody(out) if(data.renderBody)/>
-        </${data.contentTag}>
+        <${data.contentTag} class=data.contentClass w-body/>
 </${data.mainTag}>


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- change `data.renderBody(out)` to `w-body`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Using `data.renderBody(out)` is ok on the server, but with widgets it's preferred to use `w-body`. This fixes the clientside rendering that was previously broken in Marko v4. Verified in both v3 and v4. Note that this was not caught automatically because we aren't doing clientside tests yet for this component (we will soon).

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
https://github.com/eBay/ebayui-core/issues/57

