### PR TITLE
Fix body scrolling on open dialogs for mweb.

### DIFF
--- a/marko-cli.js
+++ b/marko-cli.js
@@ -4,6 +4,7 @@ const isTravis = require('is-travis');
 
 module.exports = markoCli => {
     markoCli.config.browserBuilder = {
+        flags: ['skin-ds6'],
         plugins: [
             'lasso-marko',
             'lasso-less'

--- a/src/common/body-scroll/index.js
+++ b/src/common/body-scroll/index.js
@@ -4,6 +4,15 @@ let previousStyles;
 module.exports = {
     /**
      * Prevents the `<body>` element from scrolling.
+     *
+     * This is done by forcing the body to be `fixed` and setting it's height/width inline.
+     * The body is then translated the reverse of the scroll position using negative margins.
+     *
+     * This approach was chosen over the more common just `overflow:hidden` to address some
+     * issues with iOS and Android browsers.
+     *
+     * Finally the scroll position is also stored so that it can be reapplied after restoring
+     * scrolling.
      */
     prevent() {
         const { body } = document;
@@ -25,6 +34,10 @@ module.exports = {
     },
     /**
      * Restores scrolling of the `<body>` element.
+     *
+     * This will also restore the scroll position, and inline body styles from before the body
+     * scroll was prevented. You should not call this function without first preventing the
+     * body scroll.
      */
     restore() {
         const { body } = document;

--- a/src/common/body-scroll/index.js
+++ b/src/common/body-scroll/index.js
@@ -1,0 +1,40 @@
+let previousPosition;
+let previousStyles;
+
+module.exports = {
+    /**
+     * Prevents the `<body>` element from scrolling.
+     */
+    prevent() {
+        const { body } = document;
+        const { scrollX, scrollY } = window;
+        const { width, height, marginTop, marginLeft } = getComputedStyle(body);
+        let styleText = 'position:fixed;overflow:hidden;';
+        previousPosition = [scrollX, scrollY];
+        previousStyles = body.getAttribute('style');
+        styleText += `height:${width};`;
+        styleText += `width:${height};`;
+        styleText += `margin-top:${-1 * (scrollY - parseInt(marginTop, 10))}px;`;
+        styleText += `margin-left:${-1 * (scrollX - parseInt(marginLeft, 10))}px`;
+
+        if (previousStyles) {
+            styleText = `${previousStyles};${styleText}`;
+        }
+
+        body.setAttribute('style', styleText);
+    },
+    /**
+     * Restores scrolling of the `<body>` element.
+     */
+    restore() {
+        const { body } = document;
+
+        if (previousStyles) {
+            body.setAttribute('style', previousStyles);
+        } else {
+            body.removeAttribute('style');
+        }
+
+        window.scrollTo(...previousPosition);
+    }
+};

--- a/src/common/body-scroll/test/test.browser.js
+++ b/src/common/body-scroll/test/test.browser.js
@@ -1,0 +1,65 @@
+const expect = require('chai').expect;
+const bodyScroll = require('../');
+const { body } = document;
+
+describe('body-scroll', () => {
+    const contentDiv = document.createElement('div');
+    contentDiv.innerHTML += '<br/>'.repeat(1000);
+
+    before(() => {
+        window.scrollTo(0, 0);
+        // Ensure the document can scroll.
+        document.body.appendChild(contentDiv);
+    });
+
+    after(() => {
+        document.body.removeChild(contentDiv);
+    });
+
+    afterEach(() => {
+        window.scrollTo(0, 0);
+    });
+
+    test('applies correct styles when at top of the page', () => {
+        expect(body.getAttribute('style')).to.equal(null);
+        bodyScroll.prevent();
+        expect(body.getAttribute('style'))
+            .to.contain('overflow:hidden')
+            .and.to.contain('position:fixed')
+            .and.to.contain('margin-top:0px')
+            .and.to.contain('margin-left:0px');
+
+        bodyScroll.restore();
+        expect(body.getAttribute('style')).to.equal(null);
+    });
+
+    test('applies correct styles when scrolled', () => {
+        window.scrollTo(0, 10);
+        expect(body.getAttribute('style')).to.equal(null);
+        bodyScroll.prevent();
+        expect(body.getAttribute('style'))
+            .to.contain('overflow:hidden')
+            .and.to.contain('position:fixed')
+            .and.to.contain('margin-top:-10px')
+            .and.to.contain('margin-left:0px');
+
+        bodyScroll.restore();
+        expect(body.getAttribute('style')).to.equal(null);
+    });
+
+    test('preserves existing inline body styles', () => {
+        expect(body.getAttribute('style')).to.equal(null);
+
+        const initialStyleText = 'color:green';
+        body.setAttribute('style', initialStyleText);
+        bodyScroll.prevent();
+        expect(body.getAttribute('style'))
+            .to.contain(initialStyleText)
+            .and.to.contain('overflow:hidden');
+
+        bodyScroll.restore();
+        expect(body.getAttribute('style')).to.equal(initialStyleText);
+
+        body.removeAttribute('style');
+    });
+});

--- a/src/common/transition/index.js
+++ b/src/common/transition/index.js
@@ -31,6 +31,10 @@ module.exports = (el, baseClass, cb) => {
         cancelFrame = undefined;
         if (pending === 0) {
             cancel();
+
+            if (cb) {
+                cb();
+            }
         }
     });
 

--- a/src/components/ebay-dialog/test/test.browser.js
+++ b/src/components/ebay-dialog/test/test.browser.js
@@ -26,7 +26,7 @@ describe('given the dialog is in the default state', () => {
         });
 
         test('then <body> is scrollable', () => {
-            expect(document.body.style.overflow).to.equal('');
+            expect(document.body.getAttribute('style')).to.equal(null);
         });
 
         test('then it\'s siblings are visible', () => {
@@ -44,7 +44,7 @@ describe('given the dialog is in the default state', () => {
 
     describe('when open is set to true on the DOM', () => {
         beforeEach((done) => {
-            widget.once('update', () => setTimeout(done));
+            widget.subscribeTo(root).once('dialog-show', done);
             root.open = true;
         });
 
@@ -53,7 +53,7 @@ describe('given the dialog is in the default state', () => {
 
     describe('when the show method is called on the widget', () => {
         beforeEach((done) => {
-            widget.once('update', () => setTimeout(done));
+            widget.subscribeTo(root).once('dialog-show', done);
             widget.show();
         });
 
@@ -61,10 +61,6 @@ describe('given the dialog is in the default state', () => {
     });
 
     function thenItIsOpen(skipRerender) {
-        test('then the show event is called', (done) => {
-            root.addEventListener('dialog-show', () => done());
-        });
-
         test('then it is visible in the DOM', () => {
             expect(dialog.hidden).to.equal(false);
             expect(dialog.getAttribute('aria-hidden')).to.equal('false');
@@ -75,15 +71,12 @@ describe('given the dialog is in the default state', () => {
         });
 
         test('then <body> is not scrollable', () => {
-            expect(document.body.style.overflow).to.equal('hidden');
+            expect(document.body.getAttribute('style')).to.contain('overflow:hidden;');
         });
 
-        test('then it traps focus', (done) => {
+        test('then it traps focus', () => {
             expect(dialog.classList.contains('keyboard-trap--active')).to.equal(true);
-            root.addEventListener('dialog-show', () => {
-                expect(document.activeElement.className).to.eql(close.className);
-                done();
-            });
+            expect(document.activeElement.className).to.eql(close.className);
         });
 
         if (!skipRerender) {
@@ -129,21 +122,18 @@ describe('given the dialog is in the open state', () => {
         });
 
         test('then <body> is not scrollable', () => {
-            expect(document.body.style.overflow).to.equal('hidden');
+            expect(document.body.getAttribute('style')).to.contain('overflow:hidden;');
         });
 
-        test('then it traps focus', (done) => {
+        test('then it traps focus', () => {
             expect(dialog.classList.contains('keyboard-trap--active')).to.equal(true);
-            root.addEventListener('dialog-show', () => {
-                expect(document.activeElement.className).to.eql(close.className);
-                done();
-            });
+            expect(document.activeElement.className).to.eql(close.className);
         });
     });
 
     describe('when open is set to false on the DOM', () => {
         beforeEach((done) => {
-            widget.once('update', () => setTimeout(done));
+            widget.subscribeTo(root).once('dialog-close', done);
             root.open = false;
         });
 
@@ -152,7 +142,7 @@ describe('given the dialog is in the open state', () => {
 
     describe('when close is called on the widget', () => {
         beforeEach((done) => {
-            widget.once('update', () => setTimeout(done));
+            widget.subscribeTo(root).once('dialog-close', done);
             widget.close();
         });
 
@@ -161,7 +151,7 @@ describe('given the dialog is in the open state', () => {
 
     describe('when the close button is clicked', () => {
         beforeEach((done) => {
-            widget.once('update', () => setTimeout(done));
+            widget.subscribeTo(root).once('dialog-close', done);
             close.click();
         });
 
@@ -170,7 +160,7 @@ describe('given the dialog is in the open state', () => {
 
     describe('when the mask is clicked', () => {
         beforeEach((done) => {
-            widget.once('update', () => setTimeout(done));
+            widget.subscribeTo(root).once('dialog-close', done);
             dialog.click(); // simulate clicking outside the dialog.
         });
 
@@ -178,16 +168,12 @@ describe('given the dialog is in the open state', () => {
     });
 
     function thenItIsClosed(skipRerender) {
-        test('then the close event is called', (done) => {
-            root.addEventListener('dialog-close', () => done());
-        });
-
         test('then it is hidden in the DOM', () => {
             expect(dialog.hidden).to.equal(true);
         });
 
         test('then <body> is scrollable', () => {
-            expect(document.body.style.overflow).to.equal('');
+            expect(document.body.getAttribute('style')).to.equal(null);
         });
 
         test('then it\'s siblings are visible', () => {


### PR DESCRIPTION
## Description
This changes the way scrolling is prevented on the `ebay-dialog` is open.
Previously `overflow:hidden` was set on the body which was not respected in mweb.
Now `position:fixed` is used and the scroll position is accounted for by using negative margins.

I extracted the `body scrolling` functionality into the common js just because it was getting slightly unruly in the component itself.

## References
Closes #107 