### PR TITLE
Changed semver range for makeup dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,10 +93,10 @@
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "lodash.throttle": "^4.1.1",
-    "makeup-expander": "^0.3.0",
-    "makeup-key-emitter": "~0.0.2",
-    "makeup-prevent-scroll-keys": "~0.0.1",
-    "makeup-roving-tabindex": "~0.0.3",
+    "makeup-expander": "^0.3.2",
+    "makeup-key-emitter": "~0.0.3",
+    "makeup-prevent-scroll-keys": "~0.0.2",
+    "makeup-roving-tabindex": "~0.0.5",
     "nodelist-foreach-polyfill": "^1.2.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -94,9 +94,9 @@
     "lodash.set": "^4.3.2",
     "lodash.throttle": "^4.1.1",
     "makeup-expander": "^0.3.0",
-    "makeup-key-emitter": "^0.0.2",
-    "makeup-prevent-scroll-keys": "^0.0.1",
-    "makeup-roving-tabindex": "^0.0.3",
+    "makeup-key-emitter": "~0.0.2",
+    "makeup-prevent-scroll-keys": "~0.0.1",
+    "makeup-roving-tabindex": "~0.0.3",
     "nodelist-foreach-polyfill": "^1.2.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5117,15 +5117,15 @@ make-dir@^1.0.0:
     pify "^3.0.0"
 
 makeup-exit-emitter@~0.0:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/makeup-exit-emitter/-/makeup-exit-emitter-0.0.3.tgz#619bce4c0ca663d662275b7db16d922896d1a99e"
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/makeup-exit-emitter/-/makeup-exit-emitter-0.0.4.tgz#26482e73db3ef6ef5f8ac2c3c21e8197488fd458"
   dependencies:
     custom-event-polyfill "~0.3"
     makeup-next-id "~0.0"
 
 makeup-expander@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.3.0.tgz#487f2286124af6f4e55fd1ba11198d52334d9d2d"
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.3.1.tgz#c60dccd2921e6a02cf41847306b21e9a5d7a6435"
   dependencies:
     custom-event-polyfill "~0.3"
     makeup-exit-emitter "~0.0"
@@ -5136,31 +5136,31 @@ makeup-focusables@~0.0:
   version "0.0.2"
   resolved "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.0.2.tgz#2e4bc6a08f12ecd8a0a5fa6e5c676b81cf5365a4"
 
-makeup-key-emitter@^0.0.2, makeup-key-emitter@~0.0:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/makeup-key-emitter/-/makeup-key-emitter-0.0.2.tgz#86e2e27166fd42a3e55f82b0ad304463b4b86289"
+makeup-key-emitter@~0.0, makeup-key-emitter@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/makeup-key-emitter/-/makeup-key-emitter-0.0.3.tgz#4fe16127cce749a785f4e2538800415d267fd356"
   dependencies:
     custom-event-polyfill "~0.3"
 
 makeup-navigation-emitter@~0.0:
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/makeup-navigation-emitter/-/makeup-navigation-emitter-0.0.4.tgz#a9dd0d2b9050db1c5ef658bb6d7d0393fd783c26"
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/makeup-navigation-emitter/-/makeup-navigation-emitter-0.0.6.tgz#befcc18d31ee125c332307fb7c304cddbfab4bda"
   dependencies:
     custom-event-polyfill "^0.3.0"
     makeup-exit-emitter "~0.0"
     makeup-key-emitter "~0.0"
 
 makeup-next-id@~0.0:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/makeup-next-id/-/makeup-next-id-0.0.1.tgz#e4bf4821616c85c96d09631aa166732006468f06"
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/makeup-next-id/-/makeup-next-id-0.0.2.tgz#70f19812b0b5cb8d5f0f7f78719179ea4b61a0ef"
 
-makeup-prevent-scroll-keys@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/makeup-prevent-scroll-keys/-/makeup-prevent-scroll-keys-0.0.1.tgz#ed23d327f80db68f89e732f178d04048589648ec"
+makeup-prevent-scroll-keys@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/makeup-prevent-scroll-keys/-/makeup-prevent-scroll-keys-0.0.2.tgz#1c255e5f97968ee3586c0aa55d0d8b3df8318501"
 
