### PR TITLE
Pagination: fix pass-through on controls

### DIFF
--- a/src/common/test-utils/server.js
+++ b/src/common/test-utils/server.js
@@ -10,33 +10,36 @@ function getCheerio(output) {
 }
 
 /**
- * Put input in single-entry array when specified (for marko nested tags)
- * @param {Object} input
- * @param {String} arrayKey
+ * Create input to be used for rendering through test utils
+ * @param {Object} input: additional input to use with test utils
+ * @param {String} arrayKey: if provided, assign input as a single-entry array (for marko nested tags)
+ * @param {String} baseInput: if provided, use as base for additional input
  */
-function setupInput(input, arrayKey) {
-    let newInput = input;
+function setupInput(input, arrayKey, baseInput) {
+    let newInput = baseInput ? Object.assign(baseInput, input) : input;
+
     if (arrayKey) {
-        newInput = { [arrayKey]: [input] };
+        newInput = { [arrayKey]: [newInput] };
     }
+
     return newInput;
 }
 
-function testCustomClass(context, selector, arrayKey, isPassThrough) {
+function testCustomClass(context, selector, arrayKey, isPassThrough, baseInput) {
     let input;
     if (isPassThrough) {
-        input = setupInput({ '*': { class: 'class1 class2' } }, arrayKey);
+        input = setupInput({ '*': { class: 'class1 class2' } }, arrayKey, baseInput);
     } else {
-        input = setupInput({ class: 'class1 class2' }, arrayKey);
+        input = setupInput({ class: 'class1 class2' }, arrayKey, baseInput);
     }
     const $ = getCheerio(context.render(input));
     expect($(`${selector}.class1.class2`).length).to.equal(1);
 }
 
-function testHtmlAttributes(context, selector, arrayKey) {
+function testHtmlAttributes(context, selector, arrayKey, baseInput) {
     // check that each method is correctly supported
     ['*', 'htmlAttributes'].forEach(key => {
-        const input = setupInput({ [key]: { 'aria-role': 'link' } }, arrayKey);
+        const input = setupInput({ [key]: { 'aria-role': 'link' } }, arrayKey, baseInput);
         const $ = getCheerio(context.render(input));
         expect($(`${selector}[aria-role=link]`).length).to.equal(1);
     });

--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -36,12 +36,12 @@ function getInitialState(input) {
         };
         if (item.type === 'previous') {
             prevItem = tempItem;
-            prevItem.class = 'pagination__previous';
+            prevItem.class = ['pagination__previous', item.class];
             prevItem.disabled = Boolean(item.disabled) || !href;
             continue;
         } else if (item.type === 'next') {
             nextItem = tempItem;
-            nextItem.class = 'pagination__next';
+            nextItem.class = ['pagination__next', item.class];
             nextItem.disabled = Boolean(item.disabled) || !href;
             continue;
         } else {
@@ -52,8 +52,8 @@ function getInitialState(input) {
 
     return {
         hijax,
-        nextItem: nextItem || { class: 'pagination__next', disabled: true },
-        prevItem: prevItem || { class: 'pagination__previous', disabled: true },
+        nextItem: nextItem || { class: 'pagination__next', disabled: true, htmlAttributes: {} },
+        prevItem: prevItem || { class: 'pagination__previous', disabled: true, htmlAttributes: {} },
         items,
         accessibilityPrev: input.accessibilityPrev || 'Previous page',
         accessibilityNext: input.accessibilityNext || 'Next page',

--- a/src/components/ebay-pagination/template.marko
+++ b/src/components/ebay-pagination/template.marko
@@ -12,6 +12,7 @@
         role=data.role
         w-onkeydown="handlePreviousPageKeyDown"
         w-onclick="handlePreviousPage"
+        ${data.prevItem.htmlAttributes}
         if(data.prevItem)>
        <span></span>
     </a>
@@ -37,6 +38,7 @@
         role=data.role
         w-onkeydown="handleNextPageKeyDown"
         w-onclick="handleNextPage"
+        ${data.nextItem.htmlAttributes}
         if(data.nextItem)>
        <span></span>
     </a>

--- a/src/components/ebay-pagination/test/test.server.js
+++ b/src/components/ebay-pagination/test/test.server.js
@@ -47,11 +47,30 @@ describe('pagination', () => {
 });
 
 describe('pagination-item', () => {
+    const previousControlInput = { type: 'previous' };
+    const nextControlInput = { type: 'next' };
+
     test('handles pass-through html attributes for item', context => {
         testUtils.testHtmlAttributes(context, '.pagination__item', 'items');
     });
 
+    test('handles pass-through html attributes for previous control', context => {
+        testUtils.testHtmlAttributes(context, '.pagination__previous', 'items', previousControlInput);
+    });
+
+    test('handles pass-through html attributes for next control', context => {
+        testUtils.testHtmlAttributes(context, '.pagination__next', 'items', nextControlInput);
+    });
+
     test('handles custom class for item', context => {
         testUtils.testCustomClass(context, '.pagination__item', 'items');
+    });
+
+    test('handles custom class for previous control', context => {
+        testUtils.testCustomClass(context, '.pagination__previous', 'items', false, previousControlInput);
+    });
+
+    test('handles custom class for next control', context => {
+        testUtils.testCustomClass(context, '.pagination__next', 'items', false, nextControlInput);
     });
 });


### PR DESCRIPTION
## Description
Adding html attributes pass through in navigation arrows just like the pagination items.

## Context
Adding it as it was missed in earlier PR

## References
Fixes #170 

