### PR TITLE
eBay-dialog: Fix mask click on mobile safari.

### DIFF
--- a/src/components/ebay-dialog/index.js
+++ b/src/components/ebay-dialog/index.js
@@ -10,7 +10,10 @@ const template = require('./template.marko');
 function init() {
     this.dialogEl = this.getEl('dialog');
     this.closeEl = this.getEl('close');
+    this.maskEl = this.getEl('mask');
     observer.observeRoot(this, ['open']);
+    // Add an event listener to the mask to fix an issue with Safari not recognizing it as a touch target.
+    this.subscribeTo(this.maskEl).on('click', () => {});
 }
 
 function getInitialState(input) {

--- a/src/components/ebay-dialog/template.marko
+++ b/src/components/ebay-dialog/template.marko
@@ -1,7 +1,7 @@
 
 <div class="dialog-placeholder" w-bind>
     <div w-id="dialog" class=data.dialogClass hidden=!data.open role="dialog" w-preserve-attrs="hidden" ${data.htmlAttributes}>
-        <div class=data.maskClass w-onclick="close"/>
+        <div class=data.maskClass w-id="mask" w-onclick="close"/>
         <div class=data.windowClass role="document">
             <button class="dialog__close" type="button" aria-label=data.ariaLabelClose w-id="close" w-onclick="close">
                 <svg aria-hidden="true" focusable="false" height="17" width="17">


### PR DESCRIPTION
## Description
This PR adds a dummy event handler to the dialog mask element to fix an issue where mobile safari was not recognizing it as a touch target.

## References
#93
