### PR TITLE
Fix default tag for ebay-menu-item.

### DIFF
--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -31,10 +31,10 @@ function getInitialState(input) {
 
         if (isFake) {
             classes.push('fake-menu__item');
-            if (href) {
-                tag = 'a';
-            } else if (itemType === 'button') {
+            if (itemType === 'button') {
                 tag = 'button';
+            } else {
+                tag = 'a';
             }
         } else {
             tag = 'div';

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -110,6 +110,13 @@ describe('menu-item', () => {
         expect($('button.fake-menu__item').length).to.equal(1);
     });
 
+    test('renders fake version without href', context => {
+        const linkItem = { renderBody: mock.renderBody, href: '' };
+        const input = { type: 'fake', items: [linkItem] };
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($('a.fake-menu__item[href]').length).to.equal(1);
+    });
+
     ['radio', 'checkbox'].forEach(type => {
         [true, false].forEach(checked => {
             test(`renders with type=${type} and checked=${checked}`, context => {


### PR DESCRIPTION
## Description
This updates the `ebay-menu-item` to ensure that fake links always get a `tag` set.
By default they will be set to an `<a>` tag unless the type has been explicitly set.

## References
Fixes: #168