### PR TITLE
Fix for ebay-select options not being clickable

### DIFF
--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -26,6 +26,7 @@
             for(option in data.options)
             role='option'
             class=['listbox__option', option.class]
+            tabindex="-1"
             w-on-click='handleOptionClick'
             w-preserve-attrs="tabindex,data-makeup-index"
             aria-selected=String(option.selected)


### PR DESCRIPTION
## Description
The MyEbay team put the `<ebay-select>` component into their page, but could never click on an option.

## Context
When `makeup-focus-exit` was listening for a focusable another element in the `<ebay-select>` (besides the `<input>`) it found none, and so when a `click` was performed, it was circumvented by the existing "exit" handler for the `<input>`, seeing as the thing clicked was not "focusable".

Adding a tabindex makes the options focusable, thereby allowing them to be "clicked".