### PR TITLE
New component: ebay-pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For more information, please read [Building a UI Component in 2017 and Beyond](h
 * [`ebay-dialog`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-dialog)
 * [`ebay-menu`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-menu)
 * [`ebay-notice`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-notice)
+* [`ebay-pagination`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-pagination)
 * [`ebay-select`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-select)
 
 ## Getting Started

--- a/demo/browser.json
+++ b/demo/browser.json
@@ -6,12 +6,13 @@
         "@ebay/skin/marketsans",
         "./atom-light-syntax.css",
         "./style.less",
+        "../src/components/ebay-breadcrumb",
         "../src/components/ebay-button",
         "../src/components/ebay-carousel",
         "../src/components/ebay-dialog",
         "../src/components/ebay-menu",
-        "../src/components/ebay-select",
         "../src/components/ebay-notice",
-        "../src/components/ebay-breadcrumb"
+        "../src/components/ebay-pagination",
+        "../src/components/ebay-select"
     ]
 }

--- a/marko.json
+++ b/marko.json
@@ -93,5 +93,25 @@
             "@*": "expression"
         }
     },
-    "<ebay-breadcrumb-item>": {}
+    "<ebay-breadcrumb-item>": {},
+    "<ebay-pagination>": {
+        "renderer": "./src/components/ebay-pagination/index.js",
+        "transformer": "./src/common/transformer/index.js",
+        "@class": "string",
+        "@accessibility-prev": "string",
+        "@accessibility-next": "string",
+        "@accessibility-current": "string",
+        "@hijax": "boolean",
+        "@*": "expression",
+        "@items <item>[]": {
+            "@class": "string",
+            "@current": "boolean",
+            "@disabled": "string",
+            "@href": "string",
+            "@type": "string",
+            "@role": "string",
+            "@*": "expression"
+        }
+    },
+    "<ebay-pagination-item>": {}
 }

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -1,0 +1,53 @@
+# ebay-pagination
+
+The `<ebay-pagination>` is a tag used to create a pagination navigation.
+
+## ebay-pagination Tag
+
+### ebay-pagination Usage
+
+```marko
+<ebay-pagination aria-label-prev="Previous page" aria-label-next="Next page" curr-text="Results Pagination - Page 2">
+    <ebay-pagination-item href="#" previous disabled/>
+    <ebay-pagination-item href="#">item 1</ebay-pagination-item>
+    <ebay-pagination-item href="#" current>item 2</ebay-pagination-item>
+    <ebay-pagination-item href="#">item 3</ebay-pagination-item>
+    <ebay-pagination-item href="#" next/>
+</ebay-pagination>
+```
+
+### ebay-pagination Attributes
+
+Name | Type | Stateful | Description
+--- | --- | --- | ---
+`class` | String | No | custom class
+`accessibility-prev` | String | No | aria-label for previous arrow button
+`accessibility-next` | String | No | aria-label for next arrow button
+`accessibility-current` | String | No | Description for the current page (e.g. Results of Page 1)
+`hijax` | Boolean | No | Use pagination links for an ajax reload
+
+### ebay-pagination Events
+
+Event | Data | Description
+--- | --- | ---
+`pagination-previous` |  `{ event, el: event.target }`| clicked previous arrow button
+`pagination-next` | `{ event, el: event.target }` | clicked next arrow button
+`pagination-select` | `{ event, el: event.target , value: "Selected page" }` | page selected clicked
+
+## ebay-pagination-item Tag
+
+### ebay-pagination-item Usage
+
+```marko
+<ebay-pagination-item>1</ebay-pagination-item>
+```
+
+### ebay-pagination-item Attributes
+
+Name | Type | Stateful | Description
+--- | --- | --- | ---
+`disabled` | Boolean | No | Item is disabled or not (Note: should only be used in case of navigation)
+`href` | String | No | for link that looks like a menu-item
+`current` | Boolean | No | the current page
+`next` | Boolean | No | whether or not the input is the next page (when not provided taken as `disabled`)
+`previous` | Boolean | No | whether or not the input is the next page (when not provided taken as `disabled`)

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -46,8 +46,8 @@ Event | Data | Description
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`disabled` | Boolean | No | Item is disabled or not (Note: should only be used in case of navigation)
+`disabled` | Boolean | No | Previous/next button is disabled or not
+`class` | String | No | custom class
 `href` | String | No | for link that looks like a menu-item
 `current` | Boolean | No | the current page
