### PR TITLE
Fixing to walk the whole tree when transforming;

### DIFF
--- a/src/common/transformer/index.js
+++ b/src/common/transformer/index.js
@@ -8,19 +8,25 @@
  */
 function transform(el, context) {
     const parentTag = el.tagName;
-    el.body.forEach(child => {
-        const childTag = child.tagName;
-        // find the matching tag based on the child tag name of
-        // the children matching the given tagName
-        if (childTag && childTag.indexOf(`${parentTag}-`) === 0) {
-            const outputTag = `${parentTag}:${childTag.slice(parentTag.length + 1)}`;
-            const nestedTag = context.createNodeForEl(outputTag, child.getAttributes());
-            nestedTag.body = child.body;
-            child.replaceWith(nestedTag);
-        }
 
-        return child;
+    // walk the tree
+    const walker = context.createWalker({
+        enter(node) {
+            const childTag = node.tagName;
+            // find the matching tag based on the child tag name of
+            // the children matching the given tagName
+            if (node.type === 'HtmlElement' && node.tagName.indexOf(`${parentTag}-`) === 0) {
+                const outputTag = `${parentTag}:${childTag.slice(parentTag.length + 1)}`;
+                const nestedTag = context.createNodeForEl(outputTag, node.getAttributes());
+                nestedTag.body = node.body;
+                node.replaceWith(nestedTag);
+
+                walker.skip();
+            }
+        }
     });
+
+    walker.walk(el);
 }
 
 module.exports = transform;

--- a/src/common/transformer/test/test.server.js
+++ b/src/common/transformer/test/test.server.js
@@ -11,8 +11,9 @@ try {
     Builder = require('marko/compiler/Builder');
 } catch (e) {
     // v4 paths
-    CompileContext = require('marko/dist/compiler/CompileContext');
-    Builder = require('marko/dist/compiler/Builder');
+    const target = require('marko/env').isDebug ? 'src' : 'dist';
+    CompileContext = require(`marko/${target}/compiler/CompileContext`);
+    Builder = require(`marko/${target}/compiler/Builder`);
 }
 
 function getTransformedTemplate(srcString, templatePath) {
@@ -27,6 +28,7 @@ function getTransformedTemplate(srcString, templatePath) {
     );
 
     transformer(templateAST.body.array[0], context);
+
     return prettyPrint(templateAST).replace(/\>\s*</g, '><').trim();
 }
 
@@ -34,6 +36,13 @@ function getTagString(rootTag, nestedTag) {
     return {
         'before': `<${rootTag}><${rootTag}-${nestedTag}/></${rootTag}>`,
         'after': `<${rootTag}><${rootTag}:${nestedTag}/></${rootTag}>`
+    };
+}
+
+function getNestedTagString(rootTag, nestedTag) {
+    return {
+        'before': `<${rootTag}><if(true)><${rootTag}-${nestedTag}/></if></${rootTag}>`,
+        'after': `<${rootTag}><if(true)><${rootTag}:${nestedTag}/></if></${rootTag}>`
     };
 }
 
@@ -54,19 +63,19 @@ describe('when the ebay-select-option tag is tranformed', () => {
     });
 });
 
-describe('when the ebay-menu-item tag is transformed', () => {
+describe('when the ebay-select-option tag is nested and is tranformed', () => {
     let tagString;
     let outputTemplate;
 
     beforeEach(() => {
-        const rootTag = 'ebay-menu';
-        const nestedTag = 'item';
+        const rootTag = 'ebay-select';
+        const nestedTag = 'option';
         const templatePath = `../../../components/${rootTag}/template.marko`;
-        tagString = getTagString(rootTag, nestedTag);
+        tagString = getNestedTagString(rootTag, nestedTag);
         outputTemplate = getTransformedTemplate(tagString.before, templatePath);
     });
 
-    test('transforms the body contents of a menu', () => {
+    test('transforms the body contents of a listbox', () => {
         expect(outputTemplate).to.deep.equal(tagString.after);
     });
 });

--- a/src/components/ebay-select/examples/3-nested-options/template.marko
+++ b/src/components/ebay-select/examples/3-nested-options/template.marko
@@ -1,0 +1,13 @@
+<var options=[
+    { value: 1, label: 'Option 1' },
+    { value: 2, label: 'Option 2', selected: true },
+    { value: 3, label: 'Option 3' }
+]/>
+
+<span style="display: inline-block; max-width: 200px;">
+    <ebay-select name="formFieldName">
+        <if(true)>
+            <ebay-select-option for(option in options) value=option.value label=option.label selected=option.selected/>
+        </if>
+    </ebay-select>
+</span>


### PR DESCRIPTION
## Description
The previous transform was only one level deep, to the immediate children of the given component tag. This transformer now walks the entire tree looking for children that match the pattern of `{parentTag}-` (looking for the hypen, specifically).

Additionally, the tests now cover this nested tag, along with updating the paths for essential Marko APIs used during the transform.

## Context
This was reported from our first user, who couldn't get the nested tags to show the options, even though everything was set up as we would expect.

## References
Closes #64 