### PR TITLE
Misc dialog fixes.

### DIFF
--- a/src/common/body-scroll/index.js
+++ b/src/common/body-scroll/index.js
@@ -1,5 +1,6 @@
 let previousPosition;
 let previousStyles;
+let isPrevented = false;
 
 module.exports = {
     /**
@@ -21,16 +22,23 @@ module.exports = {
         let styleText = 'position:fixed;overflow:hidden;';
         previousPosition = [scrollX, scrollY];
         previousStyles = body.getAttribute('style');
-        styleText += `height:${width};`;
-        styleText += `width:${height};`;
-        styleText += `margin-top:${-1 * (scrollY - parseInt(marginTop, 10))}px;`;
-        styleText += `margin-left:${-1 * (scrollX - parseInt(marginLeft, 10))}px`;
+        styleText += `height:${height};`;
+        styleText += `width:${width};`;
+
+        if (scrollY) {
+            styleText += `margin-top:${-1 * (scrollY - parseInt(marginTop, 10))}px;`;
+        }
+
+        if (scrollX) {
+            styleText += `margin-left:${-1 * (scrollX - parseInt(marginLeft, 10))}px`;
+        }
 
         if (previousStyles) {
             styleText = `${previousStyles};${styleText}`;
         }
 
         body.setAttribute('style', styleText);
+        isPrevented = true;
     },
     /**
      * Restores scrolling of the `<body>` element.
@@ -40,14 +48,16 @@ module.exports = {
      * body scroll.
      */
     restore() {
-        const { body } = document;
+        if (isPrevented) {
+            const { body } = document;
+            if (previousStyles) {
+                body.setAttribute('style', previousStyles);
+            } else {
+                body.removeAttribute('style');
+            }
 
-        if (previousStyles) {
-            body.setAttribute('style', previousStyles);
-        } else {
-            body.removeAttribute('style');
+            window.scrollTo(...previousPosition);
+            isPrevented = false;
         }
-
-        window.scrollTo(...previousPosition);
     }
 };

--- a/src/common/body-scroll/test/test.browser.js
+++ b/src/common/body-scroll/test/test.browser.js
@@ -26,8 +26,8 @@ describe('body-scroll', () => {
         expect(body.getAttribute('style'))
             .to.contain('overflow:hidden')
             .and.to.contain('position:fixed')
-            .and.to.contain('margin-top:0px')
-            .and.to.contain('margin-left:0px');
+            .and.to.not.contain('margin-top')
+            .and.to.not.contain('margin-left');
 
         bodyScroll.restore();
         expect(body.getAttribute('style')).to.equal(null);
@@ -41,7 +41,7 @@ describe('body-scroll', () => {
             .to.contain('overflow:hidden')
             .and.to.contain('position:fixed')
             .and.to.contain('margin-top:-10px')
-            .and.to.contain('margin-left:0px');
+            .and.to.not.contain('margin-left');
 
         bodyScroll.restore();
         expect(body.getAttribute('style')).to.equal(null);

--- a/src/components/ebay-dialog/index.js
+++ b/src/components/ebay-dialog/index.js
@@ -92,11 +92,14 @@ function trap(opts) {
 
             if (isTrapped) {
                 focusEl.focus();
-                bodyScroll.prevent();
                 emitAndFire(this, 'dialog-show');
             } else {
                 bodyScroll.restore();
                 emitAndFire(this, 'dialog-close');
+
+                // Reset dialog scroll position lazily to avoid jank.
+                // Note since the dialog is not in the dom at this point none of the scroll methods will work.
+                setTimeout(() => this.el.replaceChild(this.dialogEl, this.dialogEl), 20);
             }
         };
 
@@ -106,6 +109,7 @@ function trap(opts) {
 
         if (isTrapped) {
             if (!isFirstRender) {
+                bodyScroll.prevent();
                 this.cancelTransition = transition({
                     el: this.dialogEl,
                     className: 'dialog--show',


### PR DESCRIPTION
## Description
The primary enhancement in this PR is that a dialog's scroll position is reset once it is closed.
This behavior was inconsistent between dweb and mweb (related: #113).

Additionally this PR contains the following small changes/fixes:
* Fix preventing body scroll multiple times.
* Fix typo in body sizing after preventing scrolling (previously height/width were backwards and caused issues).
* Only set margin-top/left if needed when preventing body scroll.

## References
Fixes #113 