-`next` | Boolean | No | whether or not the input is the next page (when not provided taken as `disabled`)
-`previous` | Boolean | No | whether or not the input is the next page (when not provided taken as `disabled`)
+`type` | String | No | "previous", "next" or "page"(default). To specify if the information entered is for the previous or next arrrow button or a page. If the `type='previous|next'` isn't provided the previous/next arrow buttons will be taken as `disabled`

--- a/src/components/ebay-pagination/browser.json
+++ b/src/components/ebay-pagination/browser.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "if-not-flag": "ebayui-no-skin",
+            "dependencies": [
+                "@ebay/skin/pagination",
+                "@ebay/skin/utility",
+                "@ebay/skin/icon"
+            ]
+        },
+        "require: marko-widgets",
+        "require: ./index.js"
+    ]
+}

--- a/src/components/ebay-pagination/examples/1-basic-links/template.marko
+++ b/src/components/ebay-pagination/examples/1-basic-links/template.marko
@@ -1,0 +1,13 @@
+<ebay-pagination>
+    <ebay-pagination-item href="#" type="previous" disabled></ebay-pagination-item>
+    <ebay-pagination-item href="#" current>1</ebay-pagination-item>
+    <ebay-pagination-item href="#">2</ebay-pagination-item>
+    <ebay-pagination-item href="#">3</ebay-pagination-item>
+    <ebay-pagination-item href="#">4</ebay-pagination-item>
+    <ebay-pagination-item href="#">5</ebay-pagination-item>
+    <ebay-pagination-item href="#">6</ebay-pagination-item>
+    <ebay-pagination-item href="#">7</ebay-pagination-item>
+    <ebay-pagination-item href="#">8</ebay-pagination-item>
+    <ebay-pagination-item href="#">9</ebay-pagination-item>
+    <ebay-pagination-item href="#" type="next"></ebay-pagination-item>
+</ebay-pagination>

--- a/src/components/ebay-pagination/examples/2-hijax/template.marko
+++ b/src/components/ebay-pagination/examples/2-hijax/template.marko
@@ -1,0 +1,13 @@
+<ebay-pagination hijax>
+    <ebay-pagination-item href="#" type="previous" disabled></ebay-pagination-item>
+    <ebay-pagination-item href="#" current>1</ebay-pagination-item>
+    <ebay-pagination-item href="#">2</ebay-pagination-item>
+    <ebay-pagination-item href="#">3</ebay-pagination-item>
+    <ebay-pagination-item href="#">4</ebay-pagination-item>
+    <ebay-pagination-item href="#">5</ebay-pagination-item>
+    <ebay-pagination-item href="#">6</ebay-pagination-item>
+    <ebay-pagination-item href="#">7</ebay-pagination-item>
+    <ebay-pagination-item href="#">8</ebay-pagination-item>
+    <ebay-pagination-item href="#">9</ebay-pagination-item>
+    <ebay-pagination-item href="#" type="next"></ebay-pagination-item>
+</ebay-pagination>

--- a/src/components/ebay-pagination/examples/3-arrows-disabled/template.marko
+++ b/src/components/ebay-pagination/examples/3-arrows-disabled/template.marko
@@ -1,0 +1,5 @@
+<ebay-pagination>
+    <ebay-pagination-item type="previous" disabled></ebay-pagination-item>
+    <ebay-pagination-item href="#" current>1</ebay-pagination-item>
+    <ebay-pagination-item href="#" type="next" disabled></ebay-pagination-item>
+</ebay-pagination>

--- a/src/components/ebay-pagination/examples/4-without-arrows-input/template.marko
+++ b/src/components/ebay-pagination/examples/4-without-arrows-input/template.marko
@@ -1,0 +1,3 @@
+<ebay-pagination>
+    <ebay-pagination-item href="#" current>1</ebay-pagination-item>
+</ebay-pagination>

