### PR TITLE
Menu: remove empty span when there is no label

### DIFF
--- a/src/components/ebay-menu/examples/8-no-label/template.marko
+++ b/src/components/ebay-menu/examples/8-no-label/template.marko
@@ -1,0 +1,5 @@
+<ebay-menu>
+    <ebay-menu-item>item 1</ebay-menu-item>
+    <ebay-menu-item>item 2</ebay-menu-item>
+    <ebay-menu-item>item 3</ebay-menu-item>
+</ebay-menu>

--- a/src/components/ebay-menu/template.marko
+++ b/src/components/ebay-menu/template.marko
@@ -1,7 +1,7 @@
 <span class=data.menuClass w-bind w-on-expander-expand="handleExpand" w-on-expander-collapse="handleCollapse" ${data.htmlAttributes}>
     <ebay-button w-id="button" class=data.buttonClass aria-expanded=String(data.expanded) aria-haspopup="true">
         <span class="expand-btn__cell">
-            <span>${data.label}</span>
+            <span if(data.label)>${data.label}</span>
             <span class="expand-btn__icon" aria-hidden="true"/>
         </span>
     </ebay-button>

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -2,13 +2,19 @@ const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/server');
 const mock = require('../mock');
 
+const labelSelector = '.expand-btn__cell > span:not(.expand-btn__icon)';
+
 describe('menu', () => {
     test('renders basic version', context => {
-        const input = {};
+        const labelText = 'label';
+        const input = { label: labelText };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.menu').length).to.equal(1);
         expect($('.expand-btn').length).to.equal(1);
         expect($('.menu__items[role=menu]').length).to.equal(1);
+        const $label = $(labelSelector);
+        expect($label.length).to.equal(1);
+        expect($label.html()).to.equal(labelText);
     });
 
     test('renders fake version', context => {
@@ -83,6 +89,13 @@ describe('menu', () => {
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.expand-btn').length).to.equal(1);
         expect($('.expand-btn.expand-btn--borderless').length).to.equal(0);
+    });
+
+    test('renders without label', context => {
+        const input = { label: '' };
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($(labelSelector).length).to.equal(0);
+        expect($('.expand-btn__icon').length).to.equal(1);
     });
 
     test('handles pass-through html attributes', context => {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- remove empty span when there's no label
- add new example
- update tests

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Follow-up to some of the Skin work for supporting a menu without a label.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #162

## Screenshots
<!-- Upload screenshots if appropriate. -->
<img width="501" alt="screen shot 2018-05-23 at 2 35 45 pm" src="https://user-images.githubusercontent.com/3595986/40452421-9d26a0ee-5e96-11e8-869b-f2e919cb48f3.png">
