### PR TITLE
Build: Add browser policy and eslint plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,12 @@
 {
     "extends": "ebay",
-    "parserOptions": {
-        "sourceType": "module"
+    "env": {
+        "browser": true
     },
     "plugins": [
         "import",
-        "mocha"
+        "mocha",
+        "compat"
     ],
     "rules": {
         "import/order": [2, {"groups": ["builtin", "external", "internal", "parent", "sibling", "index"]}],
@@ -13,6 +14,7 @@
         "mocha/no-identical-title": 2,
         "mocha/no-nested-tests": 2,
         "mocha/no-return-and-callback": 2,
-        "mocha/no-sibling-hooks": 2
+        "mocha/no-sibling-hooks": 2,
+        "compat/compat": 2
     }
 }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ _template.marko_
 
 *Note:  when using DOM events, you should also handle event destruction and delegation as needed.*
 
+## Browser Policy
+
+All components support browsers from the official Tier 1 and Tier 2 of the eBay Browser Policy. This list is defined in the `browserslist` section of our [package.json](https://github.com/eBay/ebayui-core/blob/master/package.json), where it is also accessible to internal tooling.
+
 ## Releases &amp; Milestones
 
 For upcoming roadmap and release history, please refer to our [releases](https://github.com/eBay/ebayui-core/releases) and [milestones](https://github.com/eBay/ebayui-core/milestones) pages.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,19 @@
     "lint",
     "test"
   ],
+  "browserslist": [
+    "Chrome >= 49",
+    "Firefox >= 48",
+    "Safari >= 6",
+    "Edge >= 12",
+    "IE >= 9",
+    "Opera 47-48",
+
+    "ChromeAndroid >= 38",
+    "ios_saf >= 7",
+    "ie_mob >= 10",
+    "Android >= 3"
+  ],
   "files": [
     "dist/",
     "marko.json",
@@ -60,6 +73,7 @@
     "coveralls": "^3.0.0",
     "eslint": "^4.11.0",
     "eslint-config-ebay": "^0.1.9",
+    "eslint-plugin-compat": "^2.2.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-mocha": "^4.11.0",
     "express": "^4.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,6 +1527,10 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
+caniuse-db@^1.0.30000794:
+  version "1.0.30000821"
+  resolved "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000821.tgz#3fcdc67c446a94a9cdd848248a4e3e54b2da7419"
+
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805:
   version "1.0.30000810"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz#47585fffce0e9f3593a6feea4673b945424351d9"
@@ -2826,6 +2830,16 @@ eslint-module-utils@^2.1.1:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-compat@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-2.2.0.tgz#d612a9988d9fba66bcd8e86fcc1b551753aac995"
+  dependencies:
+    babel-runtime "^6.26.0"
+    browserslist "^2.11.3"
+    caniuse-db "^1.0.30000794"
+    mdn-browser-compat-data "^0.0.20"
+    requireindex "^1.1.0"
+
 eslint-plugin-import@^2.8.0:
   version "2.9.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz#26002efbfca5989b7288ac047508bd24f217b169"
@@ -3100,7 +3114,7 @@ express@^4.16.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
+extend@3, extend@3.0.1, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -5336,6 +5350,12 @@ mdast-util-compact@^1.0.0:
     unist-util-modify-children "^1.0.0"
     unist-util-visit "^1.1.0"
 
+mdn-browser-compat-data@^0.0.20:
+  version "0.0.20"
+  resolved "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.20.tgz#26e4a226d96cc5318fdc504d6dfd86907752da5c"
+  dependencies:
+    extend "3.0.1"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -7115,6 +7135,10 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
 
 requires-port@1.x.x:
   version "1.0.0"


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- condense browser policy into a `browserslist` definition
- use this list to drive `eslint-plugin-compat`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This helps define our browser support both internally and externally. The eBay policy has 3 tiers, so effectively we need to support tier 1 and 2 (as a component library). We could delineate the exact tiers and browsers, but I don't really want to repeat either the actual eBay Browser Policy or our `browserslist`.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
https://github.com/amilajack/eslint-plugin-compat
#53 
#54 

## Screenshots
Failure looks like this:
```sh
  174:5  error  fetch is not supported in Safari 6, iOS Safari 7.0-7.1, IE Mobile 10, IE 9, Edge 12, Android Browser 3  compat/compat

✖ 1 problem (1 error, 0 warnings)

error An unexpected error occurred: "Command failed.
```