### PR TITLE
README - Update for Marko v4 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ For more information, please read [Building a UI Component in 2017 and Beyond](h
 * [Marko](https://markojs.com) (v3+)
 * [eBay Skin](https://ebay.github.io/skin/) (v4+)
 
-> Note:\
-> Marko v3 requires [Marko Widgets v6](https://github.com/marko-js/marko-widgets)\
-> Marko v4 requires [Marko Widgets v7](https://github.com/marko-js/marko-widgets/tree/v7)
+*Note:\
+Marko v3 requires [Marko Widgets v6](https://github.com/marko-js/marko-widgets)\
+Marko v4 requires [Marko Widgets v7](https://github.com/marko-js/marko-widgets/tree/v7)*
 
 ### Components
 * [`ebay-breadcrumb`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-breadcrumb)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ For more information, please read [Building a UI Component in 2017 and Beyond](h
 * [Marko](https://markojs.com) (v3+)
 * [eBay Skin](https://ebay.github.io/skin/) (v4+)
 
-*NOTE: Marko v3 also requires [Marko Widgets](https://github.com/marko-js/marko-widgets).*
+> Note:\
+> Marko v3 requires [Marko Widgets v6](https://github.com/marko-js/marko-widgets)\
+> Marko v4 requires [Marko Widgets v7](https://github.com/marko-js/marko-widgets/tree/v7)
 
 ### Components
 * [`ebay-breadcrumb`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-breadcrumb)
@@ -58,12 +60,6 @@ _browser.json_
         "@ebay/ebayui-core/ebay-menu"
     ]
 }
-```
-
-If you're using Marko v3 `ebayui` components in Marko v4, add the `marko-widgets` backwards compatibility layer.
-
-```sh
-yarn add marko-widgets@7
 ```
 
 ### Attributes

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ _browser.json_
 }
 ```
 
+If you're using Marko v3 ebayui tags in Marko v4, add the `marko-widgets` backwards compatibility layer.
+
+```sh
+marko-widgets@7
+```
+
 ### Attributes
 
 Attributes provide initial state for a component. We can see that the menu has `label` and `type` attributes:

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ _browser.json_
 }
 ```
 
-If you're using Marko v3 ebayui tags in Marko v4, add the `marko-widgets` backwards compatibility layer.
+If you're using Marko v3 `ebayui` components in Marko v4, add the `marko-widgets` backwards compatibility layer.
 
 ```sh
-marko-widgets@7
+yarn add marko-widgets@7
 ```
 
 ### Attributes


### PR DESCRIPTION
## Description

Updates README with steps for users of latest Marko version trying out the `<ebay-menu>` example in the README.

## Context

First time `ebayui` consumers who are on Marko v4 immediately run into runtime errors with the provided README example; and may not be aware that `ebayui` components require an additional compatibility layer given that the required version of Marko is "3+".
