### PR TITLE
Carousel: fix initial client render in v4

### DIFF
--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -85,6 +85,7 @@ function init() {
 
     this.subscribeTo(resizeUtil).on('resize', refresh.bind(this));
     this.refresh();
+    this.refresh(); // FIXME: currently needs a second call in v4
 }
 
 function refresh() {


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- add extra `this.refresh()` in `init()`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
The carousel does an initial call to `this.refresh()` to do sizing calculations and set up initial state based on client rendering. Everything works fine in v3, but for some reason, the top `this.refresh()` call does not work correctly in v4. I started out fixing this by doing `setTimeout(refresh.bind(this))`, but that causes lots of problems in the tests, which I didn't make much progress on. I noticed that a second call magically fixes everything, and all the tests are still fine.

@DylanPiercey I'm guessing this is related to Marko internals, especially with it working fine in v3.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
Fixes #142 
Fixes #143 
