### PR TITLE
Pass originalEvent when custom event maps to interaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebay/ebayui-core",
-  "version": "0.4.0-0",
+  "version": "0.4.0-1",
   "scripts": {
     "installMarkoV3": "yarn add marko@^3 marko-widgets@^6 -D",
     "installMarkoV4": "yarn add marko@^4 marko-widgets@^7 -D",

--- a/src/common/test-utils/browser.js
+++ b/src/common/test-utils/browser.js
@@ -1,3 +1,5 @@
+const expect = require('chai').expect;
+
 /**
  * Trigger generic DOM event
  * @param {HTMLElement} el
@@ -11,6 +13,15 @@ function triggerEvent(el, type, keyCode) {
     el.dispatchEvent(event);
 }
 
+/**
+ * Check that the spy was called with an originalEvent
+ * @param {Object} spy
+ */
+function testOriginalEvent(spy) {
+    expect(spy.getCall(0).args[0].originalEvent instanceof Event).to.equal(true);
+}
+
 module.exports = {
-    triggerEvent
+    triggerEvent,
+    testOriginalEvent
 };

--- a/src/components/ebay-breadcrumb/README.md
+++ b/src/components/ebay-breadcrumb/README.md
@@ -22,7 +22,7 @@ Name | Type | Stateful | Description
 
 Event | Description | Data
 --- | ---
-`breadcrumb-select` | click breadcrumb items | `{ event, el: event.target }`
+`breadcrumb-select` | click breadcrumb items | `{ originalEvent, el }`
 
 ## ebay-breadcrumb-item Attributes
 

--- a/src/components/ebay-breadcrumb/index.js
+++ b/src/components/ebay-breadcrumb/index.js
@@ -45,9 +45,9 @@ function getInitialState({ hijax }) {
     return { hijax };
 }
 
-function handleClick(event) {
-    eventUtils.preventDefaultIfHijax(event, this.state.hijax);
-    emitAndFire(this, 'breadcrumb-select', { el: event.target });
+function handleClick(originalEvent) {
+    eventUtils.preventDefaultIfHijax(originalEvent, this.state.hijax);
+    emitAndFire(this, 'breadcrumb-select', { originalEvent, el: event.target });
 }
 
 module.exports = markoWidgets.defineComponent({

--- a/src/components/ebay-breadcrumb/index.js
+++ b/src/components/ebay-breadcrumb/index.js
@@ -47,7 +47,7 @@ function getInitialState({ hijax }) {
 
 function handleClick(originalEvent) {
     eventUtils.preventDefaultIfHijax(originalEvent, this.state.hijax);
-    emitAndFire(this, 'breadcrumb-select', { originalEvent, el: event.target });
+    emitAndFire(this, 'breadcrumb-select', { originalEvent, el: originalEvent.target });
 }
 
 module.exports = markoWidgets.defineComponent({

--- a/src/components/ebay-breadcrumb/test/test.browser.js
+++ b/src/components/ebay-breadcrumb/test/test.browser.js
@@ -4,24 +4,29 @@ const testUtils = require('../../../common/test-utils/browser');
 const mock = require('../mock');
 const renderer = require('../');
 
-describe('Basic breadcrumb', () => {
+describe('given a basic breadcrumb', () => {
     let widget;
-    let list;
-    describe('when item is clicked', () => {
-        let clickSpy;
+    let firstItem;
+
+    beforeEach(() => {
         widget = renderer.renderSync(mock.basicItems).appendTo(document.body).getWidget();
+        firstItem = document.querySelectorAll('nav li a')[0];
+    });
+    afterEach(() => widget.destroy());
+
+    describe('when item is clicked', () => {
+        let spy;
         beforeEach((done) => {
-            list = document.querySelectorAll('nav li a');
-            clickSpy = sinon.spy();
-            widget.on('breadcrumb-select', clickSpy);
-            testUtils.triggerEvent(list[0], 'click');
+            spy = sinon.spy();
+            widget.on('breadcrumb-select', spy);
+            testUtils.triggerEvent(firstItem, 'click');
             setTimeout(done);
         });
-        afterEach(() => widget.destroy());
 
-        it('then it emits the breadcrumb-select event', () => {
-            expect(clickSpy.calledOnce).to.equal(true);
-            expect(Object.keys(clickSpy.args[0][0])).to.deep.equal(['el']);
+        it('then it emits the breadcrumb-select event with correct data', () => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(spy.getCall(0).args[0].el).to.equal(firstItem);
+            testUtils.testOriginalEvent(spy);
         });
     });
 });

--- a/src/components/ebay-breadcrumb/test/test.browser.js
+++ b/src/components/ebay-breadcrumb/test/test.browser.js
@@ -25,7 +25,7 @@ describe('given a basic breadcrumb', () => {
 
         it('then it emits the breadcrumb-select event with correct data', () => {
             expect(spy.calledOnce).to.equal(true);
-            expect(spy.getCall(0).args[0].el).to.equal(firstItem);
+            expect(spy.getCall(0).args[0].el).to.deep.equal(firstItem);
             testUtils.testOriginalEvent(spy);
         });
     });

--- a/src/components/ebay-button/test/test.browser.js
+++ b/src/components/ebay-button/test/test.browser.js
@@ -29,8 +29,7 @@ describe('given button is enabled', () => {
 
         test('then it emits the event with correct data', () => {
             expect(spy.calledOnce).to.equal(true);
-            const originalEvent = spy.getCall(0).args[0].originalEvent;
-            expect(originalEvent instanceof Event).to.equal(true);
+            testUtils.testOriginalEvent(spy);
         });
     });
 });

--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -42,8 +42,8 @@ Event | Data | Description
 --- | --- | ---
 `carousel-update` | { [visibleIndexes] } | called whenever item visibility changes, including initialization
 `carousel-move` | | start of carousel content movement animation
-`carousel-next` | | click next control
-`carousel-prev` | | click previous control
+`carousel-next` | { originalEvent } | click next control
+`carousel-prev` | { originalEvent } | click previous control
 
 ### Additional Events for type="discrete"
 Event | Data | Description

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -101,25 +101,25 @@ function update_index() { // eslint-disable-line camelcase
     this.performSlide();
 }
 
-function handleNext() {
+function handleNext(originalEvent) {
     if (!this.state.nextControlDisabled) {
         if (this.state.isDiscrete) {
             this.simulateDotClick(this.state.slide + 1);
         } else if (this.state.isContinuous) {
             this.setState('index', this.calculateNextIndex());
         }
-        emitAndFire(this, 'carousel-next');
+        emitAndFire(this, 'carousel-next', { originalEvent });
     }
 }
 
-function handlePrev() {
+function handlePrev(originalEvent) {
     if (!this.state.prevControlDisabled) {
         if (this.state.isDiscrete) {
             this.simulateDotClick(this.state.slide - 1);
         } else if (this.state.isContinuous) {
             this.setState('index', this.calculatePrevIndex());
         }
-        emitAndFire(this, 'carousel-prev');
+        emitAndFire(this, 'carousel-prev', { originalEvent });
     }
 }
 

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -8,6 +8,11 @@ const privates = renderer.privates;
 const constants = privates.constants;
 const containerWidth = 800; // puppeteer default
 
+function testControlEvent(spy) {
+    expect(spy.calledOnce).to.equal(true);
+    testUtils.testOriginalEvent(spy);
+}
+
 describe('given the carousel is in the default state', () => {
     let widget;
     let root;
@@ -123,9 +128,7 @@ describe('given the carousel starts in the default state with items', () => {
             setTimeout(done);
         });
 
-        it('then it emits the marko next event', () => {
-            expect(nextSpy.calledOnce).to.equal(true);
-        });
+        it('then it emits the marko next event', () => testControlEvent(nextSpy));
 
         it('then it emits the marko move event', () => {
             expect(moveSpy.calledOnce).to.equal(true);
@@ -220,9 +223,7 @@ describe('given a continuous carousel has next button clicked', () => {
             setTimeout(done);
         });
 
-        it('then it emits the marko prev event', () => {
-            expect(prevSpy.calledOnce).to.equal(true);
-        });
+        it('then it emits the marko prev event', () => testControlEvent(prevSpy));
 
         it('then it emits the marko move event', () => {
             expect(moveSpy.calledOnce).to.equal(true);
@@ -454,9 +455,7 @@ describe('given a discrete carousel', () => {
             setTimeout(done);
         });
 
-        it('then it emits the marko next event', () => {
-            expect(nextSpy.calledOnce).to.equal(true);
-        });
+        it('then it emits the marko next event', () => testControlEvent(nextSpy));
 
         it('then it emits the marko slide event', () => {
             expect(slideSpy.calledOnce).to.equal(true);
@@ -541,9 +540,7 @@ describe('given a discrete carousel has next button clicked', () => {
             setTimeout(done);
         });
 
-        it('then it emits the marko prev event', () => {
-            expect(prevSpy.calledOnce).to.equal(true);
-        });
+        it('then it emits the marko prev event', () => testControlEvent(prevSpy));
 
         it('then it emits the marko slide event', () => {
             expect(slideSpy.calledOnce).to.equal(true);
@@ -608,9 +605,7 @@ describe('given a discrete carousel with half width items', () => {
             setTimeout(done);
         });
 
-        it('then it emits the marko next event', () => {
-            expect(nextSpy.calledOnce).to.equal(true);
-        });
+        it('then it emits the marko next event', () => testControlEvent(nextSpy));
 
         it('then it emits the marko slide event', () => {
             expect(slideSpy.calledOnce).to.equal(true);

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -30,9 +30,9 @@ Name | Type | Stateful | Description
 
 Event | Data | Description
 --- | --- | ---
-`pagination-previous` |  `{ event, el: event.target }`| clicked previous arrow button
-`pagination-next` | `{ event, el: event.target }` | clicked next arrow button
-`pagination-select` | `{ event, el: event.target , value: "Selected page" }` | page selected clicked
+`pagination-previous` | `{ originalEvent, el }`| clicked previous arrow button
+`pagination-next` | `{ originalEvent, el }` | clicked next arrow button
+`pagination-select` | `{ originalEvent, el, value }` | page selected clicked
 
 ## ebay-pagination-item Tag
 

--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -102,19 +102,20 @@ function refresh() {
  * Handle normal mouse click for item, next page and previous page respectively.
  * @param {MouseEvent} event
  */
-function handlePageClick(event) {
-    eventUtils.preventDefaultIfHijax(event, this.state.hijax);
-    emitAndFire(this, 'pagination-select', { el: event.target, value: event.target.innerText });
+function handlePageClick(originalEvent) {
+    const target = originalEvent.target;
+    eventUtils.preventDefaultIfHijax(originalEvent, this.state.hijax);
+    emitAndFire(this, 'pagination-select', { originalEvent, el: target, value: target.innerText });
 }
 
-function handleNextPage(event) {
-    eventUtils.preventDefaultIfHijax(event, this.state.hijax);
-    emitAndFire(this, 'pagination-next', { el: this.nextPageEl });
+function handleNextPage(originalEvent) {
+    eventUtils.preventDefaultIfHijax(originalEvent, this.state.hijax);
+    emitAndFire(this, 'pagination-next', { originalEvent, el: this.nextPageEl });
 }
 
-function handlePreviousPage(event) {
-    eventUtils.preventDefaultIfHijax(event, this.state.hijax);
-    emitAndFire(this, 'pagination-previous', { el: this.previousPageEl });
+function handlePreviousPage(originalEvent) {
+    eventUtils.preventDefaultIfHijax(originalEvent, this.state.hijax);
+    emitAndFire(this, 'pagination-previous', { originalEvent, el: this.previousPageEl });
 }
 
 /**

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -6,14 +6,14 @@ const renderer = require('../');
 
 function testControlEvent(spy, el) {
     expect(spy.calledOnce).to.equal(true);
-    expect(spy.getCall(0).args[0].el).to.equal(el);
+    expect(spy.getCall(0).args[0].el).to.deep.equal(el);
     testUtils.testOriginalEvent(spy);
 }
 
 function testSelectEvent(spy, el) {
     const eventData = spy.getCall(0).args[0];
     expect(spy.calledOnce).to.equal(true);
-    expect(eventData.el).to.equal(el);
+    expect(eventData.el).to.deep.equal(el);
     expect(eventData.value).to.equal('1');
     testUtils.testOriginalEvent(spy);
 }

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -4,6 +4,20 @@ const testUtils = require('../../../common/test-utils/browser');
 const mock = require('../mock');
 const renderer = require('../');
 
+function testControlEvent(spy, el) {
+    expect(spy.calledOnce).to.equal(true);
+    expect(spy.getCall(0).args[0].el).to.equal(el);
+    testUtils.testOriginalEvent(spy);
+}
+
+function testSelectEvent(spy, el) {
+    const eventData = spy.getCall(0).args[0];
+    expect(spy.calledOnce).to.equal(true);
+    expect(eventData.el).to.equal(el);
+    expect(eventData.value).to.equal('1');
+    testUtils.testOriginalEvent(spy);
+}
+
 describe('given the menu is in the default state with links', () => {
     let widget;
     let root;
@@ -33,8 +47,7 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the marko event called pagination-previous', () => {
-            expect(spy.calledOnce).to.equal(true);
-            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+            testControlEvent(spy, previousButton);
         });
     });
 
@@ -48,8 +61,7 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the pagination-previous event with correct data', () => {
-            expect(spy.calledOnce).to.equal(true);
-            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+            testControlEvent(spy, previousButton);
         });
     });
 
@@ -62,8 +74,7 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the marko event called pagination-next', () => {
-            expect(spy.calledOnce).to.equal(true);
-            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+            testControlEvent(spy, nextButton);
         });
     });
 
@@ -77,8 +88,7 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the pagination-next event with correct data', () => {
-            expect(spy.calledOnce).to.equal(true);
-            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+            testControlEvent(spy, nextButton);
         });
     });
 
@@ -91,10 +101,7 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the marko event called pagination-select', () => {
-            expect(spy.calledOnce).to.equal(true);
-            const eventData = spy.getCall(0).args[0];
-            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el', 'value']);
-            expect(eventData.value).to.be.equal('1');
+            testSelectEvent(spy, pageItem);
         });
     });
 
@@ -107,8 +114,7 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the marko event called pagination-previous', () => {
-            expect(spy.calledOnce).to.equal(true);
-            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+            testControlEvent(spy, previousButton);
         });
     });
 
@@ -121,8 +127,7 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the marko event called pagination-next', () => {
-            expect(spy.calledOnce).to.equal(true);
-            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el']);
+            testControlEvent(spy, nextButton);
         });
     });
 
@@ -135,10 +140,7 @@ describe('given the menu is in the default state with links', () => {
         });
 
         test('then it emits the marko event called pagination-select', () => {
-            expect(spy.calledOnce).to.equal(true);
-            const eventData = spy.getCall(0).args[0];
-            expect(Object.keys(spy.args[0][0])).to.deep.equal(['el', 'value']);
-            expect(eventData.value).to.be.equal('1');
+            testSelectEvent(spy, pageItem);
         });
     });
 });


### PR DESCRIPTION
## Description
- adds `originalEvent` for breadcrumb, carousel, and pagination
- update docs
- includes minor cleanup and related refactoring 

## Context
I looked through each component for events that only map to user interaction, and then added `originalEvent` to the custom event data. There are some cases where the event can be triggered by both UI and API. For those cases, I am not passing the `originalEvent`, because I think it seems strange to sometimes pass it and sometimes not for the same event. We can see if teams actually need this functionality later on.

## References
Follow up to #141 
Fixes #126 
