### PR TITLE
222: disabled combobox still allowed the menu to be shown

### DIFF
--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -73,7 +73,7 @@ function init() {
     if (this.state.options && this.state.options.length > 0) {
         this.expander = new Expander(this.el, {
             autoCollapse: true,
-            expandOnClick: true,
+            expandOnClick: !this.state.disabled,
             contentSelector: `.${comboboxOptionsClass}`,
             hostSelector: comboboxHostSelector,
             hostContainerClass: `${comboboxBtnClass}`,
@@ -82,6 +82,10 @@ function init() {
 
         observer.observeRoot(this, ['selected'], (index) => {
             this.processAfterStateChange(optionEls[index]);
+        });
+
+        observer.observeRoot(this, ['disabled'], () => {
+            this.expander.expandOnClick = !this.state.disabled;
         });
 
         const selectedObserverCallback = (optionEl) => {

--- a/src/components/ebay-combobox/test/test.browser.js
+++ b/src/components/ebay-combobox/test/test.browser.js
@@ -237,3 +237,54 @@ describe('given the combobox is in an expanded state', () => {
         });
     });
 });
+
+describe('given the combobox is in an disabled state', () => {
+    let widget;
+    let root;
+    let button;
+
+    beforeEach(() => {
+        const renderedWidget = renderer.renderSync({
+            options: mock.options,
+            disabled: true
+        });
+        widget = renderedWidget.appendTo(document.body).getWidget();
+        root = document.querySelector('.combobox');
+        button = root.querySelector('.combobox__control');
+    });
+
+    afterEach(() => widget.destroy());
+
+    describe('when the button is clicked once', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('combobox-expand', spy);
+            testUtils.triggerEvent(button, 'click');
+        });
+
+        test('then it does not emit the event from expander-expand', () => {
+            expect(spy.calledOnce).to.equal(false);
+        });
+    });
+
+    describe('when the disabled state is changed programmatically', () => {
+        beforeEach((done) => {
+            root.disabled = false;
+            setTimeout(done);
+        });
+
+        describe('when the button is clicked once', () => {
+            let spy;
+            beforeEach(() => {
+                spy = sinon.spy();
+                widget.on('combobox-expand', spy);
+                testUtils.triggerEvent(button, 'click');
+            });
+
+            test('then it emits the event from expander-expand', () => {
+                expect(spy.calledOnce).to.equal(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Description
The expander's ability to open on click is now tied to whether the component is enabled.

## Context
There was a bug that allowed a disabled combobox to still show the menu of options.

## References
Fixes #222 