### PR TITLE
Select: fix pass-through on nested options

### DIFF
--- a/src/components/ebay-select/index.js
+++ b/src/components/ebay-select/index.js
@@ -15,11 +15,10 @@ const comboboxOptionSelector = '.combobox__option[role=option]';
 
 function getInitialState(input) {
     const options = (input.options || []).map(option => {
-        const classes = [option.class];
         const selected = option.selected;
 
         return {
-            classes,
+            class: option.class,
             value: option.value,
             label: option.label,
             selected: Boolean(selected),

--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -25,8 +25,9 @@
         <div
             for(option in data.options)
             role='option'
-            class=['combobox__option', option.class]
+            class=['combobox__option', option.classes]
             tabindex="-1"
+            ${option.htmlAttributes}
             w-on-click='handleOptionClick'
             w-preserve-attrs="tabindex,data-makeup-index"
             aria-selected=String(option.selected)

--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -25,7 +25,7 @@
         <div
             for(option in data.options)
             role='option'
-            class=['combobox__option', option.classes]
+            class=['combobox__option', option.class]
             tabindex="-1"
             ${option.htmlAttributes}
             w-on-click='handleOptionClick'

--- a/src/components/ebay-select/test/test.server.js
+++ b/src/components/ebay-select/test/test.server.js
@@ -9,33 +9,53 @@ const options = [{
 }];
 const emptyOptions = [];
 
-test('renders basic version', context => {
-    const input = { options };
-    const $ = testUtils.getCheerio(context.render(input));
-    expect($('.combobox').length).to.equal(1);
-    expect($('.combobox__control').length).to.equal(1);
-    expect($('.combobox__options[role=listbox]').length).to.equal(1);
-    expect($('.combobox__option[role=option]').length).to.equal(2);
-    expect($('.combobox__option[role=option][aria-selected="true"]').length).to.equal(1);
+describe('select', () => {
+    test('renders basic version', context => {
+        const input = { options };
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($('.combobox').length).to.equal(1);
+        expect($('.combobox__control').length).to.equal(1);
+        expect($('.combobox__options[role=listbox]').length).to.equal(1);
+        expect($('.combobox__option[role=option]').length).to.equal(2);
+        expect($('.combobox__option[role=option][aria-selected="true"]').length).to.equal(1);
+    });
+
+    test('renders empty', context => {
+        const input = { emptyOptions };
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($('.combobox').length).to.equal(1);
+        expect($('.combobox__control').length).to.equal(1);
+        expect($('.combobox__options[role=listbox]').length).to.equal(0);
+        expect($('.combobox__option[role=option]').length).to.equal(0);
+    });
+
+    test('renders with second item selected', context => {
+        const input = { options };
+        input.options[0].selected = false;
+        input.options[1].selected = true;
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($('.combobox').length).to.equal(1);
+        expect($('.combobox__control').length).to.equal(1);
+        expect($('.combobox__options[role=listbox]').length).to.equal(1);
+        expect($('.combobox__option[role=option]').length).to.equal(2);
+        expect($('.combobox__option[role=option][aria-selected="true"]:nth-child(2)').length).to.equal(1);
+    });
+
+    test('handles pass-through html attributes', context => {
+        testUtils.testHtmlAttributes(context, 'span.combobox');
+    });
+
+    test('handles custom class', context => {
+        testUtils.testCustomClass(context, 'span.combobox');
+    });
 });
 
-test('renders empty', context => {
-    const input = { emptyOptions };
-    const $ = testUtils.getCheerio(context.render(input));
-    expect($('.combobox').length).to.equal(1);
-    expect($('.combobox__control').length).to.equal(1);
-    expect($('.combobox__options[role=listbox]').length).to.equal(0);
-    expect($('.combobox__option[role=option]').length).to.equal(0);
-});
+describe('select-option', () => {
+    test('handles pass-through html attributes', context => {
+        testUtils.testHtmlAttributes(context, '.combobox__option', 'options');
+    });
 
-test('renders with second item selected', context => {
-    const input = { options };
-    input.options[0].selected = false;
-    input.options[1].selected = true;
-    const $ = testUtils.getCheerio(context.render(input));
-    expect($('.combobox').length).to.equal(1);
-    expect($('.combobox__control').length).to.equal(1);
-    expect($('.combobox__options[role=listbox]').length).to.equal(1);
-    expect($('.combobox__option[role=option]').length).to.equal(2);
-    expect($('.combobox__option[role=option][aria-selected="true"]:nth-child(2)').length).to.equal(1);
+    test('handles custom class', context => {
+        testUtils.testCustomClass(context, '.combobox__option', 'options');
+    });
 });


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
For `ebay-select-option`:
- fix custom class 
- pass through `htmlAttributes`
- add tests (diff is only big because I added new `describe()`s)

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Looks like these were basically typos from earlier. The tests should help keep this working.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
Fixes https://github.com/eBay/ebayui-core/issues/114

