### PR TITLE
Support dynamic pass-through attributes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["env"]
+    "presets": ["env"],
+    "plugins": ["transform-object-assign"]
 }

--- a/README.md
+++ b/README.md
@@ -83,7 +83,26 @@ var menu = document.querySelector('.menu');
 menu.label = 'Sortieren';
 ```
 
-*NOTE: Undocumented attributes are assumed to be HTML and will be applied to the root element of the custom tag.*
+#### Pass-Through Attributes
+
+HTML attributes can be used on any component, and they will be passed through to the most prominent tag of the component. The most prominent tag is usually the root, but individual components will note if it varies for specific cases.
+
+Example of static usage:
+```marko
+<ebay-button id="my-button"/>
+```
+
+For using pass-through attributes dynamically, they should be sent through the `htmlAttributes` attribute:
+```marko
+<!-- data.htmlAttributes = {id: 'my-button'} -->
+<ebay-button htmlAttributes=data.htmlAttributes/>
+```
+
+Static and dynamic pass-through attributes can be used simulatenously (htmlAttributes takes precedence in conflicts):
+```marko
+<!-- data.htmlAttributes = {id: 'my-button'} -->
+<ebay-button htmlAttributes=data.htmlAttributes type="submit"/>
+```
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ Example of static usage:
 <ebay-button id="my-button"/>
 ```
 
-For using pass-through attributes dynamically, they should be sent through the `htmlAttributes` attribute:
+For using pass-through attributes dynamically, they should be sent through the `html-attributes` attribute:
 ```marko
-<!-- data.htmlAttributes = {id: 'my-button'} -->
-<ebay-button htmlAttributes=data.htmlAttributes/>
+<!-- data.htmlAttributes = { id: 'my-button' } -->
+<ebay-button html-attributes=data.htmlAttributes/>
 ```
 
-Static and dynamic pass-through attributes can be used simulatenously (htmlAttributes takes precedence in conflicts):
+Static and dynamic pass-through attributes can be used simulatenously (html-attributes takes precedence in conflicts):
 ```marko
-<!-- data.htmlAttributes = {id: 'my-button'} -->
-<ebay-button htmlAttributes=data.htmlAttributes type="submit"/>
+<!-- data.htmlAttributes = { id: 'my-button' } -->
+<ebay-button html-attributes=data.htmlAttributes type="submit"/>
 ```
 
 ### Events

