### PR TITLE
Notice: add dismiss functionality

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -68,7 +68,7 @@
         "@class": "string",
         "@hidden": "boolean",
         "@aria-text": "string",
-        "@aria-close": "string",
+        "@aria-label-close": "string",
         "@dismissible":"boolean",
         "@*": "expression"
     }

--- a/marko.json
+++ b/marko.json
@@ -67,6 +67,7 @@
         "@status": "string",
         "@class": "string",
         "@aria-text": "string",
+        "@hidden":"boolean",
         "@*": "expression"
     }
 }

--- a/marko.json
+++ b/marko.json
@@ -66,8 +66,10 @@
         "@heading-level": "string",
         "@status": "string",
         "@class": "string",
+        "@hidden": "boolean",
         "@aria-text": "string",
-        "@hidden":"boolean",
+        "@aria-close": "string",
+        "@dismissible":"boolean",
         "@*": "expression"
     }
 }

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -25,6 +25,7 @@ Name | Type | Stateful | Description
 `heading-level` | String | No| used in case of "page" level notices to specify the heading tag according to the notice's placement
 `dismissible` | Boolean | No | used to specify the dismiss button in page notice
 `hidden` | Boolean | Yes | whether the widget is hidden or not (Note: not supported as initial attribute)
+`aria-label-close` | String | No | adding description for the button for a11y users
 
 ### ebay-notice Events
 

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -2,9 +2,9 @@
 
 The `<ebay-notice>` is a tag used to create a custom-designed notice element. The notice can be single or multi-line but each line should be wrapped inside a `<p>` tag.
 
-In case of dismissible notice if the parent of `<ebay-notice>` wants to close it, the property `hidden` can be used to change the state of the widget (other than the dismiss button provided).
+For the dismissible use case, if the parent of `<ebay-notice>` wants to close it, the property `hidden` can be used to change the state of the widget (other than the dismiss button provided).
 
-(Note: To use dismiss button in ebay-notice please include `@ebay/skin/icon`)
+(Note:  To use the dismiss button in `<ebay-notice>` please include `@ebay/skin/icon`)
 
 ## ebay-notice Usage
 
@@ -30,4 +30,4 @@ Name | Type | Stateful | Description
 
 Event | Description
 --- | ---
-`notice-dismissed` | the page notice was dismissed/closed
+`notice-change` | the page notice was dismissed/undismissed

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -4,6 +4,8 @@ The `<ebay-notice>` is a tag used to create a custom-designed notice element. Th
 
 In case of dismissible notice if the parent of `<ebay-notice>` wants to close it, the property `hidden` can be used to change the state of the widget (other than the dismiss button provided).
 
+(Note: To use dismiss button in ebay-notice please include `@ebay/skin/icon`)
+
 ## ebay-notice Usage
 
 ```marko

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -21,7 +21,7 @@ Name | Type | Stateful | Description
 `status`  | String | No | "priority" (default), "confirmation" or "information"
 `aria-text` | String | No | adding description for the notice for a11y users
 `heading-level` | String | No| used in case of "page" level notices to specify the heading tag according to the notice's placement
-`dismissible` | Boolean | Yes | used to specify the dismiss button in page notice
+`dismissible` | Boolean | No | used to specify the dismiss button in page notice
 `hidden` | Boolean | Yes | whether the widget is hidden or not (Note: not supported as initial attribute)
 
 ### ebay-notice Events

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -30,4 +30,4 @@ Name | Type | Stateful | Description
 
 Event | Data | Description
 --- | --- | ---
-`notice-change` | `{hidden}` | the page notice was dismissed/undismissed
+`notice-change` | `{ hidden }` | the page notice was dismissed/undismissed

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -28,6 +28,6 @@ Name | Type | Stateful | Description
 
 ### ebay-notice Events
 
-Event | Description
---- | ---
-`notice-change` | the page notice was dismissed/undismissed
+Event | Data | Description
+--- | --- | ---
+`notice-change` | `{hidden}` | the page notice was dismissed/undismissed

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -19,3 +19,10 @@ Name | Type | Stateful | Description
 `status`  | String | No | "priority" (default), "confirmation" or "information"
 `aria-text` | String | No | adding description for the notice for a11y users
 `heading-level` | String | No| used in case of "page" level notices to specify the heading tag according to the notice's placement
+`dismissible` | Boolean | Yes | used to specify the dismiss button in page notice
+
+### ebay-notice Events
+
+Event | Description
+--- | ---
+`notice-dismissed` | the page notice was dismissed/closed

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -31,4 +31,5 @@ Name | Type | Stateful | Description
 
 Event | Data | Description
 --- | --- | ---
-`notice-change` | `{ hidden }` | the page notice was dismissed/undismissed
+`notice-show` | `{ hidden }` | the page notice was shown
+`notice-hide` | `{ hidden }` | the page notice was hidden

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -2,6 +2,8 @@
 
 The `<ebay-notice>` is a tag used to create a custom-designed notice element. The notice can be single or multi-line but each line should be wrapped inside a `<p>` tag.
 
+In case of dismissible notice if the parent of `<ebay-notice>` wants to close it, the property `hidden` can be used to change the state of the widget (other than the dismiss button provided).
+
 ## ebay-notice Usage
 
 ```marko