--- a/src/components/ebay-pagination/examples/5-accessibility-text/template.marko
+++ b/src/components/ebay-pagination/examples/5-accessibility-text/template.marko
@@ -1,0 +1,13 @@
+<ebay-pagination accessibility-prev="Previous page" accessibility-next="Next page" accessibility-current="Results Pagination - Page 4">
+    <ebay-pagination-item href="#" type="previous" disabled></ebay-pagination-item>
+    <ebay-pagination-item href="#" >1</ebay-pagination-item>
+    <ebay-pagination-item href="#">2</ebay-pagination-item>
+    <ebay-pagination-item href="#">3</ebay-pagination-item>
+    <ebay-pagination-item href="#" current>4</ebay-pagination-item>
+    <ebay-pagination-item href="#">5</ebay-pagination-item>
+    <ebay-pagination-item href="#">6</ebay-pagination-item>
+    <ebay-pagination-item href="#">7</ebay-pagination-item>
+    <ebay-pagination-item href="#">8</ebay-pagination-item>
+    <ebay-pagination-item href="#">9</ebay-pagination-item>
+    <ebay-pagination-item href="#" type="next"></ebay-pagination-item>
+</ebay-pagination>

--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -1,0 +1,159 @@
+const processHtmlAttributes = require('../../common/html-attributes');
+const eventUtils = require('../../common/event-utils');
+const emitAndFire = require('../../common/emit-and-fire');
+const template = require('./template.marko');
+
+const constants = {
+    indexForNavigation: 2,
+    minPagesRequired: 5,
+    maxPagesAllowed: 9,
+    margin: 8
+};
+
+function getInitialState(input) {
+    let prevItem;
+    let nextItem;
+    const items = [];
+    const inputItems = input.items || [];
+    const isHijax = input.hijax || false;
+    let role;
+
+    if (isHijax) {
+        role = 'button';
+    }
+
+    for (let i = 0; i < inputItems.length; ++i) {
+        const item = inputItems[i];
+        const href = item.href;
+        const current = item.current;
+
+        const tempItem = {
+            role,
+            href,
+            current: Boolean(current) || false,
+            htmlAttributes: processHtmlAttributes(item),
+            renderBody: item.renderBody
+        };
+        if (item.type === 'previous') {
+            prevItem = tempItem;
+            prevItem.class = 'pagination__previous';
+            prevItem.disabled = Boolean(item.disabled) || !href;
+            continue;
+        } else if (item.type === 'next') {
+            nextItem = tempItem;
+            nextItem.class = 'pagination__next';
+            nextItem.disabled = Boolean(item.disabled) || !href;
+            continue;
+        } else {
+            tempItem.class = ['pagination__item', item.class];
+        }
+        items.push(tempItem);
+    }
+
+    return {
+        isHijax,
+        nextItem: nextItem || { class: 'pagination__next', disabled: true },
+        prevItem: prevItem || { class: 'pagination__previous', disabled: true },
+        items,
+        accessibilityPrev: input.accessibilityPrev || 'Previous page',
+        accessibilityNext: input.accessibilityNext || 'Next page',
+        accessibilityCurrent: input.accessibilityCurrent || 'Results Pagination - Page 1',
+        classes: ['pagination', input.class],
+        htmlAttributes: processHtmlAttributes(input)
+    };
+}
+
+function getTemplateData(state) {
+    return state;
+}
+
+function init() {
+    this.pageContainerEl = this.el.querySelector('.pagination__items');
+    this.pageEls = this.pageContainerEl.children;
+    this.containerEl = this.el;
+    this.subscribeTo(eventUtils.resizeUtil).on('resize', refresh.bind(this));
+    this.refresh();
+}
+
+function refresh() {
+    const containerWidth = this.containerEl.offsetWidth;
+    const pageNumWidth = this.pageEls[0].offsetWidth + constants.margin;
+    const numPagesAllowed = Math.floor(containerWidth / pageNumWidth) - constants.indexForNavigation;
+    const adjustedNumPages = Math.min(constants.maxPagesAllowed,
+        Math.max(numPagesAllowed, constants.minPagesRequired));
+    const totalPages = this.pageEls.length;
+
+    // Let's show all the pages that we can.
+    for (let i = 5; i < adjustedNumPages && i < totalPages; ++i) {
+        if (this.pageEls[i].hasAttribute('hidden')) {
+            this.pageEls[i].removeAttribute('hidden');
+        }
+    }
+
+    // Now that we are showing all the pages that we can, lets hide remaining pages.
+    for (let i = adjustedNumPages; i < totalPages; ++i) {
+        this.pageEls[i].setAttribute('hidden', true);
+    }
+}
+
+function handleHijax(e) {
+    if (this.state.isHijax) {
+        e.preventDefault();
+    }
+}
+
+/**
+ * Handle normal mouse click for item, next page and previous page respectively.
+ * @param {MouseEvent} event
+ */
+function handlePageClick(event) {
+    this.handleHijax(event);
+    emitAndFire(this, 'pagination-select', { el: event.target, value: event.target.innerText });
+}
+
+function handleNextPage(event) {
+    this.handleHijax(event);
+    emitAndFire(this, 'pagination-next', { el: event.target });
+}
+
+function handlePreviousPage(event) {
+    this.handleHijax(event);
+    emitAndFire(this, 'pagination-previous', { el: event.target });
+}
+
+/**
+ * Handle accessibility for item, next page and previous page respectively.
+ * @param {KeyboardEvent} event
+ */
+function handlePageKeyDown(event) {
+    eventUtils.handleActionKeydown(event, () => {
+        this.handlePageClick(event);
+    });
+}
+
+function handleNextPageKeyDown(event) {
+    eventUtils.handleActionKeydown(event, () => {
+        this.handleNextPage(event);
+    });
+}
+
+function handlePreviousPageKeyDown(event) {
+    eventUtils.handleActionKeydown(event, () => {
+        this.handlePreviousPage(event);
+    });
+}
+
+module.exports = require('marko-widgets').defineComponent({
+    template,
+    init,
+    refresh,
+    handleHijax,
+    handlePageClick,
+    handleNextPage,
+    handlePreviousPage,
+    handlePageKeyDown,
+    handleNextPageKeyDown,
+    handlePreviousPageKeyDown,
+    getInitialState,
+    getTemplateData
+});

