### PR TITLE
Allow style to pass through the button

### DIFF
--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -46,6 +46,7 @@ function getTemplateData(state, input) {
 
     model.tag = tag;
     model.classes = classes;
+    model.style = input.style;
     model.disabled = state.disabled;
     model.partiallyDisabled = input.partiallyDisabled ? 'true' : null; // for aria-disabled
     model.htmlAttributes = processHtmlAttributes(input);

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -5,6 +5,7 @@
     w-onkeydown="handleKeydown"
     type="button"
     class=data.classes
+    style=data.style
     href=data.href
     disabled=data.disabled
     aria-disabled=data.partiallyDisabled


### PR DESCRIPTION
# Description
Add style as a pass through to the 

## Context

Given that marko treats `class` and `style` differently. We should allow the style to also be explicitly defined in the template, this way we don't run into trouble when using the ebay-button inside a nested component.

```
// this is button wrapper file
<ebay-button ...input />
```

```
// this is the user of the  button-wrapper
$ const style = { color: red }
<button-wrapper fluid style=style > some text <button-wrapper />
```

This doesn't add `style` to the `input['*']` object. And if we otherwise did:
```
// this is button wrapper file
<ebay-button style=input.style />
```

What we get is:

![image](https://user-images.githubusercontent.com/3291619/38955274-2e3d99b0-4322-11e8-9963-ad0f981a980e.png)