-makeup-roving-tabindex@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/makeup-roving-tabindex/-/makeup-roving-tabindex-0.0.3.tgz#8a0fc1a8c9de861213ffd74a397d666f227e6332"
+makeup-roving-tabindex@~0.0.3:
+  version "0.0.5"
+  resolved "https://registry.npmjs.org/makeup-roving-tabindex/-/makeup-roving-tabindex-0.0.5.tgz#5bd855216eed374846b5d26466488ee0b6aeed0e"
   dependencies:
     makeup-navigation-emitter "~0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5116,27 +5116,27 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
-makeup-exit-emitter@~0.0:
+makeup-exit-emitter@~0.0, makeup-exit-emitter@~0.0.4:
   version "0.0.4"
   resolved "https://registry.npmjs.org/makeup-exit-emitter/-/makeup-exit-emitter-0.0.4.tgz#26482e73db3ef6ef5f8ac2c3c21e8197488fd458"
   dependencies:
     custom-event-polyfill "~0.3"
     makeup-next-id "~0.0"
 
-makeup-expander@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.3.1.tgz#c60dccd2921e6a02cf41847306b21e9a5d7a6435"
+makeup-expander@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.3.2.tgz#bb5223ad26dbfeedbf7dc7ea3a21e1d19b58632b"
   dependencies:
     custom-event-polyfill "~0.3"
-    makeup-exit-emitter "~0.0"
-    makeup-focusables "~0.0"
-    makeup-next-id "~0.0"
+    makeup-exit-emitter "~0.0.4"
+    makeup-focusables "~0.0.3"
+    makeup-next-id "~0.0.2"
 
-makeup-focusables@~0.0:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.0.2.tgz#2e4bc6a08f12ecd8a0a5fa6e5c676b81cf5365a4"
+makeup-focusables@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.0.3.tgz#e30f36a99beb7c5166daafb8f823fefcc7a551fa"
 
-makeup-key-emitter@~0.0, makeup-key-emitter@~0.0.2:
+makeup-key-emitter@~0.0, makeup-key-emitter@~0.0.3:
   version "0.0.3"
   resolved "https://registry.npmjs.org/makeup-key-emitter/-/makeup-key-emitter-0.0.3.tgz#4fe16127cce749a785f4e2538800415d267fd356"
   dependencies:
@@ -5150,15 +5150,15 @@ makeup-navigation-emitter@~0.0:
     makeup-exit-emitter "~0.0"
     makeup-key-emitter "~0.0"
 
-makeup-next-id@~0.0:
+makeup-next-id@~0.0, makeup-next-id@~0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/makeup-next-id/-/makeup-next-id-0.0.2.tgz#70f19812b0b5cb8d5f0f7f78719179ea4b61a0ef"
 
-makeup-prevent-scroll-keys@~0.0.1:
+makeup-prevent-scroll-keys@~0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/makeup-prevent-scroll-keys/-/makeup-prevent-scroll-keys-0.0.2.tgz#1c255e5f97968ee3586c0aa55d0d8b3df8318501"
 
-makeup-roving-tabindex@~0.0.3:
+makeup-roving-tabindex@~0.0.5:
   version "0.0.5"
   resolved "https://registry.npmjs.org/makeup-roving-tabindex/-/makeup-roving-tabindex-0.0.5.tgz#5bd855216eed374846b5d26466488ee0b6aeed0e"
   dependencies:


### PR DESCRIPTION
## Description

Changed semver range for makeup dependencies in 0.0.x version and regenerated yarn.lock.

## Context

The caret is not correct for 0.0.x. It meant patch updates would not be taken.

```
^0.2.3 := >=0.2.3 <0.3.0
^0.0.3 := >=0.0.3 <0.0.4
```

The regenerated yarn.lock now has latest patch releases in makeup which fix the .babelrc issue (https://github.com/makeup-js/makeup-expander/issues/5).

If approved these changes will be immediately published as v0.1.1 patch release.

## References

https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004