--- a/src/components/ebay-pagination/mock/index.js
+++ b/src/components/ebay-pagination/mock/index.js
@@ -1,0 +1,136 @@
+const renderBody = (stream) => stream.write('1');
+module.exports = {
+    basicLinks: {
+        'aria-label-previous': 'Previous page',
+        'aria-label-next': 'Next page',
+        'curr-text': 'Results Pagination - Page 2',
+        items: [
+            {
+                type: 'previous',
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                current: true,
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                type: 'next',
+                href: 'https://www.ebay.com/'
+            }
+        ]
+    },
+    hijax: {
+        'ariaLabelPrevious': 'Previous page',
+        'ariaLabelNext': 'Next page',
+        'currText': 'Results Pagination - Page 2',
+        'hijax': true,
+        items: [
+            {
+                type: 'previous',
+                href: 'https://www.ebay.com/'
+            },
+            {
+                current: true,
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                type: 'next',
+                href: 'https://www.ebay.com/'
+            }
+        ]
+    },
+    basicLinksWithoutCurrent: {
+        'ariaLabelPrevious': 'Previous page',
+        'ariaLabelNext': 'Next page',
+        'currText': 'Results Pagination - Page X',
+        'fakeLink': true,
+        items: [
+            {
+                type: 'previous',
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                type: 'next',
+                href: 'https://www.ebay.com/'
+            }
+        ]
+    },
+    basicLinksWithoutNavigation: {
+        'ariaLabelPrevious': 'Previous page',
+        'ariaLabelNext': 'Next page',
+        'currText': 'Results Pagination - Page 1',
+        'fakeLink': true,
+        items: [
+            {
+                current: true,
+                renderBody,
+                href: 'https://www.ebay.com/'
+            }
+        ]
+    },
+    disabledNavigation: {
+        'ariaLabelPrevious': 'Previous page',
+        'ariaLabelNext': 'Next page',
+        'currText': 'Results Pagination - Page 2',
+        items: [
+            {
+                type: 'previous'
+            },
+            {
+                current: true,
+                renderBody,
+                href: 'https://www.ebay.com/'
+            },
+            {
+                type: 'next',
+                disabled: true
+            }
+        ]
+    }
+};

