### PR TITLE
Breadcrumb: add hijax

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -90,8 +90,10 @@
     "<ebay-breadcrumb>": {
         "renderer": "./src/components/ebay-breadcrumb/index.js",
         "transformer": "./src/common/transformer/index.js",
+        "@class": "string",
         "@heading-text": "string",
         "@heading-level": "string",
+        "@hijax": "boolean",
         "@*": "expression",
         "@items <item>[]": {
             "@href": "string",

--- a/src/common/event-utils/index.js
+++ b/src/common/event-utils/index.js
@@ -24,6 +24,12 @@ function handleUpDownArrowsKeydown(e, callback) {
     handleKeydown([38, 40], e, callback);
 }
 
+function preventDefaultIfHijax(e, hijax) {
+    if (hijax) {
+        e.preventDefault();
+    }
+}
+
 const handlers = [];
 function addEventListener(_, handler) {
     if (handlers.length === 0) {
@@ -51,6 +57,7 @@ module.exports = {
     handleActionKeydown,
     handleEscapeKeydown,
     handleUpDownArrowsKeydown,
+    preventDefaultIfHijax,
     resizeUtil: {
         addEventListener,
         removeEventListener

--- a/src/common/event-utils/test/test.browser.js
+++ b/src/common/event-utils/test/test.browser.js
@@ -7,6 +7,7 @@ const testUtils = require('../../test-utils/browser');
 const handleActionKeydown = eventUtils.handleActionKeydown;
 const handleEscapeKeydown = eventUtils.handleEscapeKeydown;
 const handleUpDownArrowsKeydown = eventUtils.handleUpDownArrowsKeydown;
+const preventDefaultIfHijax = eventUtils.preventDefaultIfHijax;
 
 describe('handleActionKeydown()', () => {
     [
@@ -52,6 +53,25 @@ describe('handleUpDownArrowsKeydown()', () => {
         const callback = sinon.spy();
         handleUpDownArrowsKeydown({ keyCode: 1 }, callback);
         expect(callback.called).to.equal(false);
+    });
+});
+
+describe('preventDefaultIfHijax()', () => {
+    let preventDefaultSpy;
+    beforeEach(() => {
+        preventDefaultSpy = sinon.spy();
+    });
+
+    test('executes preventDefault if hijax', () => {
+        const e = { preventDefault: preventDefaultSpy };
+        preventDefaultIfHijax(e, true);
+        expect(preventDefaultSpy.calledOnce).to.equal(true);
+    });
+
+    test('does not execute preventDefault if not hijax', () => {
+        const e = { preventDefault: preventDefaultSpy };
+        preventDefaultIfHijax(e, false);
+        expect(preventDefaultSpy.called).to.equal(false);
     });
 });
 

--- a/src/components/ebay-breadcrumb/README.md
+++ b/src/components/ebay-breadcrumb/README.md
@@ -13,8 +13,10 @@
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
+`class` | String | No | custom class
 `heading-text` | String | No | heading for breadcrumb which will be clipped
 `heading-level` | String | No | heading level(h1-h4) for breadcrumb and default is `h2`
+`hijax` | Boolean | No | Prevent link navigation; for use with ajax
 
 ## ebay-breadcrumb Events
 

--- a/src/components/ebay-breadcrumb/examples/5-hijax/template.marko
+++ b/src/components/ebay-breadcrumb/examples/5-hijax/template.marko
@@ -1,0 +1,11 @@
+<ebay-breadcrumb hijax class="breadcrumb--hijax">
+    <ebay-breadcrumb-item href="http://www.ebay.com/">eBay</ebay-breadcrumb-item>
+    <ebay-breadcrumb-item href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches & Accessories</ebay-breadcrumb-item>
+    <ebay-breadcrumb-item href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</ebay-breadcrumb-item>
+    <ebay-breadcrumb-item href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906">Smart Watch Bands</ebay-breadcrumb-item>
+</ebay-breadcrumb>
+
+<script>(function() {
+    var breadcrumb = document.querySelector(".breadcrumb--hijax");
+    breadcrumb.addEventListener("breadcrumb-select", e => console.log(e.detail));
+})()</script>

--- a/src/components/ebay-breadcrumb/index.js
+++ b/src/components/ebay-breadcrumb/index.js
@@ -1,23 +1,29 @@
 const markoWidgets = require('marko-widgets');
 const emitAndFire = require('../../common/emit-and-fire');
 const processHtmlAttributes = require('../../common/html-attributes');
+const eventUtils = require('../../common/event-utils');
 const template = require('./template.marko');
 
 function getTemplateData(state, input) {
-    const htmlAttributes = processHtmlAttributes(input);
     const inputItems = input.items || [];
+    const hijax = input.hijax || false;
     let items = (inputItems).map((item, index) => {
         const itemHtmlAttributes = processHtmlAttributes(item);
         let tag = 'a';
         let ariaCurrent = null;
+        let role;
         const href = item.href || null;
         const current = ((inputItems.length - 1) === index);
         if (current && !href) {
             tag = 'span';
             ariaCurrent = 'page';
         }
+        if (hijax) {
+            role = 'button';
+        }
         return {
             tag,
+            role,
             htmlAttributes: itemHtmlAttributes,
             renderBody: item.renderBody,
             href,
@@ -27,17 +33,26 @@ function getTemplateData(state, input) {
     items = Object.keys(items).length > 0 ? items : null;
     return {
         items,
+        hijax,
+        classes: ['breadcrumb', input.class],
         headingText: input.headingText || '',
         headingLevel: input.headingLevel || 'h2',
-        htmlAttributes
+        htmlAttributes: processHtmlAttributes(input)
     };
 }
+
+function getInitialState({ hijax }) {
+    return { hijax };
+}
+
 function handleClick(event) {
+    eventUtils.preventDefaultIfHijax(event, this.state.hijax);
     emitAndFire(this, 'breadcrumb-select', { el: event.target });
 }
 
 module.exports = markoWidgets.defineComponent({
     template,
     getTemplateData,
+    getInitialState,
     handleClick
 });

--- a/src/components/ebay-breadcrumb/mock/index.js
+++ b/src/components/ebay-breadcrumb/mock/index.js
@@ -27,6 +27,10 @@ module.exports = {
         items: basicItems,
         '*': { dataview: 'data-view tracking' }
     },
+    hijax: {
+        hijax: true,
+        items: basicItems
+    },
     itemsWithMissingLinks: {
         headingText: 'Page navigation',
         items: itemsWithMissingLinks,

--- a/src/components/ebay-breadcrumb/template.marko
+++ b/src/components/ebay-breadcrumb/template.marko
@@ -1,12 +1,8 @@
-<if(data.items)>
-    <nav aria-labelledby="breadcrumb-heading" class="breadcrumb" role="navigation" ${data.htmlAttributes} w-bind w-onclick="handleClick">
-        <${data.headingLevel} id="breadcrumb-heading" class="clipped">${data.headingText}</${data.headingLevel}>
-        <ul>
-            <for(item in data.items)>
-                <li>
-                    <${item.tag} href=item.href aria-current=item.ariaCurrent ${item.htmlAttributes} w-body=item.renderBody/>
-                </li>
-            </for>
-        </ul>
-    </nav>
-</if>
+<nav if(data.items) aria-labelledby="breadcrumb-heading" class=data.classes role="navigation" ${data.htmlAttributes} w-bind w-onclick="handleClick">
+    <${data.headingLevel} id="breadcrumb-heading" class="clipped">${data.headingText}</${data.headingLevel}>
+    <ul>
+        <li for(item in data.items)>
+            <${item.tag} href=item.href aria-current=item.ariaCurrent role=item.role ${item.htmlAttributes} w-body=item.renderBody/>
+        </li>
+    </ul>
+</nav>

--- a/src/components/ebay-breadcrumb/test/test.server.js
+++ b/src/components/ebay-breadcrumb/test/test.server.js
@@ -1,6 +1,6 @@
 const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/server');
-const mock = require('../mock/index');
+const mock = require('../mock');
 
 describe('should render with basic breadcrumb and ', () => {
     test('return nav element with input', context => {
@@ -36,6 +36,11 @@ describe('should render with basic breadcrumb and ', () => {
     });
 });
 
+test('should set item roles for hijax version', context => {
+    const input = mock.hijax;
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($('li a[role="button"]').length).to.equal(input.items.length);
+});
 test('should return zero nav element in the page', context => {
     const input = {};
     const $ = testUtils.getCheerio(context.render(input));

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -24,7 +24,7 @@ Name | Type | Stateful | Description
 `accessibility-prev` | String | No | aria-label for previous arrow button
 `accessibility-next` | String | No | aria-label for next arrow button
 `accessibility-current` | String | No | Description for the current page (e.g. Results of Page 1)
-`hijax` | Boolean | No | Use pagination links for an ajax reload
+`hijax` | Boolean | No | Prevent link navigation; for use with ajax
 
 ### ebay-pagination Events
 

--- a/src/components/ebay-pagination/examples/2-hijax/template.marko
+++ b/src/components/ebay-pagination/examples/2-hijax/template.marko
@@ -1,4 +1,4 @@
-<ebay-pagination hijax>
+<ebay-pagination hijax class="pagination--hijax">
     <ebay-pagination-item href="#" type="previous" disabled></ebay-pagination-item>
     <ebay-pagination-item href="#" current>1</ebay-pagination-item>
     <ebay-pagination-item href="#">2</ebay-pagination-item>
@@ -11,3 +11,8 @@
     <ebay-pagination-item href="#">9</ebay-pagination-item>
     <ebay-pagination-item href="#" type="next"></ebay-pagination-item>
 </ebay-pagination>
+
+<script>(function() {
+    var pagination = document.querySelector(".pagination--hijax");
+    pagination.addEventListener("pagination-select", e => console.log(e.detail));
+})()</script>

--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -15,10 +15,10 @@ function getInitialState(input) {
     let nextItem;
     const items = [];
     const inputItems = input.items || [];
-    const isHijax = input.hijax || false;
+    const hijax = input.hijax || false;
     let role;
 
-    if (isHijax) {
+    if (hijax) {
         role = 'button';
     }
 
@@ -51,7 +51,7 @@ function getInitialState(input) {
     }
 
     return {
-        isHijax,
+        hijax,
         nextItem: nextItem || { class: 'pagination__next', disabled: true },
         prevItem: prevItem || { class: 'pagination__previous', disabled: true },
         items,
@@ -96,28 +96,22 @@ function refresh() {
     }
 }
 
-function handleHijax(e) {
-    if (this.state.isHijax) {
-        e.preventDefault();
-    }
-}
-
 /**
  * Handle normal mouse click for item, next page and previous page respectively.
  * @param {MouseEvent} event
  */
 function handlePageClick(event) {
-    this.handleHijax(event);
+    eventUtils.preventDefaultIfHijax(event, this.state.hijax);
     emitAndFire(this, 'pagination-select', { el: event.target, value: event.target.innerText });
 }
 
 function handleNextPage(event) {
-    this.handleHijax(event);
+    eventUtils.preventDefaultIfHijax(event, this.state.hijax);
     emitAndFire(this, 'pagination-next', { el: event.target });
 }
 
 function handlePreviousPage(event) {
-    this.handleHijax(event);
+    eventUtils.preventDefaultIfHijax(event, this.state.hijax);
     emitAndFire(this, 'pagination-previous', { el: event.target });
 }
 
@@ -147,7 +141,6 @@ module.exports = require('marko-widgets').defineComponent({
     template,
     init,
     refresh,
-    handleHijax,
     handlePageClick,
     handleNextPage,
     handlePreviousPage,

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -107,17 +107,4 @@ describe('given the menu is in the default state with links', () => {
             expect(eventData.value).to.be.equal('1');
         });
     });
-    describe('when an action button is activated for a hijax pagination', () => {
-        let spy;
-        beforeEach(() => {
-            spy = sinon.spy(widget, 'handleHijax');
-            testUtils.triggerEvent(previousButton, 'click');
-        });
-
-        afterEach(() => widget.handleHijax.restore());
-
-        test('then handleHijax method is called', () => {
-            expect(spy.calledOnce).to.equal(true);
-        });
-    });
 });


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- add `hijax` functionality to breadcrumb component
- create `preventDefaultIfHijax` util
- standardize usage across breadcrumb and pagination
- improve hijax examples
- minor related cleanup
- update tests and docs

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Standardizing `hijax` usage for similar cases in the two components.

Note: `breadcrumb-select` currently fires even on `span` elements, which is unchanged in the `hijax` case. This may need fixing/refactoring, but I avoided changing that behavior as part of this PR.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
#112 
