### PR TITLE
Carousel: fix accessibility id in v4

### DIFF
--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -1,5 +1,5 @@
 <div class=data.classes w-bind ${data.htmlAttributes}>
-    <var statusId="carousel-status-${widget.id}"/>
+    <var statusId=("carousel-status-" + widget.id)/>
     <div class=("carousel__container" + (data.bothControlsDisabled ? " carousel__container--controls-disabled" : ""))>
         <span
             if(data.isDiscrete)


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- update accessibility id definition

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This was working fine in v3, but not in v4. Looks to be a Marko bug, but the workaround is really simple.

## Screenshots
<!-- Upload screenshots if appropriate-->
v4 Before:
<img width="241" alt="screen shot 2018-05-10 at 12 27 55 pm" src="https://user-images.githubusercontent.com/3595986/39890150-c3c8f424-544e-11e8-86a0-b5ac5fb5d550.png">

v4 After:
<img width="243" alt="screen shot 2018-05-10 at 12 28 05 pm" src="https://user-images.githubusercontent.com/3595986/39890153-c58e9a34-544e-11e8-9624-d2f3197262d8.png">
