### PR TITLE
Upgraded to makeup-expander v0.4.0 (fixes #92)

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
-    "makeup-expander": "^0.3.2",
+    "makeup-expander": "~0.4.0",
     "makeup-focusables": "~0.0.3",
     "makeup-key-emitter": "~0.0.3",
     "makeup-keyboard-trap": "^0.0.9",

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -156,7 +156,7 @@ function init() {
     const expander = new Expander(this.el, { // eslint-disable-line no-unused-vars
         hostSelector: buttonSelector,
         focusManagement: 'focusable',
-        click: true,
+        expandOnClick: true,
         autoCollapse: true
     });
 }
@@ -257,7 +257,8 @@ function handleItemKeydown(e) {
     });
 
     eventUtils.handleEscapeKeydown(e, () => {
-        this.buttonEl.focus(); // triggers collapse through makeup
+        this.buttonEl.focus();
+        this.setState('expanded', false);
     });
 }
 

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -168,10 +168,11 @@ describe('given the menu is in the expanded state', () => {
 
     describe('when the escape key is pressed', () => {
         let spy;
-        beforeEach(() => {
+        beforeEach((done) => {
             spy = sinon.spy();
             widget.on('menu-collapse', spy);
             testUtils.triggerEvent(firstItem, 'keydown', 27);
+            setTimeout(done);
         });
 
         test('then it collapses', () => {

--- a/src/components/ebay-select/index.js
+++ b/src/components/ebay-select/index.js
@@ -66,11 +66,11 @@ function init() {
     if (this.state.options && this.state.options.length > 0) {
         this.expander = new Expander(this.el, {
             autoCollapse: true,
-            click: true,
+            expandOnClick: true,
             contentSelector: `.${comboboxOptionsClass}`,
             hostSelector: comboboxHostSelector,
             hostContainerClass: `${comboboxBtnClass}`,
-            spacebar: true
+            simulateSpacebarClick: true
         });
 
         observer.observeRoot(this, ['selected'], (index) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,9 +5498,9 @@ makeup-exit-emitter@~0.0, makeup-exit-emitter@~0.0.4:
     custom-event-polyfill "~0.3"
     makeup-next-id "~0.0"
 
-makeup-expander@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.3.2.tgz#bb5223ad26dbfeedbf7dc7ea3a21e1d19b58632b"
+makeup-expander@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.4.0.tgz#8f810be697dc1c2dc279a43e442b74f7cf414292"
   dependencies:
     custom-event-polyfill "~0.3"
     makeup-exit-emitter "~0.0.4"


### PR DESCRIPTION
## Description

Upgraded to makeup-expander v0.4.0.

The latest version of makeup-expander has some refinements based around autoCollapse. These refinements separate the keyboard and mouse collapse behaviour.

In short:

* menu will no longer collapse when moving mouse out of the menu overlay
* menu will now collapse when clicking outside of menu overlay
* menu will continue to collapse when keyboard focus leaves widget
* menu will continue to collapse when ESC key is pressed on a menu item

Fixes #92.

## References

https://github.com/makeup-js/makeup-expander/commit/3be210249f23bab7f6103993f127b6c81b2557d1
