### PR TITLE
carousel: Fix issue when rerendering carousel from parent component.

### DIFF
--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -210,7 +210,7 @@ describe('given the carousel starts in the default state with items', () => {
         });
 
         it('then index is normalized to lastIndex', () => {
-            expect(root.index).to.equal(widget.lastIndex);
+            expect(root.index).to.equal(widget.state.lastIndex);
         });
 
         it('then it emits the marko events', () => {


### PR DESCRIPTION
## Description
This fixes an issue with the carousel which caused the `translation` to be reset after rerendering a parent component.

## Context
What happens currently is that when the carousel is rerendered it's `getInitialState` is called and the `translation` gets reset to zero. In most cases the `translation` is recalculated since it is applied after any updates however the check to see if the translation was needed didn't account for a rerender where the index stayed the same.

## References
This is related to and fixes #177
