### PR TITLE
Button: pass originalEvent

### DIFF
--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -20,6 +20,6 @@ Name | Type | Stateful | Description
 
 ## ebay-button Events
 
-Event | Description
---- | ---
-`button-click` | click
+Event | Data | Description
+--- | --- | ---
+`button-click` | `{ originalEvent }` | click

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -53,9 +53,9 @@ function getTemplateData(state, input) {
     return model;
 }
 
-function handleClick() {
+function handleClick(originalEvent) {
     if (!this.state.disabled) {
-        emitAndFire(this, 'button-click');
+        emitAndFire(this, 'button-click', { originalEvent });
     }
 }
 

--- a/src/components/ebay-button/test/test.browser.js
+++ b/src/components/ebay-button/test/test.browser.js
@@ -27,8 +27,10 @@ describe('given button is enabled', () => {
             testUtils.triggerEvent(root, 'click');
         });
 
-        test('then it emits the event', () => {
+        test('then it emits the event with correct data', () => {
             expect(spy.calledOnce).to.equal(true);
+            const originalEvent = spy.getCall(0).args[0].originalEvent;
+            expect(originalEvent instanceof Event).to.equal(true);
         });
     });
 });


### PR DESCRIPTION
## Description
- update `button-click` to send `originalEvent`
- update docs and tests

## Context
Fixes the button case to unblock teams, but we'll need to apply this to the other components too.

## References
https://github.com/eBay/ebayui-core/issues/126
