### PR TITLE
Select: Fixes clicked element returned;

### DIFF
--- a/src/components/ebay-select/index.js
+++ b/src/components/ebay-select/index.js
@@ -104,7 +104,18 @@ function handleCollapse() {
  * @param {MouseEvent} event
  */
 function handleOptionClick(event) {
-    this.processAfterStateChange(event.target);
+    let el;
+
+    // find the element with the data
+    // start with the target element
+    if (event.target.dataset.optionValue) {
+        el = event.target;
+    // check up the tree one level (in case option-label or status was clicked)
+    } else if (event.target.parentNode.dataset.optionValue) {
+        el = event.target.parentNode;
+    }
+
+    this.processAfterStateChange(el);
     this.expander.collapse();
     this.el.querySelector(listboxHostSelector).focus();
 }

--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -31,14 +31,10 @@
             w-preserve-attrs="tabindex,data-makeup-index"
             aria-selected=String(option.selected)
             data-option-value=option.value>
-            <span
-                class='listbox__option-label'
-                data-option-value=option.value>
+            <span class='listbox__option-label'>
                 ${option.label}
             </span>
-            <span
-                class='listbox__status'
-                data-option-value=option.value/>
+            <span class='listbox__status'/>
         </div>
     </div>
     <select

--- a/src/components/ebay-select/test/test.browser.js
+++ b/src/components/ebay-select/test/test.browser.js
@@ -125,6 +125,7 @@ describe('given the listbox is in an expanded state', () => {
     let button;
     let ariaControl;
     let secondOption;
+    let secondOptionLabel;
 
     beforeEach(() => {
         const renderedWidget = renderer.renderSync({ options: mock.options });
@@ -133,6 +134,7 @@ describe('given the listbox is in an expanded state', () => {
         button = root.querySelector('.listbox__control');
         ariaControl = button.querySelector('input');
         secondOption = root.querySelector('.listbox__options .listbox__option:nth-child(2)');
+        secondOptionLabel = secondOption.querySelector('span:not(.listbox__status)');
         testUtils.triggerEvent(button, 'click');
     });
 
@@ -152,6 +154,25 @@ describe('given the listbox is in an expanded state', () => {
             const eventData = selectSpy.getCall(0).args[0];
             expect(eventData.index).to.equal(1);
             expect(eventData.selected).to.deep.equal(['2']);
+            expect(eventData.el).to.deep.equal(secondOption);
+        });
+    });
+
+    describe('when an option is clicked on the label', () => {
+        let selectSpy;
+
+        beforeEach(() => {
+            selectSpy = sinon.spy();
+            widget.on('listbox-change', selectSpy);
+            testUtils.triggerEvent(secondOptionLabel, 'click');
+        });
+
+        test('then it emits the listbox-select event with correct data', () => {
+            expect(selectSpy.calledOnce).to.equal(true);
+            const eventData = selectSpy.getCall(0).args[0];
+            expect(eventData.index).to.equal(1);
+            expect(eventData.selected).to.deep.equal(['2']);
+            expect(eventData.el).to.deep.equal(secondOption);
         });
     });
 


### PR DESCRIPTION
## Description
When a user clicks on the select's option, you could get different elements returned in the event. This PR will look for the target with the `optionValue`, which is expected to be available.

Additionally, removing the `optionValue` data attribute from the nested elements, since they should not have them.

## References
Fixes #89 