### PR TITLE
Fixes for documentation and type of attribute in marko.json

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -111,7 +111,7 @@
         "@items <item>[]": {
             "@class": "string",
             "@current": "boolean",
-            "@disabled": "string",
+            "@disabled": "boolean",
             "@href": "string",
             "@type": "string",
             "@role": "string",

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -8,11 +8,11 @@ The `<ebay-pagination>` is a tag used to create a pagination navigation.
 
 ```marko
 <ebay-pagination aria-label-prev="Previous page" aria-label-next="Next page" curr-text="Results Pagination - Page 2">
-    <ebay-pagination-item href="#" previous disabled/>
+    <ebay-pagination-item href="#" type="previous" disabled/>
     <ebay-pagination-item href="#">item 1</ebay-pagination-item>
     <ebay-pagination-item href="#" current>item 2</ebay-pagination-item>
     <ebay-pagination-item href="#">item 3</ebay-pagination-item>
-    <ebay-pagination-item href="#" next/>
+    <ebay-pagination-item href="#" type="next"/>
 </ebay-pagination>
 ```
 


### PR DESCRIPTION

## Description
Correcting a couple of misses in the main PR

## Context
Have corrected the explanation of the use of pagination component that was missed when I changed the `next|previous` values to `type=next|previous`.
