### PR TITLE
Transition utility fixes.

### DIFF
--- a/src/common/transition/test/test.browser.js
+++ b/src/common/transition/test/test.browser.js
@@ -38,7 +38,7 @@ describe('transition', () => {
     });
 
     it('applies classes in correct order', (done) => {
-        transition(transitionEl, 'show');
+        transition({ el: transitionEl, className: 'show', waitFor: [transitionEl] });
         transitionEl.removeAttribute('hidden');
         expect(transitionEl.classList.contains('show-init')).to.equal(true);
 
@@ -56,7 +56,7 @@ describe('transition', () => {
 
     it('triggers a callback once complete', (done) => {
         const spy = sinon.spy();
-        transition(transitionEl, 'show', spy);
+        transition({ el: transitionEl, className: 'show', waitFor: [transitionEl] }, spy);
         transitionEl.removeAttribute('hidden');
         transitionEl.addEventListener('transitionend', spy);
         setTimeout(() => {

--- a/src/components/ebay-dialog/index.js
+++ b/src/components/ebay-dialog/index.js
@@ -10,8 +10,10 @@ const template = require('./template.marko');
 
 function init() {
     this.dialogEl = this.getEl('dialog');
+    this.windowEl = this.getEl('window');
     this.closeEl = this.getEl('close');
     this.bodyEl = this.getEl('body');
+    this.transitionEls = [this.windowEl, this.dialogEl];
     observer.observeRoot(this, ['open']);
     // Add an event listener to the dialog to fix an issue with Safari not recognizing it as a touch target.
     this.subscribeTo(this.dialogEl).on('click', () => {});
@@ -104,13 +106,21 @@ function trap(opts) {
 
         if (isTrapped) {
             if (!isFirstRender) {
-                this.cancelTransition = transition(this.dialogEl, 'dialog--show', onFinishTransition);
+                this.cancelTransition = transition({
+                    el: this.dialogEl,
+                    className: 'dialog--show',
+                    waitFor: this.transitionEls
+                }, onFinishTransition);
             }
 
             this.dialogEl.removeAttribute('hidden');
         } else {
             if (!isFirstRender) {
-                this.cancelTransition = transition(this.dialogEl, 'dialog--hide', onFinishTransition);
+                this.cancelTransition = transition({
+                    el: this.dialogEl,
+                    className: 'dialog--hide',
+                    waitFor: this.transitionEls
+                }, onFinishTransition);
             }
 
             this.dialogEl.setAttribute('hidden', '');

--- a/src/components/ebay-dialog/template.marko
+++ b/src/components/ebay-dialog/template.marko
@@ -1,7 +1,7 @@
 
 <div class="dialog-placeholder" w-bind>
     <div w-id="dialog" class=data.dialogClass hidden=!data.open role="dialog" w-preserve-attrs="hidden" ${data.htmlAttributes} w-onclick="close">
-        <div class=data.windowClass role="document">
+        <div w-id="window" class=data.windowClass role="document">
             <button class="dialog__close" type="button" aria-label=data.ariaLabelClose w-id="close">
                 <svg aria-hidden="true" focusable="false" height="17" width="17">
                     <path


### PR DESCRIPTION
## Description
Currently the transition utility tries to figure out how many transitions it should wait for before marking the animation as completed. In this PR the options for the transition utility are changed and it now requires passing in a list of elements to wait for their transitions to end.

## References
#127