### PR TITLE
Added a check to return the correct target

### DIFF
--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -119,7 +119,7 @@ function handlePreviousPage(event) {
  * gets the correct target for pagination arrow button
  */
 function getCorrectElement(event) {
-    if (event.target.nodeName === 'SPAN') {
+    if (event.target.nodeName.toUpperCase() === 'SPAN') {
         return event.target.parentNode;
     }
     return event.target;

--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -107,12 +107,22 @@ function handlePageClick(event) {
 
 function handleNextPage(event) {
     eventUtils.preventDefaultIfHijax(event, this.state.hijax);
-    emitAndFire(this, 'pagination-next', { el: event.target });
+    emitAndFire(this, 'pagination-next', { el: getCorrectElement(event) });
 }
 
 function handlePreviousPage(event) {
     eventUtils.preventDefaultIfHijax(event, this.state.hijax);
-    emitAndFire(this, 'pagination-previous', { el: event.target });
+    emitAndFire(this, 'pagination-previous', { el: getCorrectElement(event) });
+}
+
+/**
+ * gets the correct target for pagination arrow button
+ */
+function getCorrectElement(event) {
+    if (event.target.nodeName === 'SPAN') {
+        return event.target.parentNode;
+    }
+    return event.target;
 }
 
 /**
@@ -144,6 +154,7 @@ module.exports = require('marko-widgets').defineComponent({
     handlePageClick,
     handleNextPage,
     handlePreviousPage,
+    getCorrectElement,
     handlePageKeyDown,
     handleNextPageKeyDown,
     handlePreviousPageKeyDown,

--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -71,6 +71,8 @@ function init() {
     this.pageContainerEl = this.el.querySelector('.pagination__items');
     this.pageEls = this.pageContainerEl.children;
     this.containerEl = this.el;
+    this.previousPageEl = this.el.querySelector('.pagination__previous');
+    this.nextPageEl = this.el.querySelector('.pagination__next');
     this.subscribeTo(eventUtils.resizeUtil).on('resize', refresh.bind(this));
     this.refresh();
 }
@@ -107,22 +109,12 @@ function handlePageClick(event) {
 
 function handleNextPage(event) {
     eventUtils.preventDefaultIfHijax(event, this.state.hijax);
-    emitAndFire(this, 'pagination-next', { el: getCorrectElement(event) });
+    emitAndFire(this, 'pagination-next', { el: this.nextPageEl });
 }
 
 function handlePreviousPage(event) {
     eventUtils.preventDefaultIfHijax(event, this.state.hijax);
-    emitAndFire(this, 'pagination-previous', { el: getCorrectElement(event) });
-}
-
-/**
- * gets the correct target for pagination arrow button
- */
-function getCorrectElement(event) {
-    if (event.target.nodeName.toUpperCase() === 'SPAN') {
-        return event.target.parentNode;
-    }
-    return event.target;
+    emitAndFire(this, 'pagination-previous', { el: this.previousPageEl });
 }
 
 /**
@@ -154,7 +146,6 @@ module.exports = require('marko-widgets').defineComponent({
     handlePageClick,
     handleNextPage,
     handlePreviousPage,
-    getCorrectElement,
     handlePageKeyDown,
     handleNextPageKeyDown,
     handlePreviousPageKeyDown,

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -8,8 +8,10 @@ describe('given the menu is in the default state with links', () => {
     let widget;
     let root;
     let previousButton;
+    let previousButtonInner;
     let pageItem;
     let nextButton;
+    let nextButtonInner;
 
     beforeEach(() => {
         widget = renderer.renderSync(mock.hijax).appendTo(document.body).getWidget();
@@ -17,6 +19,8 @@ describe('given the menu is in the default state with links', () => {
         previousButton = root.querySelector('.pagination__previous');
         nextButton = root.querySelector('.pagination__next');
         pageItem = root.querySelector('.pagination__item');
+        nextButtonInner = nextButton.querySelector('span');
+        previousButtonInner = previousButton.querySelector('span');
     });
     afterEach(() => widget.destroy());
 
@@ -34,6 +38,21 @@ describe('given the menu is in the default state with links', () => {
         });
     });
 
+    describe('when an previous button\'s inner span is clicked', () => {
+        let spy;
+        beforeEach((done) => {
+            spy = sinon.spy();
+            widget.on('pagination-previous', spy);
+            testUtils.triggerEvent(previousButtonInner, 'click');
+            setTimeout(done);
+        });
+
+        test('then it emits the pagination-previous event with correct data', () => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+        });
+    });
+
     describe('when the next button is clicked', () => {
         let spy;
         beforeEach(() => {
@@ -43,6 +62,21 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the marko event called pagination-next', () => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+        });
+    });
+
+    describe('when an next button\'s inner span is clicked', () => {
+        let spy;
+        beforeEach((done) => {
+            spy = sinon.spy();
+            widget.on('pagination-next', spy);
+            testUtils.triggerEvent(nextButtonInner, 'click');
+            setTimeout(done);
+        });
+
+        test('then it emits the pagination-next event with correct data', () => {
             expect(spy.calledOnce).to.equal(true);
             expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
         });


### PR DESCRIPTION
## Description
The changes here fix the issue where if a mouse click is registered at the center of the pagination arrow the returned target is an empty `span` as the content of the pagination arrows is in a child `span` inside the actual `a` that has all the `data-*`

## Context
For all the pagination arrow clicks added a check for the `span` tag, if it was indeed a `span` it returns the `parentNode` else it returns the current target. 

## References
Fixes #146 