@@ -20,6 +22,7 @@ Name | Type | Stateful | Description
 `aria-text` | String | No | adding description for the notice for a11y users
 `heading-level` | String | No| used in case of "page" level notices to specify the heading tag according to the notice's placement
 `dismissible` | Boolean | Yes | used to specify the dismiss button in page notice
+`hidden` | Boolean | Yes | whether the widget is hidden or not (Note: not supported as initial attribute)
 
 ### ebay-notice Events
 

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -29,7 +29,7 @@ Name | Type | Stateful | Description
 
 ### ebay-notice Events
 
-Event | Data | Description
---- | --- | ---
-`notice-show` | `{ hidden }` | the page notice was shown
-`notice-hide` | `{ hidden }` | the page notice was hidden
+Event | Description
+--- | ---
+`notice-show` | the page notice was shown
+`notice-hide` | the page notice was hidden

--- a/src/components/ebay-notice/examples/4-dismissible-notice/template.marko
+++ b/src/components/ebay-notice/examples/4-dismissible-notice/template.marko
@@ -1,0 +1,7 @@
+<ebay-notice
+    status="information"
+    type="page"
+    aria-text="information" dismissible=true aria-close="Dismiss notice">
+    <p><strong>Congrats!</strong> You just listed <a href="#">"Spam and Eggs From the Cow's Perspective</a> (paperback)."</p>
+    <p>You can check <a href="#">your listing</a> or <a href="#">sell another item</a></p>
+</ebay-notice>

--- a/src/components/ebay-notice/examples/4-dismissible-notice/template.marko
+++ b/src/components/ebay-notice/examples/4-dismissible-notice/template.marko
@@ -1,7 +1,7 @@
 <ebay-notice
     status="information"
     type="page"
