### PR TITLE
Support lasso flag switching via URL;

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -8,6 +8,7 @@ const demoUtils = require('./utils.js');
 const template = require('./template.marko');
 
 const app = express();
+const defaultComponentRoute = 'ebay-button';
 
 let transforms;
 if (process.env.NODE_ENV === 'production') {
@@ -24,18 +25,18 @@ app.use(require('lasso/middleware').serveStatic());
 app.use(express.static(__dirname));
 
 app.get('/', (req, res) => {
-    res.redirect(301, '/ds6/ebay-button');
+    res.redirect(301, '/ds6');
 });
 
-app.get('/ds6/', (req, res) => {
-    res.redirect(301, '/ds6/ebay-button');
+app.get('/ds4', (req, res) => {
+    res.redirect(301, `/ds4/${defaultComponentRoute}`);
 });
 
-app.get('/ds4/', (req, res) => {
-    res.redirect(301, '/ds4/ebay-button');
+app.get('/ds6', (req, res) => {
+    res.redirect(301, `/ds6/${defaultComponentRoute}`);
 });
 
-app.get('/:design_system/:component?', (req, res) => {
+app.get('/:designSystem/:component?', (req, res) => {
     const name = req.params.component;
     const componentsPath = `${__dirname}/../src/components`;
     const examplesPath = `${componentsPath}/${name}/examples`;
@@ -51,7 +52,7 @@ app.get('/:design_system/:component?', (req, res) => {
         components: demoUtils.getComponentsWithExamples('src')
     };
     const md = new MobileDetect(req.headers['user-agent']);
-    const dsFlag = req.params.design_system === 'ds6' ? 'skin-ds6' : '';
+    const dsFlag = req.params.designSystem === 'ds6' ? 'skin-ds6' : '';
     const lassoFlags = [];
 
     // allow .only in example folder name

--- a/demo/index.js
+++ b/demo/index.js
@@ -27,7 +27,7 @@ app.get('/', (req, res) => {
     res.redirect(301, '/ebay-button');
 });
 
-app.get('/:component?', (req, res) => {
+app.get('/:design_system/:component?', (req, res) => {
     const name = req.params.component;
     const componentsPath = `${__dirname}/../src/components`;
     const examplesPath = `${componentsPath}/${name}/examples`;
@@ -42,6 +42,9 @@ app.get('/:component?', (req, res) => {
         })).filter(demoUtils.isDirectory),
         components: demoUtils.getComponentsWithExamples('src')
     };
+    const md = new MobileDetect(req.headers['user-agent']);
+    const dsFlag = req.params.design_system === 'ds6' ? 'skin-ds6' : '';
+    const lassoFlags = [];
 
     // allow .only in example folder name
     model.examples.some((example) => {
@@ -53,8 +56,7 @@ app.get('/:component?', (req, res) => {
 
     req.model = model;
 
-    const md = new MobileDetect(req.headers['user-agent']);
-    const lassoFlags = ['skin-ds6'];
+    lassoFlags.push(dsFlag);
     if (md.mobile() || md.tablet()) {
         lassoFlags.push('touch');
     } else {

--- a/demo/index.js
+++ b/demo/index.js
@@ -24,7 +24,15 @@ app.use(require('lasso/middleware').serveStatic());
 app.use(express.static(__dirname));
 
 app.get('/', (req, res) => {
-    res.redirect(301, '/ebay-button');
+    res.redirect(301, '/ds6/ebay-button');
+});
+
+app.get('/ds6/', (req, res) => {
+    res.redirect(301, '/ds6/ebay-button');
+});
+
+app.get('/ds4/', (req, res) => {
+    res.redirect(301, '/ds4/ebay-button');
 });
 
 app.get('/:design_system/:component?', (req, res) => {

--- a/demo/template.marko
+++ b/demo/template.marko
@@ -3,13 +3,13 @@
     <head>
         <lasso-head/>
         <title>ebayui-core</title>
-        <link rel="shortcut icon" href="favicon.ico">
+        <link rel="shortcut icon" href="/favicon.ico">
         <meta name="viewport" content="width=device-width">
     </head>
     <body>
         <header>
             <for (component in data.model.components)>
-                <a href=component><span>${component}</span></a>
+                <a href=`/${data.params.design_system}/${component}`><span>${component}</span></a>
             </for>
         </header>
         <h1>${data.params.component}</h1>

--- a/demo/template.marko
+++ b/demo/template.marko
@@ -9,7 +9,7 @@
     <body>
         <header>
             <for (component in data.model.components)>
-                <a href=`/${data.params.design_system}/${component}`><span>${component}</span></a>
+                <a href=`/${data.params.designSystem}/${component}`><span>${component}</span></a>
             </for>
         </header>
         <h1>${data.params.component}</h1>


### PR DESCRIPTION
## Description
Updates the demo site to support adding the design system to the URL. Uses a Lasso flag.

## Context
We need to be able to test the components with DS4, and this will provide the necessary switch.

**Examples:**
```
http://localhost:3000/ds4/ebay-combobox/
http://localhost:3000/ds6/ebay-combobox/
```