--- a/src/components/ebay-pagination/template.marko
+++ b/src/components/ebay-pagination/template.marko
@@ -1,0 +1,43 @@
+<nav class=data.classes ${data.htmlAttributes} w-bind aria-labelledby="pagination-heading-${widget.elId()}" role="navigation">
+    <span aria-live="polite" role="status">
+        <h2 class="clipped"
+            id="pagination-heading-${widget.elId()}">
+            ${data.accessibilityCurrent}
+        </h2>
+    </span>
+    <a aria-disabled=String(data.prevItem.disabled)
+        aria-label=data.accessibilityPrev
+        class=data.prevItem.class
+        href=data.prevItem.href
+        role=data.role
+        w-onkeydown="handlePreviousPageKeyDown"
+        w-onclick="handlePreviousPage"
+        if(data.prevItem)>
+       <span></span>
+    </a>
+    <ol class="pagination__items">
+        <for(item in data.items)>
+            <li>
+                <a aria-current=(item.current ? "page" : '')
+                    href=item.href
+                    role=item.role
+                    class=item.class
+                    w-onkeydown="handlePageKeyDown"
+                    w-onclick="handlePageClick"
+                    ${item.htmlAttributes}
+                    w-body=item.renderBody>
+                </a>
+            </li>
+        </for>
+    </ol>
+    <a aria-disabled=String(data.nextItem.disabled)
+        aria-label=data.accessibilityNext
+        class=data.nextItem.class
+        href=data.nextItem.href
+        role=data.role
+        w-onkeydown="handleNextPageKeyDown"
+        w-onclick="handleNextPage"
+        if(data.nextItem)>
+       <span></span>
+    </a>
+</nav>

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -1,0 +1,123 @@
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const testUtils = require('../../../common/test-utils/browser');
+const mock = require('../mock');
+const renderer = require('../');
+
+describe('given the menu is in the default state with links', () => {
+    let widget;
+    let root;
+    let previousButton;
+    let pageItem;
+    let nextButton;
+
+    beforeEach(() => {
+        widget = renderer.renderSync(mock.hijax).appendTo(document.body).getWidget();
+        root = document.querySelector('nav.pagination');
+        previousButton = root.querySelector('.pagination__previous');
+        nextButton = root.querySelector('.pagination__next');
+        pageItem = root.querySelector('.pagination__item');
+    });
+    afterEach(() => widget.destroy());
+
+    describe('when the previous button is clicked', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('pagination-previous', spy);
+            testUtils.triggerEvent(previousButton, 'click');
+        });
+
+        test('then it emits the marko event called pagination-previous', () => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+        });
+    });
+
+    describe('when the next button is clicked', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('pagination-next', spy);
+            testUtils.triggerEvent(nextButton, 'click');
+        });
+
+        test('then it emits the marko event called pagination-next', () => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+        });
+    });
+
+    describe('when the page number is clicked', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('pagination-select', spy);
+            testUtils.triggerEvent(pageItem, 'click');
+        });
+
+        test('then it emits the marko event called pagination-select', () => {
+            expect(spy.calledOnce).to.equal(true);
+            const eventData = spy.getCall(0).args[0];
+            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el', 'value']);
+            expect(eventData.value).to.be.equal('1');
+        });
+    });
+
+    describe('when the previous button is activated through keydown', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('pagination-previous', spy);
+            testUtils.triggerEvent(previousButton, 'keydown', 32);
+        });
+
+        test('then it emits the marko event called pagination-previous', () => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+        });
+    });
+
+    describe('when the next button is activated through keydown', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('pagination-next', spy);
+            testUtils.triggerEvent(nextButton, 'keydown', 32);
+        });
+
+        test('then it emits the marko event called pagination-next', () => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+        });
+    });
+
+    describe('when the page number is activated through keydown', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('pagination-select', spy);
+            testUtils.triggerEvent(pageItem, 'keydown', 32);
+        });
+
+        test('then it emits the marko event called pagination-select', () => {
+            expect(spy.calledOnce).to.equal(true);
+            const eventData = spy.getCall(0).args[0];
+            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el', 'value']);
+            expect(eventData.value).to.be.equal('1');
+        });
+    });
+    describe('when an action button is activated for a hijax pagination', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy(widget, 'handleHijax');
+            testUtils.triggerEvent(previousButton, 'click');
+        });
+
+        afterEach(() => widget.handleHijax.restore());
+
+        test('then handleHijax method is called', () => {
+            expect(spy.calledOnce).to.equal(true);
+        });
+    });
+});

