### PR TITLE
eBay-icon: Marko v4 not moving symbols.

### DIFF
--- a/src/components/ebay-dialog/test/test.browser.js
+++ b/src/components/ebay-dialog/test/test.browser.js
@@ -8,20 +8,6 @@ describe('given the dialog is in the default state', () => {
     let close;
     let sibling;
 
-    // Stub for the close button.
-    const svg = document.createElement('svg');
-    svg.innerHTML = '<symbol id="icon-close" viewBox="1.5 1.5 21 21"><path/></symbol>';
-
-    before(() => {
-        // Add close button symbol.
-        document.body.insertBefore(svg, document.body.firstChild);
-    });
-
-    after(() => {
-        // remove close button symbol.
-        document.body.removeChild(svg);
-    });
-
     beforeEach(() => {
         sibling = document.createElement('div');
         document.body.appendChild(sibling);

--- a/src/components/ebay-icon/index.js
+++ b/src/components/ebay-icon/index.js
@@ -14,9 +14,9 @@ function init() {
 
     // If there were any symbols rendered then we move them to the svg above after rendering them.
     const defs = this.getEl('defs');
+    const symbol = defs && defs.querySelector('symbol');
 
-    if (defs) {
-        const symbol = defs.firstChild;
+    if (symbol) {
         // Here we get the name of the symbol by removing the `icon-` part.
         // We then mark this symbol as `defined` so that no other `ebay-icons` render it.
         defined[symbol.id.slice(5)] = true;


### PR DESCRIPTION
## Description
Currently in Marko v4 a comment is inserted (by Marko) which the `ebay-icon` is picking up instead of the nested symbol and trying to read it. This causes the component to throw on startup with SSR.

## Context
In this PR I explicitly look for a `symbol` tag instead of relying on `firstChild` to resolve the issue. I also removed the stub `svg` from the `ebay-dialog` tests to help us discover this issue more quickly in the future (the stub is no longer needed also).

## References
Fixes #223 