### PR TITLE
Button: add label attribute

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -33,11 +33,12 @@ app.get('/:component?', (req, res) => {
     const model = {
         name: req.params.component,
         examples: fs.readdirSync(examplesPath).map(example => ({
+            num: parseInt(example.split('-')[0]),
             name: example.split('-').slice(1, example.length).join(' '),
             code: highlight.sync(fs.readFileSync(`${examplesPath}/${example}/template.marko`, 'utf8'), 'marko'),
             sources: [`${componentsPath}/${name}`, examplesPath, `${examplesPath}/${example}`],
             path: `${examplesPath}/${example}`
-        })).filter(demoUtils.isDirectory),
+        })).filter(demoUtils.isDirectory).sort((a, b) => a.num > b.num),
         components: demoUtils.getComponentsWithExamples('src')
     };
 

--- a/marko.json
+++ b/marko.json
@@ -2,6 +2,7 @@
     "<ebay-button>": {
         "renderer": "./src/components/ebay-button/index.js",
         "@class": "string",
+        "@label": "string",
         "@disabled": "boolean",
         "@partially-disabled": "boolean",
         "@href": "string",

--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -4,6 +4,7 @@
 
 ```marko
 <ebay-button>label</ebay-button>
+<ebay-button label="label"/>
 ```
 
 ## ebay-button Attributes
@@ -11,6 +12,7 @@
 Name | Type | Stateful | Description
 --- | --- | --- | ---
 `class` | String | No | custom class
+`label` | String | Yes | can be used instead of a tag body
 `priority` | String | No | "primary" / "secondary" (default) / "none"
 `size` | String | No | "small" or "large" (default: medium)
 `href` | String | No | for link that looks like a button

--- a/src/components/ebay-button/examples/10-label-instead-of-body/template.marko
+++ b/src/components/ebay-button/examples/10-label-instead-of-body/template.marko
@@ -1,0 +1,1 @@
+<ebay-button label="label"/>

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -2,19 +2,28 @@ const markoWidgets = require('marko-widgets');
 const emitAndFire = require('../../common/emit-and-fire');
 const eventUtils = require('../../common/event-utils');
 const processHtmlAttributes = require('../../common/html-attributes');
+const observer = require('../../common/property-observer');
 const template = require('./template.marko');
 
 function getInitialState(input) {
     return {
-        disabled: Boolean(input.disabled)
+        label: input.label,
+        href: input.href,
+        priority: input.priority || 'secondary',
+        size: input.size,
+        fluid: input.fluid,
+        class: input.class,
+        partiallyDisabled: input.partiallyDisabled,
+        disabled: Boolean(input.disabled),
+        htmlAttributes: processHtmlAttributes(input)
     };
 }
 
-function getTemplateData(state, input) {
-    const href = input.href;
-    const priority = input.priority || 'secondary';
-    const size = input.size;
-    const fluid = input.fluid;
+function getTemplateData(state) {
+    const href = state.href;
+    const priority = state.priority || 'secondary';
+    const size = state.size;
+    const fluid = state.fluid;
     let classes = ['btn'];
     const model = {};
     let tag;
@@ -40,17 +49,22 @@ function getTemplateData(state, input) {
     }
 
     // must be after other class processing
-    if (input.class) {
-        classes.push(input.class);
+    if (state.class) {
+        classes.push(state.class);
     }
 
     model.tag = tag;
     model.classes = classes;
+    model.label = state.label;
+    model.partiallyDisabled = state.partiallyDisabled ? 'true' : null; // for aria-disabled
     model.disabled = state.disabled;
-    model.partiallyDisabled = input.partiallyDisabled ? 'true' : null; // for aria-disabled
-    model.htmlAttributes = processHtmlAttributes(input);
+    model.htmlAttributes = state.htmlAttributes;
 
     return model;
+}
+
+function init() {
+    observer.observeRoot(this, ['label']);
 }
 
 function handleClick() {
@@ -74,6 +88,7 @@ module.exports = markoWidgets.defineComponent({
     template,
     getInitialState,
     getTemplateData,
+    init,
     handleClick,
     handleKeydown
 });

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -1,6 +1,5 @@
 <${data.tag}
     w-bind
-    w-body
     w-onclick="handleClick"
     w-onkeydown="handleKeydown"
     type="button"
@@ -9,4 +8,10 @@
     disabled=data.disabled
     aria-disabled=data.partiallyDisabled
     ${data.htmlAttributes}>
+    <if(data.label)>
+        ${data.label}
+    </if>
+    <else>
+        <span w-body body-only-if(true)/>
+    </else>
 </>


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

I'm not sure if we should do this change or not, so I'm really looking for feedback this far. If we do decide to go with this, I'll flesh out the tests for it.

## Description
<!--- What are the changes? -->
- adds `label` attribute for `<ebay-button>` as an alternative to HTML body
- order demo examples correctly (first time we have more than 9 examples)

## Context
<!--- Why did you make these changes, and why in this particular way? -->
The button currently accepts its inner content with an HTML-like body. This allows complex HTML inside the button, but means that it can be more complicated to statefully update the content. A common use case with the button is to use a simple string label. For this case, it makes sense to expose that attribute as a stateful property. I was able to support both methods at the same time.

Note that this does add clientside rendering to the button. I'm also not sure if this pattern would apply all the time, or just for very simple components like this one.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
https://github.com/eBay/ebayui-core/issues/91