--- a/src/components/ebay-pagination/test/test.server.js
+++ b/src/components/ebay-pagination/test/test.server.js
@@ -1,0 +1,57 @@
+const expect = require('chai').expect;
+const testUtils = require('../../../common/test-utils/server');
+const mock = require('../mock/index');
+
+describe('pagination', () => {
+    test('renders basic version', context => {
+        const $ = testUtils.getCheerio(context.render(mock.basicLinks));
+        expect($('nav.pagination').length).to.equal(1);
+        expect($('.pagination__previous').length).to.equal(1);
+        expect($('.pagination__next').length).to.equal(1);
+        expect($('h2.clipped').length).to.equal(1);
+    });
+
+    test('renders fake version', context => {
+        const $ = testUtils.getCheerio(context.render(mock.hijax));
+        expect($('a.pagination__item[role="button"]').length).to.equal(2);
+    });
+
+    test('renders with a selected element when current page defined', context => {
+        const $ = testUtils.getCheerio(context.render(mock.basicLinks));
+        expect($('.pagination__item[aria-current="page"]').length).to.equal(1);
+    });
+
+    test('renders without a selected element when current page not defined', context => {
+        const $ = testUtils.getCheerio(context.render(mock.basicLinksWithoutCurrent));
+        expect($('.pagination__item[aria-current="page"]').length).to.equal(0);
+    });
+
+    test('renders with aria-disabled when navigation is disabled', context => {
+        const $ = testUtils.getCheerio(context.render(mock.disabledNavigation));
+        expect($('.pagination__previous[aria-disabled=true]').length).to.equal(1);
+    });
+
+    test('renders with arrows disabled when not provided in input', context => {
+        const $ = testUtils.getCheerio(context.render(mock.basicLinksWithoutNavigation));
+        expect($('.pagination__previous[aria-disabled=true]').length).to.equal(1);
+        expect($('.pagination__next[aria-disabled=true]').length).to.equal(1);
+    });
+
+    test('handles pass-through html attributes', context => {
+        testUtils.testHtmlAttributes(context, '.pagination');
+    });
+
+    test('handles custom class', context => {
+        testUtils.testCustomClass(context, '.pagination');
+    });
+});
+
+describe('pagination-item', () => {
+    test('handles pass-through html attributes for item', context => {
+        testUtils.testHtmlAttributes(context, '.pagination__item', 'items');
+    });
+
+    test('handles custom class for item', context => {
+        testUtils.testCustomClass(context, '.pagination__item', 'items');
+    });
+});


### PR DESCRIPTION
## Description
Contains a new component `ebay-pagination` which constructs page navigation.

## Context
- The pagination is constructed with a parent element `<ebay-pagination>` which takes as input a boolean value `fake-link` (for the ajax links), the `aria-*` (for `next`, `previous` and `heading` of the component) and its child element `<ebay-pagination-item>` which takes as input boolean type `previous`, `next` and `current` to provide context for the item and `disabled` to provide information about the navigating links.
- There are 3 events that will be fired: `pagination-previous`, `pagination-next` and `pagination-select` each returns the `target` with `pagination-select` emitting an additional `value` of the page clicked/pressed.
- When the `previous` or `next` is not provided in the input for `<ebay-pagination-item>` the navigation is taken as `disabled`. 

`(Note: To pass the tests I have added the resize-event-utils changes here, once that gets merged I will rebase it from 0.3.0)`

## References
Closes #20 

## Screenshots
<img width="776" alt="screen shot 2018-04-17 at 12 06 40 am" src="https://user-images.githubusercontent.com/6751429/38853803-43684b50-41d3-11e8-80fc-4e21610b8770.png">