--- a/marko.json
+++ b/marko.json
@@ -1,18 +1,21 @@
 {
     "<ebay-button>": {
         "renderer": "./src/components/ebay-button/index.js",
+        "@*": "expression",
+        "@htmlAttributes": "expression",
         "@class": "string",
         "@disabled": "boolean",
         "@partially-disabled": "boolean",
         "@href": "string",
         "@priority": "string",
         "@size": "size",
-        "@fluid": "boolean",
-        "@*": "expression"
+        "@fluid": "boolean"
     },
     "<ebay-carousel>": {
         "renderer": "./src/components/ebay-carousel/index.js",
         "transformer": "./src/common/transformer/index.js",
+        "@*": "expression",
+        "@htmlAttributes": "expression",
         "@class": "string",
         "@index": "string",
         "@type": "string",
@@ -23,102 +26,112 @@
         "@accessibility-status": "string",
         "@accessibility-current": "string",
         "@accessibility-other": "string",
-        "@*": "expression",
         "@items <item>[]": {
-            "@*": "expression"
+            "@*": "expression",
+            "@htmlAttributes": "expression"
         }
     },
     "<ebay-carousel-item>": {},
     "<ebay-dialog>": {
         "renderer": "./src/components/ebay-dialog/index.js",
+        "@*": "expression",
+        "@htmlAttributes": "expression",
         "@class": "string",
         "@open": "boolean",
         "@type": "string",
         "@focus": "string",
-        "@aria-label-close": "string",
-        "@*": "expression"
+        "@aria-label-close": "string"
     },
     "<ebay-select>": {
         "renderer": "./src/components/ebay-select/index.js",
         "transformer": "./src/common/transformer/index.js",
+        "@*": "expression",
+        "@htmlAttributes": "expression",
         "@class": "string",
         "@name": "string",
         "@grow": "boolean",
         "@borderless": "boolean",
-        "@*": "expression",
         "@options <option>[]": {
+            "@*": "expression",
+            "@htmlAttributes": "expression",
             "@class": "string",
             "@value": "string",
             "@label": "string",
-            "@selected": "boolean",
-            "@*": "expression"
+            "@selected": "boolean"
         }
     },
     "<ebay-select-option>": {},
     "<ebay-menu>": {
         "renderer": "./src/components/ebay-menu/index.js",
         "transformer": "./src/common/transformer/index.js",
-        "@type": "string",
+        "@*": "expression",
+        "@htmlAttributes": "expression",
         "@class": "string",
+        "@type": "string",
         "@label": "string",
         "@expanded": "boolean",
         "@reverse": "boolean",
         "@fix-width": "boolean",
         "@borderless": "boolean",
-        "@*": "expression",
         "@items <item>[]": {
+            "@*": "expression",
+            "@htmlAttributes": "expression",
             "@class": "string",
             "@href": "string",
             "@type": "string",
             "@checked": "boolean",
-            "@current": "boolean",
-            "@*": "expression"
+            "@current": "boolean"
         }
     },
     "<ebay-menu-item>": {},
     "<ebay-notice>": {
         "renderer": "./src/components/ebay-notice/index.js",
+        "@*": "expression",
+        "@htmlAttributes": "expression",
+        "@class": "string",
         "@type": "string",
         "@heading-level": "string",
         "@status": "string",
-        "@class": "string",
         "@hidden": "boolean",
         "@aria-text": "string",
         "@aria-label-close": "string",
-        "@dismissible": "boolean",
-        "@*": "expression"
+        "@dismissible": "boolean"
     },
     "<ebay-breadcrumb>": {
         "renderer": "./src/components/ebay-breadcrumb/index.js",
         "transformer": "./src/common/transformer/index.js",
+        "@*": "expression",
+        "@htmlAttributes": "expression",
         "@class": "string",
         "@heading-text": "string",
         "@heading-level": "string",
         "@hijax": "boolean",
-        "@*": "expression",
         "@items <item>[]": {
-            "@href": "string",
-            "@*": "expression"
+            "@*": "expression",
+            "@htmlAttributes": "expression",
+            "@href": "string"
         }
     },
     "<ebay-breadcrumb-item>": {},
     "<ebay-pagination>": {
         "renderer": "./src/components/ebay-pagination/index.js",
         "transformer": "./src/common/transformer/index.js",
+        "@*": "expression",
+        "@htmlAttributes": "expression",
         "@class": "string",
         "@accessibility-prev": "string",
         "@accessibility-next": "string",
         "@accessibility-current": "string",
         "@hijax": "boolean",
-        "@*": "expression",
         "@items <item>[]": {
+            "@*": "expression",
+            "@htmlAttributes": "expression",
             "@class": "string",
             "@current": "boolean",
             "@disabled": "boolean",
             "@href": "string",
             "@type": "string",
-            "@role": "string",
-            "@*": "expression"
+            "@role": "string"
         }
     },
     "<ebay-pagination-item>": {}

--- a/marko.json
+++ b/marko.json
@@ -2,7 +2,7 @@
     "<ebay-button>": {
         "renderer": "./src/components/ebay-button/index.js",
         "@*": "expression",
-        "@htmlAttributes": "expression",
+        "@html-attributes": "expression",
         "@class": "string",
         "@disabled": "boolean",
         "@partially-disabled": "boolean",
@@ -15,7 +15,7 @@
         "renderer": "./src/components/ebay-carousel/index.js",
         "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
-        "@htmlAttributes": "expression",
+        "@html-attributes": "expression",
         "@class": "string",
         "@index": "string",
         "@type": "string",
@@ -28,14 +28,14 @@
         "@accessibility-other": "string",
         "@items <item>[]": {
             "@*": "expression",
-            "@htmlAttributes": "expression"
+            "@html-attributes": "expression"
         }
     },
     "<ebay-carousel-item>": {},
     "<ebay-dialog>": {
         "renderer": "./src/components/ebay-dialog/index.js",
         "@*": "expression",
-        "@htmlAttributes": "expression",
+        "@html-attributes": "expression",
         "@class": "string",
         "@open": "boolean",
         "@type": "string",
@@ -46,14 +46,14 @@
         "renderer": "./src/components/ebay-select/index.js",
         "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
-        "@htmlAttributes": "expression",
+        "@html-attributes": "expression",
         "@class": "string",
         "@name": "string",
         "@grow": "boolean",
         "@borderless": "boolean",
         "@options <option>[]": {
             "@*": "expression",
-            "@htmlAttributes": "expression",
+            "@html-attributes": "expression",
             "@class": "string",
             "@value": "string",
             "@label": "string",
@@ -65,7 +65,7 @@
         "renderer": "./src/components/ebay-menu/index.js",
         "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
-        "@htmlAttributes": "expression",
+        "@html-attributes": "expression",
         "@class": "string",
         "@type": "string",
         "@label": "string",
@@ -75,7 +75,7 @@
         "@borderless": "boolean",
         "@items <item>[]": {
             "@*": "expression",
-            "@htmlAttributes": "expression",
+            "@html-attributes": "expression",
             "@class": "string",
             "@href": "string",
             "@type": "string",
@@ -87,7 +87,7 @@
     "<ebay-notice>": {
         "renderer": "./src/components/ebay-notice/index.js",
         "@*": "expression",
-        "@htmlAttributes": "expression",
+        "@html-attributes": "expression",
         "@class": "string",
         "@type": "string",
         "@heading-level": "string",
@@ -101,14 +101,14 @@
         "renderer": "./src/components/ebay-breadcrumb/index.js",
         "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
-        "@htmlAttributes": "expression",
+        "@html-attributes": "expression",
         "@class": "string",
         "@heading-text": "string",
         "@heading-level": "string",
         "@hijax": "boolean",
         "@items <item>[]": {
             "@*": "expression",
-            "@htmlAttributes": "expression",
+            "@html-attributes": "expression",
             "@href": "string"
         }
     },
@@ -117,7 +117,7 @@
         "renderer": "./src/components/ebay-pagination/index.js",
         "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
-        "@htmlAttributes": "expression",
+        "@html-attributes": "expression",
         "@class": "string",
         "@accessibility-prev": "string",
         "@accessibility-next": "string",
@@ -125,7 +125,7 @@
         "@hijax": "boolean",
         "@items <item>[]": {
             "@*": "expression",
-            "@htmlAttributes": "expression",
+            "@html-attributes": "expression",
             "@class": "string",
             "@current": "boolean",
             "@disabled": "boolean",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@lasso/marko-taglib": "^1.0.9",
     "async": "^2.6.0",
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "browser-refresh": "^1.7.2",
     "chai": "^4.1.2",

--- a/src/common/html-attributes/index.js
+++ b/src/common/html-attributes/index.js
@@ -13,7 +13,13 @@ function camelToKebab(s) {
  */
 function processHtmlAttributes(input = {}) {
     const attributes = {};
-    const obj = input['*'];
+    const htmlAttributes = input.htmlAttributes;
+    const wildcardAttributes = input['*'];
+
+    let obj = htmlAttributes || wildcardAttributes;
+    if (htmlAttributes && wildcardAttributes) {
+        obj = Object.assign(wildcardAttributes, htmlAttributes);
+    }
 
     if (obj) {
         Object.keys(obj).forEach((key) => {

--- a/src/common/html-attributes/test/test.server.js
+++ b/src/common/html-attributes/test/test.server.js
@@ -1,7 +1,7 @@
 const expect = require('chai').expect;
 const processHtmlAttributes = require('../');
 
-['htmlAttributes', '*'].forEach(key => {
+['*', 'htmlAttributes'].forEach(key => {
     test(`creates attributes object based on ${key}`, () => {
         const input = { [key]: { b: 2, ariaRole: 'link' } };
         const htmlAttributes = { b: 2, 'aria-role': 'link' };

--- a/src/common/html-attributes/test/test.server.js
+++ b/src/common/html-attributes/test/test.server.js
@@ -1,8 +1,22 @@
 const expect = require('chai').expect;
 const processHtmlAttributes = require('../');
 
-test('creates attributes object based on inputs', () => {
-    const input = { '*': { b: 2, ariaRole: 'link' } };
+['htmlAttributes', '*'].forEach(key => {
+    test(`creates attributes object based on ${key}`, () => {
+        const input = { [key]: { b: 2, ariaRole: 'link' } };
+        const htmlAttributes = { b: 2, 'aria-role': 'link' };
+        expect(processHtmlAttributes(input)).to.deep.equal(htmlAttributes);
+    });
+});
+
+test('merges htmlAttributes with *', () => {
+    const input = { '*': { ariaRole: 'link' }, htmlAttributes: { b: 2 } };
     const htmlAttributes = { b: 2, 'aria-role': 'link' };
+    expect(processHtmlAttributes(input)).to.deep.equal(htmlAttributes);
+});
+
+test('uses htmlAttributes over * in case of conflict', () => {
+    const input = { '*': { ariaRole: 'link' }, htmlAttributes: { ariaRole: 'button' } };
+    const htmlAttributes = { 'aria-role': 'button' };
     expect(processHtmlAttributes(input)).to.deep.equal(htmlAttributes);
 });

--- a/src/common/test-utils/server.js
+++ b/src/common/test-utils/server.js
@@ -34,9 +34,12 @@ function testCustomClass(context, selector, arrayKey, isPassThrough) {
 }
 
 function testHtmlAttributes(context, selector, arrayKey) {
-    const input = setupInput({ '*': { 'aria-role': 'link' } }, arrayKey);
-    const $ = getCheerio(context.render(input));
-    expect($(`${selector}[aria-role=link]`).length).to.equal(1);
+    // check that each method is correctly supported
+    ['htmlAttributes', '*'].forEach(key => {
+        const input = setupInput({ [key]: { 'aria-role': 'link' } }, arrayKey);
+        const $ = getCheerio(context.render(input));
+        expect($(`${selector}[aria-role=link]`).length).to.equal(1);
+    });
 }
 
 module.exports = {

--- a/src/common/test-utils/server.js
+++ b/src/common/test-utils/server.js
@@ -35,7 +35,7 @@ function testCustomClass(context, selector, arrayKey, isPassThrough) {
 
 function testHtmlAttributes(context, selector, arrayKey) {
     // check that each method is correctly supported
-    ['htmlAttributes', '*'].forEach(key => {
+    ['*', 'htmlAttributes'].forEach(key => {
         const input = setupInput({ [key]: { 'aria-role': 'link' } }, arrayKey);
         const $ = getCheerio(context.render(input));
         expect($(`${selector}[aria-role=link]`).length).to.equal(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,6 +979,12 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-object-assign@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz#f99d2f66f1a0b0d498e346c5359684740caa20ba"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"


### PR DESCRIPTION
## Description
- update `processHtmlAttributes` to accept `htmlAttributes` object
- add `htmlAttributes` to all components in `marko.json`
- minor reordering in `marko.json`
- update main `README`
- update tests

## Context
We typically differentiate pass-through attributes easily because they come under `input['*']`. However, when passing these attributes dynamically, they appear as regular attributes instead of under the wildcard. To get around this, I added an `htmlAttributes` attribute on every component that can be used with (or instead of) the wildcard.

## References
Fixes #130 
