### PR TITLE
Menu: update grow and reverse

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -56,8 +56,8 @@
         "@class": "string",
         "@label": "string",
         "@expanded": "boolean",
-        "@grow": "boolean",
-        "@grow-reverse": "boolean",
+        "@reverse": "boolean",
+        "@fix-width": "boolean",
         "@auto-collapse": "boolean",
         "@*": "expression",
         "@items <item>[]": {

--- a/src/components/ebay-menu/README.md
+++ b/src/components/ebay-menu/README.md
@@ -20,8 +20,8 @@ Name | Type | Stateful | Description
 `label` | String | Yes | button label
 `expanded` | Boolean | Yes | whether content is expanded (Note: not supported as initial attribute)
 `type` | String | No | Can be "fake" / "radio" / "checkbox"
-`reverse` | Boolean | No | grow items container beyond menu width to the left
-`fix-width` | Boolean | No | constrain items container width to menu width
+`reverse` | Boolean | No | expand menu flyout to the left
+`fix-width` | Boolean | No | constrain items container width to button width
 `auto-collapse` | Boolean | No | collapse automatically when focus lost
 `checked` (radio) | Number | Yes | will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup
 

--- a/src/components/ebay-menu/README.md
+++ b/src/components/ebay-menu/README.md
@@ -20,8 +20,8 @@ Name | Type | Stateful | Description
 `label` | String | Yes | button label
 `expanded` | Boolean | Yes | whether content is expanded (Note: not supported as initial attribute)
 `type` | String | No | Can be "fake" / "radio" / "checkbox"
-`grow` | Boolean | No | grow items container beyond menu size to the right
-`grow-reverse` | Boolean | No | grow items container beyond menu size to the left
+`reverse` | Boolean | No | grow items container beyond menu width to the left
+`fix-width` | Boolean | No | constrain items container width to menu width
 `auto-collapse` | Boolean | No | collapse automatically when focus lost
 `checked` (radio) | Number | Yes | will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup
 

--- a/src/components/ebay-menu/examples/1-basic/template.marko
+++ b/src/components/ebay-menu/examples/1-basic/template.marko
@@ -1,5 +1,5 @@
 <ebay-menu label="eBay Menu">
-    <ebay-menu-item>item 1</ebay-menu-item>
+    <ebay-menu-item>item 1 that has very long text</ebay-menu-item>
     <ebay-menu-item>item 2</ebay-menu-item>
     <ebay-menu-item>item 3</ebay-menu-item>
 </ebay-menu>

--- a/src/components/ebay-menu/examples/3-fix-width/template.marko
+++ b/src/components/ebay-menu/examples/3-fix-width/template.marko
@@ -1,4 +1,4 @@
-<ebay-menu grow label="eBay Menu">
+<ebay-menu fix-width label="eBay Menu">
     <ebay-menu-item>item 1 that has very long text</ebay-menu-item>
     <ebay-menu-item>item 2</ebay-menu-item>
     <ebay-menu-item>item 3</ebay-menu-item>

--- a/src/components/ebay-menu/examples/4-reverse/template.marko
+++ b/src/components/ebay-menu/examples/4-reverse/template.marko
@@ -1,4 +1,4 @@
-<ebay-menu grow-reverse label="eBay Menu" style="margin-left:200px">
+<ebay-menu reverse label="eBay Menu" style="margin-left:200px">
     <ebay-menu-item>item 1 that has very long text</ebay-menu-item>
     <ebay-menu-item>item 2</ebay-menu-item>
     <ebay-menu-item>item 3</ebay-menu-item>

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -75,8 +75,8 @@ function getInitialState(input) {
         isFake,
         label: input.label,
         class: input.class,
-        grow: Boolean(input.grow),
-        growReverse: Boolean(input.growReverse),
+        reverse: Boolean(input.reverse),
+        fixWidth: Boolean(input.fixWidth),
         expanded: false,
         htmlAttributes: processHtmlAttributes(input),
         items,
@@ -91,20 +91,20 @@ function getTemplateData(state) {
     if (state.isFake) {
         menuClass.push('fake-menu');
         itemsClass.push('fake-menu__items');
-        if (state.grow) {
-            itemsClass.push('fake-menu__items--grow');
+        if (state.reverse) {
+            itemsClass.push('fake-menu__items--reverse');
         }
-        if (state.growReverse) {
-            itemsClass.push('fake-menu__items--grow-reverse');
+        if (state.fixWidth) {
+            itemsClass.push('fake-menu__items--fix-width');
         }
     } else {
         menuClass.push('menu');
         itemsClass.push('menu__items');
-        if (state.grow) {
-            itemsClass.push('menu__items--grow');
+        if (state.reverse) {
+            itemsClass.push('menu__items--reverse');
         }
-        if (state.growReverse) {
-            itemsClass.push('menu__items--grow-reverse');
+        if (state.fixWidth) {
+            itemsClass.push('menu__items--fix-width');
         }
     }
 

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -20,50 +20,50 @@ describe('menu', () => {
         expect($('.fake-menu__items[role=menu]').length).to.equal(0);
     });
 
-    test('renders with grow=true', context => {
-        const input = { grow: true };
+    test('renders with reverse=true', context => {
+        const input = { reverse: true };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('.menu__items--grow').length).to.equal(1);
+        expect($('.menu__items--reverse').length).to.equal(1);
     });
 
-    test('renders with grow=false', context => {
-        const input = { grow: false };
+    test('renders with reverse=false', context => {
+        const input = { reverse: false };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.menu__items').length).to.equal(1);
     });
 
-    test('renders with type=fake, grow=true', context => {
-        const input = { type: 'fake', grow: true };
+    test('renders with type=fake, reverse=true', context => {
+        const input = { type: 'fake', reverse: true };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('.fake-menu__items--grow').length).to.equal(1);
+        expect($('.fake-menu__items--reverse').length).to.equal(1);
     });
 
-    test('renders with type=fake, grow=false', context => {
-        const input = { type: 'fake', grow: false };
+    test('renders with type=fake, reverse=false', context => {
+        const input = { type: 'fake', reverse: false };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.fake-menu__items').length).to.equal(1);
     });
 
-    test('renders with grow-reverse=true', context => {
-        const input = { growReverse: true };
+    test('renders with fix-width=true', context => {
+        const input = { fixWidth: true };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('.menu__items--grow-reverse').length).to.equal(1);
+        expect($('.menu__items--fix-width').length).to.equal(1);
     });
 
-    test('renders with grow-reverse=false', context => {
-        const input = { growReverse: false };
+    test('renders with fix-width=false', context => {
+        const input = { fixWidth: false };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.menu__items').length).to.equal(1);
     });
 
-    test('renders with type=fake, grow-reverse=true', context => {
-        const input = { type: 'fake', growReverse: true };
+    test('renders with type=fake, fix-width=true', context => {
+        const input = { type: 'fake', fixWidth: true };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('.fake-menu__items--grow-reverse').length).to.equal(1);
+        expect($('.fake-menu__items--fix-width').length).to.equal(1);
     });
 
-    test('renders with type=fake, grow-reverse=false', context => {
-        const input = { type: 'fake', growReverse: false };
+    test('renders with type=fake, fix-width=false', context => {
+        const input = { type: 'fake', fixWidth: false };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.fake-menu__items').length).to.equal(1);
     });

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -30,6 +30,7 @@ describe('menu', () => {
         const input = { reverse: false };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.menu__items').length).to.equal(1);
+        expect($('.menu__items.menu__items--reverse').length).to.equal(0);
     });
 
     test('renders with type=fake, reverse=true', context => {
@@ -42,6 +43,7 @@ describe('menu', () => {
         const input = { type: 'fake', reverse: false };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.fake-menu__items').length).to.equal(1);
+        expect($('.fake-menu__items.fake-menu__items--reverse').length).to.equal(0);
     });
 
     test('renders with fix-width=true', context => {
@@ -54,6 +56,7 @@ describe('menu', () => {
         const input = { fixWidth: false };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.menu__items').length).to.equal(1);
+        expect($('.menu__items.menu__items--fix-width').length).to.equal(0);
     });
 
     test('renders with type=fake, fix-width=true', context => {
@@ -66,6 +69,7 @@ describe('menu', () => {
         const input = { type: 'fake', fixWidth: false };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.fake-menu__items').length).to.equal(1);
+        expect($('.fake-menu__items.fake-menu__items--fix-width').length).to.equal(0);
     });
 
     test('handles pass-through html attributes', context => {


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- remove `grow`
- add `fix-width`
- change `grow-reverse` to `reverse`
- update examples, tests, docs

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This matches the latest Skin updates.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
https://github.com/eBay/skin/pull/147

## Screenshots
<!-- Upload screenshots if appropriate-->
<img width="207" alt="screen shot 2018-04-19 at 6 55 46 pm" src="https://user-images.githubusercontent.com/3595986/39026706-52122ebe-4403-11e8-9d52-09a51355db8a.png">
<img width="394" alt="screen shot 2018-04-19 at 6 55 49 pm" src="https://user-images.githubusercontent.com/3595986/39026707-52269e6c-4403-11e8-9637-816cab26bc2e.png">
<img width="282" alt="screen shot 2018-04-19 at 6 55 42 pm" src="https://user-images.githubusercontent.com/3595986/39026708-523be3f8-4403-11e8-96bd-05ca0e61e266.png">