-    aria-text="information" dismissible=true aria-close="Dismiss notice">
+    aria-text="information" dismissible aria-close="Dismiss notice">
     <p><strong>Congrats!</strong> You just listed <a href="#">"Spam and Eggs From the Cow's Perspective</a> (paperback)."</p>
     <p>You can check <a href="#">your listing</a> or <a href="#">sell another item</a></p>
 </ebay-notice>

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -24,7 +24,7 @@ const defaults = {
 };
 
 function getInitialState(input) {
-    const hidden = input.hidden || defaults.hidden;
+    const hidden = defaults.hidden;
     const type = input.type || defaults.type;
     const headingTag = (type === 'page' && input.headingLevel) ? `h${input.headingLevel}` : constants[type].headingTag;
     const status = input.status || defaults.status;
@@ -41,11 +41,10 @@ function getInitialState(input) {
         ariaText: input.ariaText || '',
         ariaClose: input.ariaClose || '',
         htmlAttributes: processHtmlAttributes(input),
-        renderBody: input.renderBody,
         mainClass: [`${type}-notice`, `${type}-notice--${status}`, input.class],
         headingClass: `${type}-notice__status`,
         contentClass: `${type}-notice__content`,
-        dismissedClass: dismissible ? `page-notice__close` : ``
+        dismissedClass: dismissible ? 'page-notice__close' : ''
     };
 }
 function getTemplateData(state) {
@@ -53,12 +52,14 @@ function getTemplateData(state) {
 }
 
 function init() {
-    observer.observeRoot(this, ['hidden']);
+    observer.observeRoot(this, ['hidden'], () => {
+        emitAndFire(this, 'notice-change');
+    });
 }
 
 function onDismiss() {
     this.setState('hidden', true);
-    emitAndFire(this, 'notice-dismissed');
+    emitAndFire(this, 'notice-change');
 }
 
 module.exports = require('marko-widgets').defineComponent({

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -19,7 +19,8 @@ const constants = {
 const defaults = {
     type: 'page',
     status: 'priority',
-    hidden: false
+    hidden: false,
+    dismissible: false
 };
 
 function getInitialState(input) {
@@ -27,20 +28,24 @@ function getInitialState(input) {
     const type = input.type || defaults.type;
     const headingTag = (type === 'page' && input.headingLevel) ? `h${input.headingLevel}` : constants[type].headingTag;
     const status = input.status || defaults.status;
+    const dismissible = (input.dismissible && type === 'page') || defaults.dismissible;
 
     return {
         mainTag: constants[type].mainTag,
         headingTag: headingTag,
         contentTag: constants[type].contentTag,
+        dismissible,
         type,
         status,
         hidden,
         ariaText: input.ariaText || '',
+        ariaClose: input.ariaClose || '',
         htmlAttributes: processHtmlAttributes(input),
         renderBody: input.renderBody,
         mainClass: [`${type}-notice`, `${type}-notice--${status}`, input.class],
         headingClass: `${type}-notice__status`,
-        contentClass: `${type}-notice__content`
+        contentClass: `${type}-notice__content`,
+        dismissedClass: dismissible ? `page-notice__close` : ``
     };
 }
 function getTemplateData(state) {

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -39,12 +39,11 @@ function getInitialState(input) {
         status,
         hidden,
         ariaText: input.ariaText || '',
-        ariaClose: input.ariaClose || '',
+        ariaLabelClose: input.ariaLabelClose || '',
         htmlAttributes: processHtmlAttributes(input),
         mainClass: [`${type}-notice`, `${type}-notice--${status}`, input.class],
         headingClass: `${type}-notice__status`,
-        contentClass: `${type}-notice__content`,
-        dismissedClass: dismissible ? 'page-notice__close' : ''
+        contentClass: `${type}-notice__content`
     };
 }
 function getTemplateData(state) {

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -51,13 +51,12 @@ function getTemplateData(state) {
 }
 
 function init() {
-    observer.observeRoot(this, ['hidden'], (hidden) => {
-        this.processAfterStateChange(hidden);
+    observer.observeRoot(this, ['hidden'], () => {
+        this.processAfterStateChange(this.state.hidden);
     });
 }
 /**
  * Common processing after data change via both UI and API
- * @param {Boolean} hidden
  */
 function processAfterStateChange(hidden) {
     if (hidden) {

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -52,14 +52,14 @@ function getTemplateData(state) {
 }
 
 function init() {
-    observer.observeRoot(this, ['hidden'], () => {
-        emitAndFire(this, 'notice-change');
+    observer.observeRoot(this, ['hidden'], (isHidden) => {
+        emitAndFire(this, 'notice-change', isHidden);
     });
 }
 
 function onDismiss() {
     this.setState('hidden', true);
-    emitAndFire(this, 'notice-change');
+    emitAndFire(this, 'notice-change', true);
 }
 
 module.exports = require('marko-widgets').defineComponent({

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -52,23 +52,23 @@ function getTemplateData(state) {
 
 function init() {
     observer.observeRoot(this, ['hidden'], () => {
-        this.processAfterStateChange(this.state.hidden);
+        this.processAfterStateChange();
     });
 }
 /**
  * Common processing after data change via both UI and API
  */
-function processAfterStateChange(hidden) {
-    if (hidden) {
-        emitAndFire(this, 'notice-hide', { hidden });
+function processAfterStateChange() {
+    if (this.state.hidden) {
+        emitAndFire(this, 'notice-hide');
     } else {
-        emitAndFire(this, 'notice-show', { hidden });
+        emitAndFire(this, 'notice-show');
     }
 }
 
 function onDismiss() {
     this.setState('hidden', true);
-    this.processAfterStateChange(true);
+    this.processAfterStateChange();
 }
 
 module.exports = require('marko-widgets').defineComponent({

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -1,4 +1,6 @@
 const processHtmlAttributes = require('../../common/html-attributes');
+const observer = require('../../common/property-observer');
+const emitAndFire = require('../../common/emit-and-fire');
 const template = require('./template.marko');
 
 const constants = {
@@ -16,10 +18,12 @@ const constants = {
 
 const defaults = {
     type: 'page',
-    status: 'confirmation'
+    status: 'priority',
+    hidden: false
 };
 
-function getTemplateData(state, input) {
+function getInitialState(input) {
+    const hidden = input.hidden || defaults.hidden;
     const type = input.type || defaults.type;
     const headingTag = (type === 'page' && input.headingLevel) ? `h${input.headingLevel}` : constants[type].headingTag;
     const status = input.status || defaults.status;
@@ -30,6 +34,7 @@ function getTemplateData(state, input) {
         contentTag: constants[type].contentTag,
         type,
         status,
+        hidden,
         ariaText: input.ariaText || '',
         htmlAttributes: processHtmlAttributes(input),
         renderBody: input.renderBody,
@@ -38,8 +43,23 @@ function getTemplateData(state, input) {
         contentClass: `${type}-notice__content`
     };
 }
+function getTemplateData(state) {
+    return state;
+}
+
+function init() {
+    observer.observeRoot(this, ['hidden']);
+}
+
+function onDismiss() {
+    this.setState('hidden', true);
+    emitAndFire(this, 'notice-dismissed');
+}
 
 module.exports = require('marko-widgets').defineComponent({
     template,
-    getTemplateData
+    getInitialState,
+    getTemplateData,
+    init,
+    onDismiss
 });

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -52,13 +52,24 @@ function getTemplateData(state) {
 
 function init() {
     observer.observeRoot(this, ['hidden'], (hidden) => {
-        emitAndFire(this, 'notice-change', { hidden });
+        this.processAfterStateChange(hidden);
     });
+}
+/**
+ * Common processing after data change via both UI and API
+ * @param {Boolean} hidden
+ */
+function processAfterStateChange(hidden) {
+    if (hidden) {
+        emitAndFire(this, 'notice-hide', { hidden });
+    } else {
+        emitAndFire(this, 'notice-show', { hidden });
+    }
 }
 
 function onDismiss() {
     this.setState('hidden', true);
-    emitAndFire(this, 'notice-change', { hidden: true });
+    this.processAfterStateChange(true);
 }
 
 module.exports = require('marko-widgets').defineComponent({
@@ -66,5 +77,6 @@ module.exports = require('marko-widgets').defineComponent({
     getInitialState,
     getTemplateData,
     init,
+    processAfterStateChange,
     onDismiss
 });

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -52,14 +52,14 @@ function getTemplateData(state) {
 }
 
 function init() {
-    observer.observeRoot(this, ['hidden'], (isHidden) => {
-        emitAndFire(this, 'notice-change', isHidden);
+    observer.observeRoot(this, ['hidden'], (hidden) => {
+        emitAndFire(this, 'notice-change', { hidden });
     });
 }
 
 function onDismiss() {
     this.setState('hidden', true);
-    emitAndFire(this, 'notice-change', true);
+    emitAndFire(this, 'notice-change', { hidden: true });
 }
 
 module.exports = require('marko-widgets').defineComponent({

--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -10,7 +10,7 @@
                 <span aria-label="${data.ariaText}" role="img"></span>
         </${data.headingTag}>
         <${data.contentTag} class=data.contentClass w-body/>
-         <button aria-label="" class="page-notice__close" w-onclick="onDismiss">
+         <button aria-label="${data.ariaClose}" class=data.dismissedClass w-onclick="onDismiss" if(data.dismissible)>
             <span></span>
         </button>
 </${data.mainTag}>

--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -10,8 +10,8 @@
                 <span aria-label="${data.ariaText}" role="img"></span>
         </${data.headingTag}>
         <${data.contentTag} class=data.contentClass w-body/>
-         <button aria-label="${data.ariaClose}"
-            class=data.dismissedClass
+         <button aria-label="${data.ariaLabelClose}"
+            class="page-notice__close"
             w-onclick="onDismiss"
             if(data.dismissible)>
                 <span></span>

--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -2,11 +2,15 @@
     w-bind
     aria-labelledby="${data.status}-status-${widget.elId()}"
     class=data.mainClass
-    ${data.htmlAttributes}>
+    ${data.htmlAttributes}
+    if(!data.hidden)>
         <${data.headingTag}
             class=data.headingClass
             id="${data.status}-status-${widget.elId()}">
                 <span aria-label="${data.ariaText}" role="img"></span>
         </${data.headingTag}>
         <${data.contentTag} class=data.contentClass w-body/>
+         <button aria-label="" class="page-notice__close" w-onclick="onDismiss">
+            <span></span>
+        </button>
 </${data.mainTag}>

--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -10,7 +10,10 @@
                 <span aria-label="${data.ariaText}" role="img"></span>
         </${data.headingTag}>
         <${data.contentTag} class=data.contentClass w-body/>
-         <button aria-label="${data.ariaClose}" class=data.dismissedClass w-onclick="onDismiss" if(data.dismissible)>
-            <span></span>
+         <button aria-label="${data.ariaClose}"
+            class=data.dismissedClass
+            w-onclick="onDismiss"
+            if(data.dismissible)>
+                <span></span>
         </button>
 </${data.mainTag}>

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -54,3 +54,34 @@ describe('given the notice is in the default state', () => {
         });
     });
 });
+
+describe('given the notice is in the hidden state', () => {
+    let widget;
+    let root;
+    beforeEach(() => {
+        widget = renderer.renderSync({ type: 'page', dismissible: true }).appendTo(document.body).getWidget();
+        root = document.querySelector('section.page-notice');
+        root.hidden = true;
+    });
+    afterEach(() => widget.destroy());
+    describe('when the widget is undismissed through hidden property', () => {
+        let spy;
+        beforeEach((done) => {
+            spy = sinon.spy();
+            widget.on('notice-change', spy);
+            root.hidden = false;
+            setTimeout(done);
+        });
+
+        test('then root is present in the DOM', () => {
+            expect(document.querySelector('.page-notice')).to.not.equal(null);
+        });
+
+        test('then it emits the marko event from notice-change', () => {
+            expect(spy.calledOnce).to.equal(true);
+            const eventData = spy.getCall(0).args[0];
+            expect(eventData.hidden).to.equal(false);
+        });
+    });
+});
+

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -22,6 +22,12 @@ describe('given the notice is in the default state', () => {
             widget.on('notice-change', spy);
             testUtils.triggerEvent(button, 'click');
         });
+        test('then root not present in the DOM', (context, done) => {
+            setTimeout(() => {
+                expect(document.querySelector('section.page-notice')).to.equal(null);
+                done();
+            }, 10);
+        });
 
         test('then it emits the marko event from notice-change', () => {
             expect(spy.calledOnce).to.equal(true);
@@ -34,6 +40,13 @@ describe('given the notice is in the default state', () => {
             spy = sinon.spy();
             widget.on('notice-change', spy);
             root.hidden = true;
+        });
+
+        test('then root not present in the DOM', (context, done) => {
+            setTimeout(() => {
+                expect(document.querySelector('section.page-notice')).to.equal(null);
+                done();
+            }, 10);
         });
 
         test('then it emits the marko event from notice-change', () => {

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -29,8 +29,6 @@ describe('given the notice is in the default state', () => {
 
         test('then it emits the marko event from notice-hide', () => {
             expect(spy.calledOnce).to.equal(true);
-            const eventData = spy.getCall(0).args[0];
-            expect(eventData.hidden).to.equal(true);
         });
     });
 
@@ -49,8 +47,6 @@ describe('given the notice is in the default state', () => {
 
         test('then it emits the marko event from notice-hide', () => {
             expect(spy.calledOnce).to.equal(true);
-            const eventData = spy.getCall(0).args[0];
-            expect(eventData.hidden).to.equal(true);
         });
     });
 });
@@ -79,8 +75,6 @@ describe('given the notice is in the hidden state', () => {
 
         test('then it emits the marko event from notice-show', () => {
             expect(spy.calledOnce).to.equal(true);
-            const eventData = spy.getCall(0).args[0];
-            expect(eventData.hidden).to.equal(false);
         });
     });
 });

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -5,11 +5,13 @@ const renderer = require('../');
 
 describe('given the notice is in the default state', () => {
     let widget;
+    let root;
     let button;
 
     beforeEach(() => {
         widget = renderer.renderSync({ type: 'page', dismissible: true }).appendTo(document.body).getWidget();
-        button = document.querySelector('.page-notice__close');
+        root = document.querySelector('section.page-notice');
+        button = root.querySelector('.page-notice__close');
     });
     afterEach(() => widget.destroy());
 
@@ -17,11 +19,24 @@ describe('given the notice is in the default state', () => {
         let spy;
         beforeEach(() => {
             spy = sinon.spy();
-            widget.on('notice-dismissed', spy);
+            widget.on('notice-change', spy);
             testUtils.triggerEvent(button, 'click');
         });
 
-        test('then it emits the marko event from notice-dismissed', () => {
+        test('then it emits the marko event from notice-change', () => {
+            expect(spy.calledOnce).to.equal(true);
+        });
+    });
+
+    describe('when the widget is dismissed through hidden property', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('notice-change', spy);
+            root.hidden = true;
+        });
+
+        test('then it emits the marko event from notice-change', () => {
             expect(spy.calledOnce).to.equal(true);
         });
     });

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -27,7 +27,7 @@ describe('given the notice is in the default state', () => {
             expect(document.querySelector('section.page-notice')).to.equal(null);
         });
 
-        test('then it emits the marko event from notice-change', () => {
+        test('then it emits the marko event from notice-hide', () => {
             expect(spy.calledOnce).to.equal(true);
             const eventData = spy.getCall(0).args[0];
             expect(eventData.hidden).to.equal(true);
@@ -47,7 +47,7 @@ describe('given the notice is in the default state', () => {
             expect(document.querySelector('section.page-notice')).to.equal(null);
         });
 
-        test('then it emits the marko event from notice-change', () => {
+        test('then it emits the marko event from notice-hide', () => {
             expect(spy.calledOnce).to.equal(true);
             const eventData = spy.getCall(0).args[0];
             expect(eventData.hidden).to.equal(true);
@@ -77,7 +77,7 @@ describe('given the notice is in the hidden state', () => {
             expect(document.querySelector('.page-notice')).to.not.equal(null);
         });
 
-        test('then it emits the marko event from notice-change', () => {
+        test('then it emits the marko event from notice-show', () => {
             expect(spy.calledOnce).to.equal(true);
             const eventData = spy.getCall(0).args[0];
             expect(eventData.hidden).to.equal(false);

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -1,0 +1,28 @@
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const testUtils = require('../../../common/test-utils/browser');
+const renderer = require('../');
+
+describe('given the notice is in the default state', () => {
+    let widget;
+    let button;
+
+    beforeEach(() => {
+        widget = renderer.renderSync({ type: 'page', dismissible: true }).appendTo(document.body).getWidget();
+        button = document.querySelector('.page-notice__close');
+    });
+    afterEach(() => widget.destroy());
+
+    describe('when the dismiss button is clicked', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('notice-dismissed', spy);
+            testUtils.triggerEvent(button, 'click');
+        });
+
+        test('then it emits the marko event from notice-dismissed', () => {
+            expect(spy.calledOnce).to.equal(true);
+        });
+    });
+});

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -17,40 +17,40 @@ describe('given the notice is in the default state', () => {
 
     describe('when the dismiss button is clicked', () => {
         let spy;
-        beforeEach(() => {
+        beforeEach((done) => {
             spy = sinon.spy();
             widget.on('notice-change', spy);
             testUtils.triggerEvent(button, 'click');
+            setTimeout(done);
         });
-        test('then root not present in the DOM', (context, done) => {
-            setTimeout(() => {
-                expect(document.querySelector('section.page-notice')).to.equal(null);
-                done();
-            }, 10);
+        test('then root not present in the DOM', () => {
+            expect(document.querySelector('section.page-notice')).to.equal(null);
         });
 
         test('then it emits the marko event from notice-change', () => {
             expect(spy.calledOnce).to.equal(true);
+            const eventData = spy.getCall(0).args[0];
+            expect(eventData.hidden).to.equal(true);
         });
     });
 
     describe('when the widget is dismissed through hidden property', () => {
         let spy;
-        beforeEach(() => {
+        beforeEach((done) => {
             spy = sinon.spy();
             widget.on('notice-change', spy);
             root.hidden = true;
+            setTimeout(done);
         });
 
-        test('then root not present in the DOM', (context, done) => {
-            setTimeout(() => {
-                expect(document.querySelector('section.page-notice')).to.equal(null);
-                done();
-            }, 10);
+        test('then root not present in the DOM', () => {
+            expect(document.querySelector('section.page-notice')).to.equal(null);
         });
 
         test('then it emits the marko event from notice-change', () => {
             expect(spy.calledOnce).to.equal(true);
+            const eventData = spy.getCall(0).args[0];
+            expect(eventData.hidden).to.equal(true);
         });
     });
 });

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -19,7 +19,7 @@ describe('given the notice is in the default state', () => {
         let spy;
         beforeEach((done) => {
             spy = sinon.spy();
-            widget.on('notice-change', spy);
+            widget.on('notice-hide', spy);
             testUtils.triggerEvent(button, 'click');
             setTimeout(done);
         });
@@ -38,7 +38,7 @@ describe('given the notice is in the default state', () => {
         let spy;
         beforeEach((done) => {
             spy = sinon.spy();
-            widget.on('notice-change', spy);
+            widget.on('notice-hide', spy);
             root.hidden = true;
             setTimeout(done);
         });
@@ -68,7 +68,7 @@ describe('given the notice is in the hidden state', () => {
         let spy;
         beforeEach((done) => {
             spy = sinon.spy();
-            widget.on('notice-change', spy);
+            widget.on('notice-show', spy);
             root.hidden = false;
             setTimeout(done);
         });

--- a/src/components/ebay-notice/test/test.server.js
+++ b/src/components/ebay-notice/test/test.server.js
@@ -39,6 +39,14 @@ test('renders page notice with correct tags', context => {
     expect($('h2.page-notice__status').length).to.equal(1);
     expect($('section.page-notice--priority').length).to.equal(1);
     expect($('div.page-notice__content').length).to.equal(1);
+    expect($('button.page-notice__close').length).to.equal(0);
+});
+
+test('renders page notice with dismiss button', context => {
+    const input = { type: 'page', status: 'priority', dismissible: true };
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($('section.page-notice--priority').length).to.equal(1);
+    expect($('button.page-notice__close').length).to.equal(1);
 });
 
 test('handles pass-through html attributes', context => {


### PR DESCRIPTION
## Description
The changes are only applicable in case of a `page-notice`.
- Adding the property `hidden`, so a parent widget can dismiss the widget by setting it to `true`.

- Adding 2 new inputs `dismissible` and `aria-close` to specify if the dismiss button should show up in the UI and for the label of the dismiss button, respectively.

- The dismissible of the notice emits a `notice-dismissed` event to notify the completion of the action.

## Context
This adds the dismiss functionality to the component

## References
Fixes issue #51 (Needs the button styles for notice from skin v3.5.0)

