### PR TITLE
convert to string to compare the option array & selected option

### DIFF
--- a/src/components/ebay-select/index.js
+++ b/src/components/ebay-select/index.js
@@ -185,7 +185,7 @@ function processAfterStateChange(el) {
  * @param {String} optionValue
  */
 function setSelectedOption(optionValue) {
-    const newOptionSelected = this.state.options.filter(option => option.value === optionValue)[0];
+    const newOptionSelected = this.state.options.filter(option => option.value.toString() === optionValue)[0];
     const newOptionSelectedValue = newOptionSelected && newOptionSelected.value;
     let options = this.clearListboxSelections(this.state.options);
 

--- a/src/components/ebay-select/test/test.browser.js
+++ b/src/components/ebay-select/test/test.browser.js
@@ -10,6 +10,7 @@ describe('given the listbox is in the default state', () => {
     let button;
     let ariaControl;
     let secondOption;
+    let nativeSelect;
 
     beforeEach(() => {
         const renderedWidget = renderer.renderSync({ options: mock.options });
@@ -18,6 +19,7 @@ describe('given the listbox is in the default state', () => {
         button = root.querySelector('.listbox__control');
         ariaControl = button.querySelector('input');
         secondOption = root.querySelector('.listbox__options .listbox__option:nth-child(2)');
+        nativeSelect = root.querySelector('.listbox__native');
     });
 
     afterEach(() => widget.destroy());
@@ -40,6 +42,8 @@ describe('given the listbox is in the default state', () => {
             const eventData = spy.getCall(0).args[0];
             expect(eventData.index).to.equal(1);
             expect(eventData.selected).to.deep.equal(['2']);
+            const nativeOption = nativeSelect.options[nativeSelect.selectedIndex].value;
+            expect(nativeOption).to.equal('2');
         });
     });
 
@@ -61,6 +65,8 @@ describe('given the listbox is in the default state', () => {
             const eventData = spy.getCall(0).args[0];
             expect(eventData.index).to.equal(0);
             expect(eventData.selected).to.deep.equal(['1']);
+            const nativeOption = nativeSelect.options[nativeSelect.selectedIndex].value;
+            expect(nativeOption).to.equal('1');
         });
     });
 
@@ -79,6 +85,8 @@ describe('given the listbox is in the default state', () => {
             const eventData = spy.getCall(0).args[0];
             expect(eventData.index).to.equal(1);
             expect(eventData.selected).to.deep.equal(['2']);
+            const nativeOption = nativeSelect.options[nativeSelect.selectedIndex].value;
+            expect(nativeOption).to.equal('2');
         });
     });
 


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
The 3rd example here doesn't work - http://app.uimarketplace.svc.32.tess.io/?pkg=@ebay/ebayui-core&tag=ebay-select 

## Context
Select UI doesn't change on click and on keyboard when the options are rendered dynamically. 

