### PR TITLE
Prevent closing dialog when clicking on whitespace in the panel.

### DIFF
--- a/src/components/ebay-dialog/index.js
+++ b/src/components/ebay-dialog/index.js
@@ -162,12 +162,24 @@ function show() {
     this.setState('open', true);
 }
 
-function close(ev) {
-    if (ev && this.bodyEl.contains(ev.target)) {
-        return;
+function close() {
+    this.setState('open', false);
+}
+
+function handleDialogClick({ target, clientY }) {
+    const { closeEl, windowEl } = this;
+
+    // Checks if we clicked inside the white panel of the dialog.
+    if (!closeEl.contains(target) && windowEl.contains(target)) {
+        const { bottom } = windowEl.getBoundingClientRect();
+        const { paddingBottom } = getComputedStyle(windowEl);
+        const windowBottom = bottom - parseInt(paddingBottom, 10);
+        if (clientY < windowBottom) {
+            return;
+        }
     }
 
-    this.setState('open', false);
+    this.close();
 }
 
 function cancelAsync() {
@@ -190,6 +202,8 @@ module.exports = markoWidgets.defineComponent({
     onRender: trap,
     onBeforeUpdate: release,
     onBeforeDestroy: destroy,
+    handleDialogClick,
+    handleCloseButtonClick: close,
     show,
     close
 });

--- a/src/components/ebay-dialog/template.marko
+++ b/src/components/ebay-dialog/template.marko
@@ -1,8 +1,8 @@
 
 <div class="dialog-placeholder" w-bind>
-    <div w-id="dialog" class=data.dialogClass hidden=!data.open role="dialog" w-preserve-attrs="hidden" ${data.htmlAttributes} w-onclick="close">
+    <div w-id="dialog" class=data.dialogClass hidden=!data.open role="dialog" w-preserve-attrs="hidden" ${data.htmlAttributes} w-onclick="handleDialogClick">
         <div w-id="window" class=data.windowClass role="document">
-            <button class="dialog__close" type="button" aria-label=data.ariaLabelClose w-id="close">
+            <button w-id="close" class="dialog__close" type="button" aria-label=data.ariaLabelClose w-onclick="handleCloseButtonClick">
                 <ebay-icon type="inline" name="close"/>
             </button>
 


### PR DESCRIPTION
## Description
This change fixes the dialog closing when clicking on whitespace at the bottom of the dialog panel.

## Context
Ideally this change would be implemented in @ebay/skin by making the `.dialog__body` fill the `.dialog__window`, or by finding an alternative to the `padding` on the `.dialog__window` however I wasn't able to find a solution that worked for all types of dialogs and was working in all browsers. Hopefully we can come back to this.

## References
Fixes #188 