### PR TITLE
Carousel: Refactor + Bug fixes / Improvements

### DIFF
--- a/marko-cli.js
+++ b/marko-cli.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isTravis = require('is-travis');
+const buildID = `${process.env.TRAVIS_BUILD_NUMBER}.${process.env.TRAVIS_JOB_NUMBER}`;
 
 module.exports = ({ config }) => {
     config.mochaOptions = { timeout: 20000 };
@@ -15,9 +16,10 @@ module.exports = ({ config }) => {
     };
 
     config.wdioOptions = {
-        idleTimeout: 1200000, // 20 mins
-        browserStackOptions: {
-            onlyAutomate: isTravis
+        browserstackOpts: {
+            force: true,
+            onlyAutomate: isTravis,
+            localIdentifier: buildID
         },
         capabilities: [{
             browser: 'Chrome',
@@ -74,8 +76,11 @@ module.exports = ({ config }) => {
         //     os: 'Windows',
         //     os_version: '7'
         }].map(capability => {
+            capability.build = buildID;
             capability.project = 'ebayui-core';
             capability['browserstack.local'] = true;
+            capability['browserstack.debug'] = true;
+            capability['browserstack.localIdentifier'] = buildID;
             return capability;
         })
     };

--- a/marko-cli.js
+++ b/marko-cli.js
@@ -3,7 +3,7 @@
 const isTravis = require('is-travis');
 
 module.exports = ({ config }) => {
-    config.mochaOptions = { timeout: 10000 };
+    config.mochaOptions = { timeout: 20000 };
     config.lassoOptions = {
         flags: ['skin-ds6'],
         plugins: ['lasso-less'],

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lasso-marko": "^2.4.2",
     "lintspaces-cli": "^0.6.0",
     "marko": "^3",
-    "marko-cli": "^3.1.4",
+    "marko-cli": "3.2.0-alpha.86e5e3fd",
     "marko-dynamic-tag": "^1.0.0",
     "marko-prettyprint": "^1.4.1",
     "marko-widgets": "^6",

--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -14,25 +14,18 @@ This component will bundle different resources depending on Lasso flags provided
 Use `touch` for touch devices, and `no-touch` for non-touch devices. Without flags, `no-touch` is assumed.
 [//]: # (TODO: `touch` should ideally be default, but currently the js behavior doesn't execute with native scrolling)
 
-Note: The `touch` carousel with type="continuous" will use native scrolling. This behavior is used instead of our controlled movement, so some functionality is limited. In this case, the carousel will not respond to `index` changes, and will not emit events.
-
 ## ebay-carousel Attributes
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`type` | String | No | "continuous" (default) or "discrete"
 `accessibility-prev` | String | No | aria-label for previous control (default: "Previous Slide")
 `accessibility-next` | String | No | aria-label for next control (default: "Next Slide")
-
-### Additional Attributes for type="continuous"
-Name | Type | Stateful | Description
---- | --- | --- | ---
 `index` | String | Yes | 0-based index position
+`items-per-slide` | String | No | automatically fit a number of items for each carousel slide and enable slide controls.
+`gap` | String | No | override the margin between carousel items (default: "16px")
 
-### Additional Attributes for type="discrete"
+### Additional Attributes for when items-per-slide is set.
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`slide` | String | Yes | 1-based slide position
-`items-per-slide` | String | No | 1 - 5 -- number of items for a single carousel slide (default: 1)
 `accessibility-status` | String | No | status text (default: "Showing Slide {currentSlide} of {totalSlides} - Carousel")
 `accessibility-current` | String | No | pagination current slide text (default: "Current Slide {currentSlide} - Carousel")
 `accessibility-other` | String | No | pagination other slide text (default: "Slide {slide} - Carousel")
@@ -41,11 +34,10 @@ Name | Type | Stateful | Description
 Event | Data | Description
 --- | --- | ---
 `carousel-update` | { [visibleIndexes] } | called whenever item visibility changes, including initialization
-`carousel-move` | | start of carousel content movement animation
 `carousel-next` | { originalEvent } | click next control
 `carousel-prev` | { originalEvent } | click previous control
 
-### Additional Events for type="discrete"
+### Additional Events for when items-per-slide is set.
 Event | Data | Description
 --- | --- | ---
 `carousel-slide` | `{ slide }` | new slide is navigated to (by controls, dots, or API)

--- a/src/components/ebay-carousel/examples/2-starting-index/template.marko
+++ b/src/components/ebay-carousel/examples/2-starting-index/template.marko
@@ -10,7 +10,7 @@
         text-align: center;
     }
 </style>
-<ebay-carousel index="2">
+<ebay-carousel index="4">
     <ebay-carousel-item class="demo2-card">Card 1</ebay-carousel-item>
     <ebay-carousel-item class="demo2-card">Card 2</ebay-carousel-item>
     <ebay-carousel-item class="demo2-card">Card 3</ebay-carousel-item>

--- a/src/components/ebay-carousel/examples/5-single-item-per-slide/template.marko
+++ b/src/components/ebay-carousel/examples/5-single-item-per-slide/template.marko
@@ -9,7 +9,7 @@
         text-align: center;
     }
 </style>
-<ebay-carousel type="discrete">
+<ebay-carousel items-per-slide="1">
     <ebay-carousel-item class="demo5-card">Card 1</ebay-carousel-item>
     <ebay-carousel-item class="demo5-card">Card 2</ebay-carousel-item>
     <ebay-carousel-item class="demo5-card">Card 3</ebay-carousel-item>

--- a/src/components/ebay-carousel/examples/6-starting-slide/template.marko
+++ b/src/components/ebay-carousel/examples/6-starting-slide/template.marko
@@ -9,7 +9,7 @@
         text-align: center;
     }
 </style>
-<ebay-carousel type="discrete" slide="2">
+<ebay-carousel index="1" items-per-slide="1">
     <ebay-carousel-item class="demo6-card">Card 1</ebay-carousel-item>
     <ebay-carousel-item class="demo6-card">Card 2</ebay-carousel-item>
     <ebay-carousel-item class="demo6-card">Card 3</ebay-carousel-item>

--- a/src/components/ebay-carousel/examples/7-two-items-per-slide/template.marko
+++ b/src/components/ebay-carousel/examples/7-two-items-per-slide/template.marko
@@ -9,7 +9,7 @@
         text-align: center;
     }
 </style>
-<ebay-carousel type="discrete" items-per-slide="2">
+<ebay-carousel items-per-slide="2">
     <ebay-carousel-item class="demo7-card">Card 1</ebay-carousel-item>
     <ebay-carousel-item class="demo7-card">Card 2</ebay-carousel-item>
     <ebay-carousel-item class="demo7-card">Card 3</ebay-carousel-item>

--- a/src/components/ebay-carousel/examples/8-three-items-per-slide/template.marko
+++ b/src/components/ebay-carousel/examples/8-three-items-per-slide/template.marko
@@ -9,7 +9,7 @@
         text-align: center;
     }
 </style>
-<ebay-carousel type="discrete" items-per-slide="3">
+<ebay-carousel items-per-slide="3">
     <ebay-carousel-item class="demo8-card">Card 1</ebay-carousel-item>
     <ebay-carousel-item class="demo8-card">Card 2</ebay-carousel-item>
     <ebay-carousel-item class="demo8-card">Card 3</ebay-carousel-item>

--- a/src/components/ebay-carousel/examples/9-accessibility-text/template.marko
+++ b/src/components/ebay-carousel/examples/9-accessibility-text/template.marko
@@ -11,7 +11,7 @@
     }
 </style>
 <ebay-carousel
-    type="discrete" items-per-slide="2"
+    items-per-slide="2"
     accessibility-prev="Go to previous slide - Top Products"
     accessibility-next="Go to next slide - Top Products"
     accessibility-status="Showing slide {currentSlide} of {totalSlides} - Top Products - Carousel"

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -136,10 +136,12 @@ function onRender() {
         return;
     }
 
-    cancelAnimationFrame(this.renderFrame);
     this.renderFrame = requestAnimationFrame(() => {
-        const { items } = state;
+        const { items, slideWidth } = state;
         const { left: containerLeft, width: containerWidth } = containerEl.getBoundingClientRect();
+
+        if (slideWidth === containerWidth) return;
+
         this.setState('slideWidth', containerWidth);
         config.preserveItems = true;
 
@@ -160,7 +162,7 @@ function cleanupAsync() {
     cancelAnimationFrame(this.renderFrame);
     if (this.cancelScrollHandler) this.cancelScrollHandler();
     if (this.cancelScrollTransition) this.cancelScrollTransition();
-    this.renderFrame = this.cancelScrollHandler = this.cancelScrollTransition = undefined;
+    this.cancelScrollHandler = this.cancelScrollTransition = undefined;
 }
 
 function emitUpdate() {

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -3,335 +3,316 @@ const resizeUtil = require('../../common/event-utils').resizeUtil;
 const emitAndFire = require('../../common/emit-and-fire');
 const processHtmlAttributes = require('../../common/html-attributes');
 const observer = require('../../common/property-observer');
+const onScrollEnd = require('./utils/on-scroll-end');
+const scrollTransition = require('./utils/scroll-transition');
 const template = require('./template.marko');
 
-const constants = {
-    types: {
-        discrete: 'discrete',
-        continuous: 'continuous'
-    },
-    margin: 16 // matches the css applied to each item
-};
-
 function getInitialState(input) {
-    let items = (input.items || []).map(item => ({
-        hidden: false,
-        htmlAttributes: processHtmlAttributes(item),
-        renderBody: item.renderBody
-    }));
-    const type = input.type || constants.types.continuous;
-    const isDiscrete = type === constants.types.discrete;
-    let itemsPerSlide;
-    let totalSlides;
-
-    if (isDiscrete) {
-        itemsPerSlide = parseInt(input.itemsPerSlide) || 1;
-        totalSlides = parseInt(items.length / itemsPerSlide);
-
-        // remove trailing items that don't fit equally in slides
-        items = items.filter((item, i) => i < totalSlides * itemsPerSlide);
-    }
-
-    return {
-        index: parseInt(input.index) || 0,
-        type,
-        isContinuous: type === constants.types.continuous,
-        isDiscrete,
-        itemsPerSlide,
-        totalSlides,
-        lastIndex: items.length - 1,
-        slide: parseInt(input.slide) || 1,
-        activeDot: isDiscrete && 1,
-        prevControlDisabled: true,
-        nextControlDisabled: false,
-        bothControlsDisabled: false,
+    const state = {
+        config: {}, // A place to store values that should not trigger an update by themselves.
+        gap: input.gap || 16,
+        index: parseInt(input.index, 10) || 0,
+        classes: ['carousel', input.class],
+        itemsPerSlide: parseInt(input.itemsPerSlide, 10) || undefined,
         accessibilityPrev: input.accessibilityPrev || 'Previous Slide',
         accessibilityNext: input.accessibilityNext || 'Next Slide',
         accessibilityStatus: input.accessibilityStatus || 'Showing Slide {currentSlide} of {totalSlides} - Carousel',
         accessibilityCurrent: input.accessibilityCurrent || 'Current Slide {currentSlide} - Carousel',
         accessibilityOther: input.accessibilityOther || 'Slide {slide} - Carousel',
-        classes: ['carousel', `carousel--${type}`, isDiscrete && `carousel--discrete-${itemsPerSlide}`, input.class],
-        translation: 0,
         htmlAttributes: processHtmlAttributes(input),
-        items
+        items: (input.items || []).map(item => ({
+            htmlAttributes: processHtmlAttributes(item),
+            renderBody: item.renderBody
+        }))
     };
-}
 
-function getTemplateData(state) {
-    if (state.isDiscrete) {
-        state.statusText = state.accessibilityStatus
-            .replace('{currentSlide}', state.slide)
-            .replace('{totalSlides}', state.totalSlides);
+    // Remove any extra items when using explicit itemsPerSlide.
+    const { items, itemsPerSlide } = state;
+    if (itemsPerSlide) {
+        items.length -= items.length % itemsPerSlide;
     }
+
     return state;
 }
 
-function init() {
-    this.itemCache = [];
-    this.listEl = this.el.querySelector('.carousel__list');
-    this.itemEls = this.listEl.children;
-    this.activeIndex = 0;
-    this.firstVisibleIndex = 0;
-    this.lastVisibleIndex = 0;
+function getTemplateData(state) {
+    let { index } = state;
+    const { items, itemsPerSlide, slideWidth, gap } = state;
+    const totalItems = items.length;
+    index %= totalItems || 1; // Ensure index is within bounds.
+    index -= index % (itemsPerSlide || 1); // Round index to the nearest valid slide index.
+    index = state.index = Math.abs(index); // Ensure positive and save back to state.
+    const offset = getOffset(state);
+    const prevControlDisabled = offset === 0;
+    const nextControlDisabled = offset === getMaxOffset(state);
+    const bothControlsDisabled = prevControlDisabled && nextControlDisabled;
+    let slide, itemWidth, totalSlides, accessibilityStatus;
 
-    const containerEl = this.el.querySelector('.carousel__container');
-    this.usesNativeScroll = window.getComputedStyle && window.getComputedStyle(containerEl)['overflow-x'] === 'scroll';
-    if (this.state.isDiscrete) {
-        observer.observeRoot(this, ['slide'], () => {
-            this.simulateDotClick(this.state.slide);
-        });
-    } else if (this.state.isContinuous) {
-        observer.observeRoot(this, ['index']);
-    }
-
-    this.subscribeTo(resizeUtil).on('resize', refresh.bind(this));
-}
-
-function onRender({ firstRender }) {
-    if (firstRender) {
-        this.refresh();
+    if (itemsPerSlide) {
+        slide = Math.ceil(index / itemsPerSlide);
+        itemWidth = `calc(${100 / itemsPerSlide}% - ${(itemsPerSlide - 1) * gap / itemsPerSlide}px)`;
+        totalSlides = Math.ceil(items.length / itemsPerSlide);
+        accessibilityStatus = state.accessibilityStatus
+            .replace('{currentSlide}', slide + 1)
+            .replace('{totalSlides}', totalSlides);
     } else {
-        this.processIndexChange();
+        itemWidth = 'auto';
+    }
+
+    items.forEach((item, i) => {
+        const { htmlAttributes: { style } } = item;
+        const marginRight = i !== items.length && `${gap}px`;
+
+        // Account for users providing a style string or object for each item.
+        if (typeof style === 'string') {
+            item.style = `${style};flex-basis:${itemWidth};margin-right:${marginRight}`;
+        } else {
+            item.style = Object.assign({}, style, {
+                'flex-basis': itemWidth,
+                'margin-right': marginRight
+            });
+        }
+
+        item.fullyVisible = (
+            item.left === undefined ||
+            item.left - offset >= 0 &&
+            item.right - offset <= slideWidth
+        );
+    });
+
+    const data = Object.assign({}, state, {
+        items,
+        slide,
+        offset,
+        totalSlides,
+        accessibilityStatus,
+        prevControlDisabled,
+        nextControlDisabled,
+        bothControlsDisabled
+    });
+
+    return data;
+}
+
+function init() {
+    this.listEl = this.getEl('list');
+    this.containerEl = this.getEl('container');
+    this.subscribeTo(resizeUtil).on('resize', onRender.bind(this));
+    observer.observeRoot(this, ['index']);
+
+    if (getComputedStyle(this.listEl).getPropertyValue('overflow-x') !== 'visible') {
+        this.state.config.nativeScrolling = true;
+        this.cancelScrollHandler = onScrollEnd(this.listEl, handleScrollEnd.bind(this));
+    } else {
+        this.subscribeTo(this.listEl).on('transitionend', this.emitUpdate.bind(this));
     }
 }
 
-function onDestroy() {
-    cancelAnimationFrame(this.processMovementFrame);
-}
-
-function refresh() {
-    this.calculateWidths(true);
-    if (this.state.isDiscrete) {
-        this.simulateDotClick(this.state.slide);
+function onRender() {
+    // Stop scrolling if we were already moving.
+    if (this.cancelScrollTransition) {
+        this.cancelScrollTransition();
+        this.cancelScrollTransition = undefined;
     }
-    this.processMovement();
-}
 
-/**
- * High level function called for movement upon changing index (via UI and API)
- * Exits early if there was no actual change to index
- */
-function processIndexChange() {
-    // TODO: API manipulation is disabled in native scroll case
-    if (this.usesNativeScroll) {
+    if (this.state.config.preserveItems) {
+        // Track if we are on a normal render or a render caused by recalculating.
+        this.state.config.preserveItems = false;
+
+        // Ensure only visible items within the carousel are focusable.
+        // We don't have access to these items in the template so me must update manually.
+        forEls(this.listEl, itemEl => {
+            focusables(itemEl).forEach(itemEl.getAttribute('aria-hidden') !== 'true'
+                ? child => child.removeAttribute('tabindex')
+                : child => child.setAttribute('tabindex', '-1')
+            );
+        });
+
+        if (this.state.config.nativeScrolling) {
+            const { listEl, state } = this;
+            const offset = getOffset(state);
+            // Animate to the new scrolling position and emit update events afterward.
+            this.cancelScrollTransition = scrollTransition(listEl, offset, () => {
+                this.cancelScrollTransition = undefined;
+                this.emitUpdate();
+            });
+        }
+
         return;
     }
 
-    if (this.state.index > this.state.lastIndex) {
-        this.setState('index', this.state.lastIndex);
-    }
+    cancelAnimationFrame(this.renderFrame);
+    this.renderFrame = requestAnimationFrame(() => {
+        const { state: { items, itemsPerSlide } } = this;
+        let slideWidth = this.containerEl.offsetWidth;
+        // Accounts for partial pixel widths by adding another pixel
+        // if we cannot divide up the slides evenly.
+        if (itemsPerSlide && slideWidth % itemsPerSlide !== 0) slideWidth++;
+        this.setState('slideWidth', slideWidth);
+        this.state.config.preserveItems = true;
 
-    if (this.containerWidth >= this.allItemsWidth || this.state.index < 0) {
-        this.setState('index', 0);
-    }
-
-    const sameIndex = this.state.index === this.activeIndex;
-    const isTranslated = (this.state.index === 0 && this.state.translation === 0) || this.state.translation !== 0;
-
-    if (sameIndex && isTranslated) {
-        return;
-    }
-
-    this.activeIndex = this.state.index;
-
-    this.processMovement();
-}
-
-/**
- * Handle movement to current state.index
- */
-function processMovement() {
-    cancelAnimationFrame(this.processMovementFrame);
-    this.processMovementFrame = requestAnimationFrame(() => {
-        const oldFirstVisibleIndex = this.firstVisibleIndex;
-        const oldLastVisibleIndex = this.lastVisibleIndex;
-        this.moveToIndex(this.state.index);
-        this.lastVisibleIndex = this.calculateLastVisibleIndex();
-        this.setState('prevControlDisabled', this.state.index === 0);
-        this.setState('nextControlDisabled', this.lastVisibleIndex === this.state.lastIndex);
-        this.setState('bothControlsDisabled', this.state.prevControlDisabled && this.state.nextControlDisabled);
-
-        // must calculate firstVisibleIndex after nextControlDisabled is set
-        this.firstVisibleIndex = this.calculateFirstVisibleIndex();
-
-        if (this.state.isDiscrete) {
-            this.setState('activeDot', (this.lastVisibleIndex + 1) / this.state.itemsPerSlide);
-        }
-
-        if (this.firstVisibleIndex !== oldFirstVisibleIndex ||
-            this.lastVisibleIndex !== oldLastVisibleIndex) {
-            const visibleIndexes = [];
-            for (let i = this.firstVisibleIndex; i <= this.lastVisibleIndex; i++) {
-                visibleIndexes.push(i);
-            }
-
-            emitAndFire(this, 'carousel-update', { visibleIndexes });
-        }
-
-        this.state.items.forEach((item, i) => {
-            item.hidden = (i < this.firstVisibleIndex || i > this.lastVisibleIndex);
-        });
-        this.setStateDirty('items');
-
-        // update nested focusable elements via DOM (we don't control this content)
-        // TODO: patch makeup-focusables to support more customized selectors?
-        const hiddenItems = this.el.querySelectorAll('.carousel__list > li[aria-hidden="true"]') || [];
-        const visibleItems = this.el.querySelectorAll('.carousel__list > li[aria-hidden="false"]') || [];
-        hiddenItems.forEach(hiddenItem => {
-            focusables(hiddenItem).forEach(focusable => focusable.setAttribute('tabindex', '-1'));
-        });
-        visibleItems.forEach(visibleItem => {
-            focusables(visibleItem).forEach(focusable => focusable.removeAttribute('tabindex'));
+        // Update item positions in the dom.
+        forEls(this.listEl, (itemEl, i) => {
+            const item = items[i];
+            item.left = itemEl.offsetLeft;
+            item.right = item.left + itemEl.offsetWidth;
         });
     });
 }
 
-/**
- * Move carousel position to an index
- */
-function moveToIndex() {
-    let translation = -1 * this.getWidthBetweenIndexes(0, this.state.index);
-    const maxTranslation = -1 * (this.allItemsWidth - this.containerWidth);
-    if (translation !== 0 && translation < maxTranslation) {
-        translation = maxTranslation;
-    }
-
-    if (translation !== this.state.translation) {
-        this.setState('translation', translation);
-        emitAndFire(this, 'carousel-move');
-    }
+function onDestroy() {
+    cancelAnimationFrame(this.renderFrame);
+    if (this.cancelScrollHandler) this.cancelScrollHandler();
+    if (this.cancelScrollTransition) this.cancelScrollTransition();
 }
 
-function calculateNextIndex() {
-    return this.calculateLastVisibleIndex() + 1;
-}
-
-function calculatePrevIndex() {
-    let index = this.state.index - 1;
-
-    // check if we'll hit the left end
-    const widthBeforeCurrentIndex = this.getWidthBetweenIndexes(0, this.state.index);
-    if (widthBeforeCurrentIndex < this.containerWidth) {
-        return 0;
-    }
-
-    if (this.state.nextControlDisabled) {
-        index = this.calculateFirstVisibleIndex() - 1;
-    }
-
-    return this.widthLoop(index, -1) + 1;
-}
-
-function widthLoop(startIndex, direction) {
-    let index = startIndex;
-    let remainingWidth = this.containerWidth;
-
-    while (remainingWidth > 0) {
-        remainingWidth -= this.getItemWidth(index);
-        if (index > this.state.lastIndex || index < 0 || remainingWidth < 0) {
-            break;
-        }
-        remainingWidth -= constants.margin;
-        index += direction;
-    }
-
-    return index;
-}
-
-function calculateFirstVisibleIndex() {
-    if (!this.state.nextControlDisabled) {
-        return this.state.index;
-    }
-
-    // if continuous carousel is all the way on right end, need to calculate manually
-    return this.widthLoop(this.state.lastIndex, -1) + 1;
-}
-
-function calculateLastVisibleIndex() {
-    return this.widthLoop(this.state.index, 1) - 1;
+function emitUpdate() {
+    const { state: { items } } = this;
+    emitAndFire(this, 'carousel-update', {
+        visibleIndexes: items
+            .filter(({ fullyVisible }) => fullyVisible)
+            .map(item => items.indexOf(item))
+    });
 }
 
 /**
- * Get the aggregate width of all items in the carousel between these indexes.
- * Calculation is from left edge of item at startIndex item until left edge of item at endIndex
- * @param {Integer} startIndex
- * @param {Integer} endIndex
+ * Moves the carousel in the `data-direction` of the clicked element if possible.
+ *
+ * @param {MouseEvent} originalEvent
+ * @param {HTMLElement} target
  */
-function getWidthBetweenIndexes(startIndex, endIndex) {
-    let width = 0;
-    for (let i = startIndex; i < endIndex; i++) {
-        width += this.getItemWidth(i) + constants.margin;
-    }
-
-    // subtract trailing margin if we hit right end
-    if (endIndex > this.state.lastIndex) {
-        width -= constants.margin;
-    }
-
-    return width;
+function handleMove(originalEvent, target) {
+    const { state: { itemsPerSlide } } = this;
+    const direction = parseInt(target.getAttribute('data-direction'), 10);
+    const nextIndex = this.getNextIndex(direction);
+    const slide = itemsPerSlide && Math.ceil(nextIndex / itemsPerSlide);
+    this.state.config.preserveItems = true;
+    this.setState('index', nextIndex);
+    emitAndFire(this, 'carousel-slide', { slide: slide + 1, originalEvent });
+    emitAndFire(this, `carousel-${direction === 1 ? 'next' : 'prev'}`, { originalEvent });
 }
 
 /**
- * Calculate and store widths of container and items
- * @params {Boolean} forceUpdate: Updates the cache with new values
+ * Moves the carousel to the slide at `data-slide` for the clicked element if possible.
+ *
+ * @param {MouseEvent} originalEvent
+ * @param {HTMLElement} target
  */
-function calculateWidths(forceUpdate) {
-    this.containerWidth = this.listEl.getBoundingClientRect().width;
-    for (let i = 0; i <= this.state.lastIndex; i++) {
-        this.getItemWidth(i, forceUpdate);
-    }
-    this.allItemsWidth = this.getWidthBetweenIndexes(0, this.state.lastIndex + 1);
+function handleDotClick(originalEvent, target) {
+    const { state: { itemsPerSlide } } = this;
+    const slide = parseInt(target.getAttribute('data-slide'), 10);
+    this.state.config.preserveItems = true;
+    this.setState('index', slide * itemsPerSlide);
+    emitAndFire(this, 'carousel-slide', { slide: slide + 1, originalEvent });
 }
 
 /**
- * Get single item width based on index
- * @params {Integer} index: Index of the carousel item
- * @params {Boolean} forceUpdate: Trigger fetch update of cache values
+ * Find the closest item index to the scroll offset and triggers an update.
+ *
+ * @param {number} scrollLeft The current scroll position of the carousel.
  */
-function getItemWidth(index, forceUpdate) {
-    if (this.itemCache && this.itemCache[index] && !forceUpdate) {
-        return this.itemCache[index];
-    } else if (index >= 0 && index <= this.state.lastIndex) {
-        this.itemCache[index] = this.itemEls[index].getBoundingClientRect().width;
-        return this.itemCache[index];
+function handleScrollEnd(scrollLeft) {
+    const { state: { items } } = this;
+
+    // Find the closest item using a binary search.
+    let start = 0;
+    let end = items.length - 1;
+    let remaining;
+    let closest;
+
+    while (end - start > 1) {
+        remaining = end - start;
+        const middle = start + Math.floor(remaining / 2);
+        if (scrollLeft < items[middle].left) end = middle;
+        else start = middle;
     }
 
-    return 0;
-}
-
-function handleNext(originalEvent) {
-    if (!this.state.nextControlDisabled) {
-        if (this.state.isDiscrete) {
-            this.simulateDotClick(this.state.slide + 1);
-        } else if (this.state.isContinuous) {
-            this.setState('index', this.calculateNextIndex());
-        }
-        emitAndFire(this, 'carousel-next', { originalEvent });
+    if (remaining === 0) {
+        closest = start;
+    } else {
+        const deltaStart = Math.abs(scrollLeft - items[start].left);
+        const deltaEnd = Math.abs(scrollLeft - items[end].left);
+        closest = deltaStart < deltaEnd ? start : end;
     }
-}
 
-function handlePrev(originalEvent) {
-    if (!this.state.prevControlDisabled) {
-        if (this.state.isDiscrete) {
-            this.simulateDotClick(this.state.slide - 1);
-        } else if (this.state.isContinuous) {
-            this.setState('index', this.calculatePrevIndex());
-        }
-        emitAndFire(this, 'carousel-prev', { originalEvent });
+    const closestOffset = items[closest].left;
+    const maxOffset = getMaxOffset(this.state);
+
+    // If we are closer to the end than the closest item, then we just go to the end.
+    if (Math.abs(maxOffset - scrollLeft) < Math.abs(closestOffset - scrollLeft)) {
+        closest = items.length - 1;
     }
+
+    // Always update with the new index to ensure the scroll animations happen.
+    this.state.config.preserveItems = true;
+    this.setStateDirty('index', closest);
 }
 
-// TODO: add carousel-dot event and remove simulated dot clicks
-function handleDotClick(e) {
-    const newSlide = parseInt(e.target.getAttribute('data-slide'));
-    emitAndFire(this, 'carousel-slide', { slide: newSlide });
-    this.setState('slide', newSlide);
-    this.setState('index', (this.state.itemsPerSlide * (newSlide - 1)));
+/**
+ * Given the current widget state, finds the active offset left of the selected item.
+ * Also automatically caps the offset at the max offset.
+ *
+ * @param {object} state The widget state.
+ * @return {number}
+ */
+function getOffset(state) {
+    const { items, index } = state;
+    if (!items.length) return 0;
+    return Math.min(items[index].left, getMaxOffset(state));
 }
 
-function simulateDotClick(slide) {
-    if (slide >= 1 && slide <= this.state.totalSlides) {
-        this.el.querySelector(`[data-slide="${slide}"]`).click();
+/**
+ * Given the current widget state, finds the last valid offset.
+ *
+ * @param {object} state The widget state.
+ * @return {number}
+ */
+function getMaxOffset(state) {
+    const { items, slideWidth } = state;
+    if (!items.length) return 0;
+    return Math.max(items[items.length - 1].right - slideWidth, 0);
+}
+
+/**
+ * Calculates the next valid index in a direction.
+ *
+ * @param {-1|1} delta 1 for right and -1 for left.
+ * @return {number}
+ */
+function getNextIndex(delta) {
+    const { state: { index, items, slideWidth } } = this;
+    const RIGHT = 1;
+    const LEFT = -1;
+    let i = index;
+    let item;
+
+    // If going backward from 0, we go to the end.
+    if (delta === LEFT && i === 0) return items.length - 1;
+
+    // Find the index of the next item that is not fully in view.
+    do item = items[i += delta]; while (item && item.fullyVisible);
+
+    // If going right, then we just want the next item not fully in view.
+    if (delta === RIGHT) return i % items.length;
+
+    // If going left, go as far left as possible while keeping this item fully in view.
+    const targetOffset = item.right - slideWidth;
+    do item = items[--i]; while (item && item.left >= targetOffset);
+    return i + 1;
+}
+
+/**
+ * Calls a function on each element within a parent element.
+ *
+ * @param {HTMLElement} parent The parent to walk through.
+ * @param {(el: HTMLElement, i: number) => any} fn The function to call.
+ */
+function forEls(parent, fn) {
+    let i = 0;
+    let child = parent.firstElementChild;
+    while (child) {
+        fn(child, i++);
+        child = child.nextElementSibling;
     }
 }
 
@@ -342,22 +323,8 @@ module.exports = require('marko-widgets').defineComponent({
     init,
     onRender,
     onDestroy,
-    refresh,
-    processIndexChange,
-    processMovement,
-    calculateNextIndex,
-    calculatePrevIndex,
-    moveToIndex,
-    widthLoop,
-    calculateFirstVisibleIndex,
-    calculateLastVisibleIndex,
-    getWidthBetweenIndexes,
-    calculateWidths,
-    getItemWidth,
-    handleNext,
-    handlePrev,
+    emitUpdate,
+    handleMove,
     handleDotClick,
-    simulateDotClick
+    getNextIndex
 });
-
-module.exports.privates = { constants };

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -160,7 +160,7 @@ function onRender() {
     });
 }
 
-function onDestroy() {
+function onBeforeDestroy() {
     cancelAnimationFrame(this.renderFrame);
     if (this.cancelScrollHandler) this.cancelScrollHandler();
     if (this.cancelScrollTransition) this.cancelScrollTransition();
@@ -322,7 +322,7 @@ module.exports = require('marko-widgets').defineComponent({
     getTemplateData,
     init,
     onRender,
-    onDestroy,
+    onBeforeDestroy,
     emitUpdate,
     handleMove,
     handleDotClick,

--- a/src/components/ebay-carousel/style-no-touch.less
+++ b/src/components/ebay-carousel/style-no-touch.less
@@ -24,12 +24,10 @@
         }
     }
 
-    &--continuous {
-        // hide controls if both are disabled
-        .carousel__container--controls-disabled .carousel__control,
-        &:hover .carousel__container--controls-disabled .carousel__control[aria-disabled="true"] {
-            opacity: 0;
-            pointer-events: none;
-        }
+    // hide controls if both are disabled
+    .carousel__container--controls-disabled .carousel__control,
+    &:hover .carousel__container--controls-disabled .carousel__control[aria-disabled="true"] {
+        opacity: 0;
+        pointer-events: none;
     }
 }

--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -9,22 +9,24 @@
         }
     }
 
-    &--continuous &__container {
-        overflow-x: scroll; // also used in js to determine scroll behavior
+    &__list {
+        overflow-x: auto; // also used in js to determine scroll behavior
         -webkit-overflow-scrolling: touch;
+        -ms-overflow-style: none;
+
+        &::-webkit-scrollbar {
+            display: none;
+        }
     }
 
-    &--discrete {
-        // show controls on touch since there's no hover
-        // TODO: swipe support on mobile discrete?
-        .carousel__control {
-            opacity: @ebay-carousel-control-enabled-opacity;
-            pointer-events: auto;
+    // show controls on touch since there's no hover
+    .carousel__control {
+        opacity: @ebay-carousel-control-enabled-opacity;
+        pointer-events: auto;
 
-            &[aria-disabled="true"] {
-                opacity: @ebay-carousel-control-disabled-opacity;
-                cursor: default;
-            }
+        &[aria-disabled="true"] {
+            opacity: @ebay-carousel-control-disabled-opacity;
+            cursor: default;
         }
     }
 }

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -15,20 +15,18 @@
 
     &__list {
         transition: transform @ebay-carousel-transition-time @ebay-carousel-transition-function;
-        transform: translateX(0);
+        will-change: transform; // Ensures that the list is on a new layer for better scrolling perf.
+        transform: translate3d(0,0,0); // Same as above, but for backward compatibility to (ie10).
+        display: flex;
         position: relative;
-        box-sizing: border-box;
         width: 100%;
         margin: 0;
         padding: 0;
 
         > li {
+            flex-grow: 0;
+            flex-shrink: 0;
             list-style: none;
-            margin-right: 16px;
-
-            &:last-of-type {
-                margin-right: 0;
-            }
         }
     }
 
@@ -69,48 +67,6 @@
         }
     }
 
-    &--continuous {
-        .carousel__list {
-            display: inline-block;
-
-            > li {
-                display: inline-block;
-            }
-        }
-    }
-
-    &--discrete {
-        .carousel__list {
-            display: flex;
-
-            // avoid flex shorthand due to ie11 bugs
-            > li {
-                flex-grow: 0;
-                flex-shrink: 0;
-            }
-        }
-
-        &-1 .carousel__list > li {
-            flex-basis: 100%;
-        }
-
-        &-2 .carousel__list > li {
-            flex-basis: calc(50% ~"-" 8px);
-        }
-
-        &-3 .carousel__list > li {
-            flex-basis: calc(33.333% ~"-" 10.666px);
-        }
-
-        &-4 .carousel__list > li {
-            flex-basis: calc(25% ~"-" 12px);
-        }
-
-        &-5 .carousel__list > li {
-            flex-basis: calc(20% ~"-" 16px);
-        }
-    }
-
     &__dots {
         margin: 8px 0;
         padding-left: 0;
@@ -120,8 +76,7 @@
             display: inline-block;
 
             > button {
-                transition: background-color @ebay-carousel-transition-time @ebay-carousel-transition-function;
-                background-color: @ds6-color-g204-gray;
+                background-color: @ds6-color-g206-gray;
                 cursor: pointer;
                 border: 0;
                 border-radius: 50%;
@@ -130,9 +85,23 @@
                 padding: 0;
                 height: 8px;
                 width: 8px;
+                overflow: hidden;
 
-                &.carousel__dot--active {
-                    background-color: @ds6-color-g206-gray;
+                // The active dot uses an after to color it in which transitions opacity.
+                // This was done to avoid transitioning the background color of the element
+                // while still allowing us to use exact ds colors.
+                &::after {
+                    transition: opacity @ebay-carousel-transition-time @ebay-carousel-transition-function;
+                    content: "";
+                    display: block;
+                    width: 100%;
+                    height: 100%;
+                    opacity: 1;
+                    background-color: @ds6-color-g204-gray;
+                }
+
+                &.carousel__dot--active::after {
+                    opacity: 0;
                 }
             }
         }

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -24,6 +24,7 @@
         padding: 0;
 
         > li {
+            display: inline-block;
             flex-grow: 0;
             flex-shrink: 0;
             list-style: none;

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -1,48 +1,56 @@
 <div class=data.classes w-bind ${data.htmlAttributes}>
+    <var config=data.config/>
     <var statusId=("carousel-status-" + widget.id)/>
-    <div class=("carousel__container" + (data.bothControlsDisabled ? " carousel__container--controls-disabled" : ""))>
+    <div w-id="container" class=["carousel__container", data.bothControlsDisabled && "carousel__container--controls-disabled"]>
         <span
-            if(data.isDiscrete)
+            if(data.totalSlides >= 1)
             id=statusId
             class="clipped"
             role="status"
             aria-live="polite">
-            ${data.statusText}
+            ${data.accessibilityStatus}
         </span>
-        <button
-            class="carousel__control carousel__control--prev"
-            w-onclick="handlePrev"
+        <button class="carousel__control carousel__control--prev"
+            w-onclick=(!data.prevControlDisabled && "handleMove")
+            data-direction=-1
             aria-describedby=statusId
             aria-label=data.accessibilityPrev
-            aria-disabled=String(data.prevControlDisabled)>
+            aria-disabled=(data.prevControlDisabled && 'true')>
             <ebay-icon type="inline" name="chevron-left"/>
         </button>
-        <ul class="carousel__list" style=("transform: translateX(" + data.translation + "px)")>
-            <for(item in data.items | status-var=loop)>
+        <ul w-id="list"
+            class="carousel__list"
+            style={transform: !config.nativeScrolling && "translate3d(-" + data.offset + "px,0,0)"}>
+            <for(index, item in data.items)>
                 <li ${item.htmlAttributes}
+                    style=item.style
                     w-body=item.renderBody
-                    aria-hidden=String(item.hidden)/>
+                    aria-hidden=(!item.fullyVisible && 'true')
+                    w-preserve-body-if(config.preserveItems)/>
             </for>
         </ul>
         <button
             class="carousel__control carousel__control--next"
-            w-onclick="handleNext"
+            w-onclick=(!data.nextControlDisabled && "handleMove")
+            data-direction=1
             aria-describedby=statusId
             aria-label=data.accessibilityNext
-            aria-disabled=String(data.nextControlDisabled)>
+            aria-disabled=(data.nextControlDisabled && 'true')>
             <ebay-icon type="inline" name="chevron-right"/>
         </button>
     </div>
-    <ul if(data.isDiscrete) class="carousel__dots" role="navigation">
-        <li for(i from 1 to data.totalSlides)>
+    <ul class="carousel__dots" role="navigation" if(data.totalSlides > 1)>
+        <li for(i from 0 to data.totalSlides - 1)>
+            <var isActive=(i === data.slide)/>
             <button
-                class=(i === data.activeDot ? "carousel__dot--active" : "")
-                w-onclick="handleDotClick"
+                class={"carousel__dot--active": isActive}
+                w-onclick=(!isActive && "handleDotClick")
                 data-slide=i
                 aria-describedby=statusId
-                aria-label=(i === data.activeDot ?
-                    data.accessibilityCurrent.replace('{currentSlide}', i) :
-                    data.accessibilityOther.replace('{slide}', i))/>
+                aria-disabled=(isActive && 'true')
+                aria-label=(isActive ?
+                    data.accessibilityCurrent.replace('{currentSlide}', i + 1) :
+                    data.accessibilityOther.replace('{slide}', i + 1))/>
         </li>
     </ul>
 </div>

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -35,9 +35,10 @@ describe('given the carousel is in the default state', () => {
     let widget;
     let root;
 
-    beforeEach(() => {
+    beforeEach((done) => {
         widget = renderer.renderSync().appendTo(document.body).getWidget();
         root = document.querySelector('.carousel');
+        delay(done);
     });
     afterEach(() => widget.destroy());
 

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -3,10 +3,10 @@ const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/browser');
 const mock = require('../mock');
 const renderer = require('../');
-
-const privates = renderer.privates;
-const constants = privates.constants;
-const containerWidth = 800; // puppeteer default
+const styleOverrides = document.createElement('style');
+// No need to run the full length animation when testing the carousel.
+styleOverrides.innerHTML = `.carousel__list { transition: transform 0.05s linear; }`;
+document.head.appendChild(styleOverrides);
 
 // wait until after marko processing and requestAnimationFrame execution
 function delay(callback) {
@@ -16,6 +16,19 @@ function delay(callback) {
 function testControlEvent(spy) {
     expect(spy.calledOnce).to.equal(true);
     testUtils.testOriginalEvent(spy);
+}
+
+function getVisibleIndexes(items) {
+    const visibleIndexes = [];
+    items.forEach((item, i) => {
+        if (item.fullyVisible) visibleIndexes.push(i);
+    });
+
+    return visibleIndexes;
+}
+
+function getTranslateX(el) {
+    return parseInt(el.style.transform.match(/translate3d\(-?(\d+)/)[1], 10);
 }
 
 describe('given the carousel is in the default state', () => {
@@ -30,7 +43,7 @@ describe('given the carousel is in the default state', () => {
 
     describe('when it is rendered', () => {
         it('then it sets state to correct defaults', () => {
-            expect(widget.state.type).to.equal('continuous');
+            expect(widget.state.gap).to.equal(16);
         });
 
         it('then it exposes state on root element', () => {
@@ -66,11 +79,7 @@ describe('given the carousel starts in the default state with items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             root.index = 1;
-            delay(done);
-        });
-
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it emits the marko update event', () => {
@@ -80,13 +89,14 @@ describe('given the carousel starts in the default state with items', () => {
         });
 
         it('then it applies a translation', () => {
-            const translation = mock.itemWidth + constants.margin;
-            expect(list.style.transform).to.equal(`translateX(-${translation}px)`);
+            const { offsetLeft } = list.children[1];
+            expect(getTranslateX(list)).to.equal(offsetLeft);
         });
 
         it('then it calculates item visibility correctly', () => {
-            expect(widget.firstVisibleIndex).to.equal(1);
-            expect(widget.lastVisibleIndex).to.equal(3);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([1, 2, 3]);
         });
     });
 
@@ -100,11 +110,7 @@ describe('given the carousel starts in the default state with items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             widget.setState('index', 1);
-            delay(done);
-        });
-
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it emits the marko update event', () => {
@@ -114,13 +120,14 @@ describe('given the carousel starts in the default state with items', () => {
         });
 
         it('then it applies a translation', () => {
-            const translation = mock.itemWidth + constants.margin;
-            expect(list.style.transform).to.equal(`translateX(-${translation}px)`);
+            const { offsetLeft } = list.children[1];
+            expect(getTranslateX(list)).to.equal(offsetLeft);
         });
 
         it('then it calculates item visibility correctly', () => {
-            expect(widget.firstVisibleIndex).to.equal(1);
-            expect(widget.lastVisibleIndex).to.equal(3);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([1, 2, 3]);
         });
     });
 
@@ -150,14 +157,10 @@ describe('given the carousel starts in the default state with items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            delay(done);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it emits the marko next event', () => testControlEvent(nextSpy));
-
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
-        });
 
         it('then it emits the marko update event', () => {
             expect(updateSpy.calledOnce).to.equal(true);
@@ -166,12 +169,13 @@ describe('given the carousel starts in the default state with items', () => {
         });
 
         it('then it applies a translation', () => {
-            expect(list.style.transform).to.equal('translateX(-480px)');
+            expect(getTranslateX(list)).to.equal(480);
         });
 
         it('then it calculates item visibility correctly', () => {
-            expect(widget.firstVisibleIndex).to.equal(3);
-            expect(widget.lastVisibleIndex).to.equal(5);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([3, 4, 5]);
         });
     });
 
@@ -184,16 +188,15 @@ describe('given the carousel starts in the default state with items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             root.index = -1;
-            delay(done);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
-        it('then index is normalized to 0', () => {
-            expect(root.index).to.equal(0);
+        it('then index is normalized to the next index', () => {
+            expect(root.index).to.equal(1);
         });
 
-        it('then it does not emit the marko events', () => {
-            expect(moveSpy.called).to.equal(false);
-            expect(updateSpy.called).to.equal(false);
+        it('then it emits the marko events', () => {
+            expect(updateSpy.called).to.equal(true);
         });
     });
 
@@ -205,31 +208,16 @@ describe('given the carousel starts in the default state with items', () => {
             updateSpy = sinon.spy();
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
-            root.index = 99;
+            root.index = 6;
             delay(done);
         });
 
-        it('then index is normalized to lastIndex', () => {
-            expect(root.index).to.equal(widget.state.lastIndex);
+        it('then index is normalized to the next index', () => {
+            expect(root.index).to.equal(0);
         });
 
-        it('then it emits the marko events', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
-            expect(updateSpy.calledOnce).to.equal(true);
-        });
-    });
-
-    describe('when the window is resized', () => {
-        let spy;
-        beforeEach(done => {
-            spy = sinon.spy(widget, 'calculateWidths');
-            testUtils.triggerEvent(window, 'resize');
-            delay(done);
-        });
-        afterEach(() => widget.calculateWidths.restore());
-
-        it('then it executes the calculateWidths', () => {
-            expect(spy.calledOnce).to.equal(true);
+        it('then it does not emit the marko events', () => {
+            expect(updateSpy.calledOnce).to.equal(false);
         });
     });
 });
@@ -250,8 +238,8 @@ describe('given a continuous carousel has next button clicked', () => {
         prevButton = root.querySelector('.carousel__control--prev');
         delay(() => {
             testUtils.triggerEvent(nextButton, 'click');
-            delay(() => {
-                expect(list.style.transform).to.equal('translateX(-480px)');
+            widget.subscribeTo(list).once('transitionend', () => {
+                expect(getTranslateX(list)).to.equal(480);
                 done();
             });
         });
@@ -270,14 +258,10 @@ describe('given a continuous carousel has next button clicked', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(prevButton, 'click');
-            delay(done);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it emits the marko prev event', () => testControlEvent(prevSpy));
-
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
-        });
 
         it('then it emits the marko update event', () => {
             expect(updateSpy.calledOnce).to.equal(true);
@@ -286,7 +270,7 @@ describe('given a continuous carousel has next button clicked', () => {
         });
 
         it('then it applies a translation back to 0', () => {
-            expect(list.style.transform).to.equal('translateX(0px)');
+            expect(getTranslateX(list)).to.equal(0);
         });
     });
 
@@ -305,9 +289,8 @@ describe('given a continuous carousel has next button clicked', () => {
             delay(done);
         });
 
-        it('then it does not emits the marko events', () => {
+        it('then it does not emit the marko events', () => {
             expect(nextSpy.called).to.equal(false);
-            expect(moveSpy.called).to.equal(false);
             expect(updateSpy.called).to.equal(false);
         });
     });
@@ -331,7 +314,7 @@ describe('given a continuous carousel with few items', () => {
         let moveSpy;
         let updateSpy;
         beforeEach(() => {
-            expect(list.style.transform).to.equal(`translateX(0px)`);
+            expect(getTranslateX(list)).to.equal(0);
             moveSpy = sinon.spy();
             updateSpy = sinon.spy();
             widget.on('carousel-move', moveSpy);
@@ -340,7 +323,6 @@ describe('given a continuous carousel with few items', () => {
         });
 
         it('then it does not emit the marko events', () => {
-            expect(moveSpy.called).to.equal(false);
             expect(updateSpy.called).to.equal(false);
         });
     });
@@ -350,12 +332,14 @@ describe('given a continuous carousel with many items', () => {
     const input = { items: mock.twelveItems };
     let widget;
     let root;
+    let list;
     let prevButton;
     let nextButton;
 
     beforeEach(done => {
         widget = renderer.renderSync(input).appendTo(document.body).getWidget();
         root = document.querySelector('.carousel');
+        list = root.querySelector('.carousel__list');
         prevButton = root.querySelector('.carousel__control--prev');
         nextButton = root.querySelector('.carousel__control--next');
         delay(done);
@@ -367,6 +351,7 @@ describe('given a continuous carousel with many items', () => {
         let moveSpy;
         let updateSpy;
         beforeEach(done => {
+            const listSub = widget.subscribeTo(list);
             nextSpy = sinon.spy();
             moveSpy = sinon.spy();
             updateSpy = sinon.spy();
@@ -374,24 +359,24 @@ describe('given a continuous carousel with many items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            delay(() => {
+            listSub.once('transitionend', () => {
                 testUtils.triggerEvent(nextButton, 'click');
-                delay(() => {
+                listSub.once('transitionend', () => {
                     testUtils.triggerEvent(nextButton, 'click');
-                    delay(done);
+                    listSub.once('transitionend', done);
                 });
             });
         });
 
         it('then it emits the marko events', () => {
             expect(nextSpy.callCount).to.equal(3);
-            expect(moveSpy.callCount).to.equal(3);
             expect(updateSpy.callCount).to.equal(3);
         });
 
         it('then the last item is visible', () => {
-            expect(widget.firstVisibleIndex).to.equal(9);
-            expect(widget.lastVisibleIndex).to.equal(mock.twelveItems.length - 1);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([9, 10, 11]);
         });
     });
 
@@ -401,6 +386,7 @@ describe('given a continuous carousel with many items', () => {
         let moveSpy;
         let updateSpy;
         beforeEach(done => {
+            const listSub = widget.subscribeTo(list);
             prevSpy = sinon.spy();
             nextSpy = sinon.spy();
             moveSpy = sinon.spy();
@@ -410,13 +396,13 @@ describe('given a continuous carousel with many items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            delay(() => {
+            listSub.once('transitionend', () => {
                 testUtils.triggerEvent(nextButton, 'click');
-                delay(() => {
+                listSub.once('transitionend', () => {
                     testUtils.triggerEvent(nextButton, 'click');
-                    delay(() => {
+                    listSub.once('transitionend', () => {
                         testUtils.triggerEvent(prevButton, 'click');
-                        delay(done);
+                        listSub.once('transitionend', done);
                     });
                 });
             });
@@ -425,14 +411,14 @@ describe('given a continuous carousel with many items', () => {
         it('then it emits the marko events', () => {
             expect(prevSpy.callCount).to.equal(1);
             expect(nextSpy.callCount).to.equal(3);
-            expect(moveSpy.callCount).to.equal(4);
             expect(updateSpy.callCount).to.equal(4);
         });
 
         it('then it moves to the correct index', () => {
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
             expect(root.index).to.equal(6);
-            expect(widget.firstVisibleIndex).to.equal(6);
-            expect(widget.lastVisibleIndex).to.equal(8);
+            expect(visibleIndexes).to.deep.equal([6, 7, 8]);
         });
     });
 
@@ -442,6 +428,7 @@ describe('given a continuous carousel with many items', () => {
         let moveSpy;
         let updateSpy;
         beforeEach(done => {
+            const listSub = widget.subscribeTo(list);
             prevSpy = sinon.spy();
             nextSpy = sinon.spy();
             moveSpy = sinon.spy();
@@ -451,11 +438,11 @@ describe('given a continuous carousel with many items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            delay(() => {
+            listSub.once('transitionend', () => {
                 testUtils.triggerEvent(nextButton, 'click');
-                delay(() => {
+                listSub.once('transitionend', () => {
                     testUtils.triggerEvent(prevButton, 'click');
-                    delay(done);
+                    listSub.once('transitionend', done);
                 });
             });
         });
@@ -463,7 +450,6 @@ describe('given a continuous carousel with many items', () => {
         it('then it emits the marko events', () => {
             expect(prevSpy.callCount).to.equal(1);
             expect(nextSpy.callCount).to.equal(2);
-            expect(moveSpy.callCount).to.equal(3);
             expect(updateSpy.callCount).to.equal(3);
         });
 
@@ -474,7 +460,7 @@ describe('given a continuous carousel with many items', () => {
 });
 
 describe('given a discrete carousel', () => {
-    const input = { type: 'discrete', items: mock.threeItems };
+    const input = { items: mock.threeItems, itemsPerSlide: 1 };
     let widget;
     let root;
     let list;
@@ -504,7 +490,7 @@ describe('given a discrete carousel', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            delay(done);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it emits the marko next event', () => testControlEvent(nextSpy));
@@ -515,10 +501,6 @@ describe('given a discrete carousel', () => {
             expect(eventData.slide).to.equal(2);
         });
 
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
-        });
-
         it('then it emits the marko update event', () => {
             expect(updateSpy.calledOnce).to.equal(true);
             const eventData = updateSpy.getCall(0).args[0];
@@ -526,32 +508,34 @@ describe('given a discrete carousel', () => {
         });
 
         it('then it applies a translation', () => {
-            expect(list.style.transform).to.equal(`translateX(-${containerWidth + constants.margin}px)`);
+            const { offsetLeft } = list.children[1];
+            expect(getTranslateX(list)).to.equal(offsetLeft);
         });
 
         it('then it calculates item visibility correctly', () => {
-            expect(widget.firstVisibleIndex).to.equal(1);
-            expect(widget.lastVisibleIndex).to.equal(1);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([1]);
         });
     });
 
     describe('when the window is resized', () => {
-        let spy;
+        let originalFrame;
+
         beforeEach(done => {
-            spy = sinon.spy(widget, 'calculateWidths');
+            originalFrame = widget.renderFrame;
             testUtils.triggerEvent(window, 'resize');
             delay(done);
         });
-        afterEach(() => widget.calculateWidths.restore());
 
-        it('then it executes the calculateWidths', () => {
-            expect(spy.calledOnce).to.equal(true);
+        it('then it causes the widget to render', () => {
+            expect(widget.renderFrame).to.not.equal(originalFrame);
         });
     });
 });
 
 describe('given a discrete carousel has next button clicked', () => {
-    const input = { type: 'discrete', items: mock.threeItems };
+    const input = { items: mock.threeItems, itemsPerSlide: 1 };
     let widget;
     let root;
     let list;
@@ -566,8 +550,9 @@ describe('given a discrete carousel has next button clicked', () => {
         prevButton = root.querySelector('.carousel__control--prev');
         delay(() => {
             testUtils.triggerEvent(nextButton, 'click');
-            delay(() => {
-                expect(list.style.transform).to.equal(`translateX(-${containerWidth + constants.margin}px)`);
+            widget.subscribeTo(list).once('transitionend', () => {
+                const { offsetLeft } = list.children[1];
+                expect(getTranslateX(list)).to.equal(offsetLeft);
                 done();
             });
         });
@@ -589,7 +574,7 @@ describe('given a discrete carousel has next button clicked', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(prevButton, 'click');
-            delay(done);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it emits the marko prev event', () => testControlEvent(prevSpy));
@@ -600,10 +585,6 @@ describe('given a discrete carousel has next button clicked', () => {
             expect(eventData.slide).to.equal(1);
         });
 
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
-        });
-
         it('then it emits the marko update event', () => {
             expect(updateSpy.calledOnce).to.equal(true);
             const eventData = updateSpy.getCall(0).args[0];
@@ -611,18 +592,19 @@ describe('given a discrete carousel has next button clicked', () => {
         });
 
         it('then it applies a translation back to 0', () => {
-            expect(list.style.transform).to.equal('translateX(0px)');
+            expect(getTranslateX(list)).to.equal(0);
         });
 
         it('then it calculates item visibility correctly', () => {
-            expect(widget.firstVisibleIndex).to.equal(0);
-            expect(widget.lastVisibleIndex).to.equal(0);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([0]);
         });
     });
 });
 
 describe('given a discrete carousel with half width items', () => {
-    const input = { type: 'discrete', itemsPerSlide: 2, items: mock.sixItems };
+    const input = { itemsPerSlide: 2, items: mock.sixItems };
     let widget;
     let root;
     let list;
@@ -634,7 +616,7 @@ describe('given a discrete carousel with half width items', () => {
         root = document.querySelector('.carousel');
         list = root.querySelector('.carousel__list');
         nextButton = root.querySelector('.carousel__control--next');
-        nextSlideDot = root.querySelector('[data-slide="2"]');
+        nextSlideDot = root.querySelector('[data-slide="1"]');
         delay(done);
     });
     afterEach(() => widget.destroy());
@@ -654,7 +636,7 @@ describe('given a discrete carousel with half width items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            delay(done);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it emits the marko next event', () => testControlEvent(nextSpy));
@@ -665,10 +647,6 @@ describe('given a discrete carousel with half width items', () => {
             expect(eventData.slide).to.equal(2);
         });
 
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
-        });
-
         it('then it emits the marko update event', () => {
             expect(updateSpy.calledOnce).to.equal(true);
             const eventData = updateSpy.getCall(0).args[0];
@@ -676,12 +654,14 @@ describe('given a discrete carousel with half width items', () => {
         });
 
         it('then it applies a translation', () => {
-            expect(list.style.transform).to.equal(`translateX(-${containerWidth + constants.margin}px)`);
+            const { offsetLeft } = list.children[2];
+            expect(getTranslateX(list)).to.equal(offsetLeft);
         });
 
         it('then it calculates item visibility correctly', () => {
-            expect(widget.firstVisibleIndex).to.equal(2);
-            expect(widget.lastVisibleIndex).to.equal(3);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([2, 3]);
         });
     });
 
@@ -700,7 +680,7 @@ describe('given a discrete carousel with half width items', () => {
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextSlideDot, 'click');
-            delay(done);
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it does not emit the marko next event', () => {
@@ -713,10 +693,6 @@ describe('given a discrete carousel with half width items', () => {
             expect(eventData.slide).to.equal(2);
         });
 
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
-        });
-
         it('then it emits the marko update event', () => {
             expect(updateSpy.calledOnce).to.equal(true);
             const eventData = updateSpy.getCall(0).args[0];
@@ -724,16 +700,18 @@ describe('given a discrete carousel with half width items', () => {
         });
 
         it('then it applies a translation', () => {
-            expect(list.style.transform).to.equal(`translateX(-${containerWidth + constants.margin}px)`);
+            const { offsetLeft } = list.children[2];
+            expect(getTranslateX(list)).to.equal(offsetLeft);
         });
 
         it('then it calculates item visibility correctly', () => {
-            expect(widget.firstVisibleIndex).to.equal(2);
-            expect(widget.lastVisibleIndex).to.equal(3);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([2, 3]);
         });
     });
 
-    describe('when slide is updated programmatically', () => {
+    describe('when index is updated programmatically', () => {
         let nextSpy;
         let slideSpy;
         let moveSpy;
@@ -747,37 +725,33 @@ describe('given a discrete carousel with half width items', () => {
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-move', moveSpy);
             widget.on('carousel-update', updateSpy);
-            root.slide = 2;
-            delay(done);
+            root.index = 4;
+            widget.subscribeTo(list).once('transitionend', done);
         });
 
         it('then it does not emit the marko next event', () => {
             expect(nextSpy.called).to.equal(false);
         });
 
-        it('then it emits the marko slide event', () => {
-            expect(slideSpy.calledOnce).to.equal(true);
-            const eventData = slideSpy.getCall(0).args[0];
-            expect(eventData.slide).to.equal(2);
-        });
-
-        it('then it emits the marko move event', () => {
-            expect(moveSpy.calledOnce).to.equal(true);
+        it('then it does not emit the marko slide event', () => {
+            expect(slideSpy.calledOnce).to.equal(false);
         });
 
         it('then it emits the marko update event', () => {
             expect(updateSpy.calledOnce).to.equal(true);
             const eventData = updateSpy.getCall(0).args[0];
-            expect(eventData.visibleIndexes).to.deep.equal([2, 3]);
+            expect(eventData.visibleIndexes).to.deep.equal([4, 5]);
         });
 
         it('then it applies a translation', () => {
-            expect(list.style.transform).to.equal(`translateX(-${containerWidth + constants.margin}px)`);
+            const { offsetLeft } = list.children[4];
+            expect(getTranslateX(list)).to.equal(offsetLeft);
         });
 
         it('then it calculates item visibility correctly', () => {
-            expect(widget.firstVisibleIndex).to.equal(2);
-            expect(widget.lastVisibleIndex).to.equal(3);
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([4, 5]);
         });
     });
 });

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -6,18 +6,18 @@ describe('carousel', () => {
     test('renders basic version', context => {
         const input = { items: mock.sixItems };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('.carousel.carousel--continuous').length).to.equal(1);
+        expect($('.carousel').length).to.equal(1);
         expect($('.carousel__control--prev').length).to.equal(1);
         expect($('.carousel__control--next').length).to.equal(1);
         expect($('ul.carousel__list').length).to.equal(1);
         expect($('ul.carousel__list > li').length).to.equal(mock.sixItems.length);
-        expect($('ul.carousel__list > li[aria-hidden=false]').length).to.equal(mock.sixItems.length);
+        expect($('ul.carousel__list > li:not([aria-hidden="true"])').length).to.equal(mock.sixItems.length);
     });
 
     test('renders accessibility text', context => {
         const input = {
-            type: 'discrete',
             items: mock.sixItems,
+            itemsPerSlide: 1,
             accessibilityPrev: 'prev',
             accessibilityNext: 'next',
             accessibilityStatus: '{currentSlide} of {totalSlides}',
@@ -28,8 +28,8 @@ describe('carousel', () => {
         expect($('.carousel__control--prev[aria-label="prev"]').length).to.equal(1);
         expect($('.carousel__control--next[aria-label="next"]').length).to.equal(1);
         expect($('.clipped[role="status"]').text()).to.equal('1 of 6');
-        expect($('[data-slide="1"][aria-label="slide 1"]').length).to.equal(1);
-        expect($('[data-slide="2"][aria-label="other 2"]').length).to.equal(1);
+        expect($('[data-slide="0"][aria-label="slide 1"]').length).to.equal(1);
+        expect($('[data-slide="1"][aria-label="other 2"]').length).to.equal(1);
     });
 
     test('handles pass-through html attributes', context => {

--- a/src/components/ebay-carousel/utils/on-scroll-end/index.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/index.js
@@ -1,0 +1,77 @@
+/**
+ * Calls a function every time scrolling completes for an element.
+ * Returns a function to stop listening for scroll ends events.
+ *
+ * (Only works in mobile and relies on touch events)
+ *
+ * @param {HTMLElement} el The element which scrolls.
+ * @param {(offset: number)=>{}} fn The function to call after scrolling completes.
+ * @return {function} A function to cancel the scroll listener.
+ */
+module.exports = function onScrollEnd(el, fn) {
+    let frame;
+    let stage = 0;
+    el.addEventListener('touchmove', handleTouchMove);
+
+    return cancel;
+
+    // First we wait for a touch move (means scrolling as started).
+    function handleTouchMove() {
+        stage++;
+        cancelTouchMove();
+        el.addEventListener('touchend', handleTouchEnd);
+    }
+
+    // Then we wait for the touch to end (user has stopped scrolling).
+    function handleTouchEnd() {
+        stage++;
+        cancelTouchEnd();
+        el.addEventListener('touchstart', handleTouchStart);
+        frame = requestAnimationFrame(() => checkScrollEnded(el.scrollLeft));
+    }
+
+    // If the user touches again before the inertial scrolling has stopped then we reset.
+    function handleTouchStart() {
+        cancel();
+        stage = 0;
+        el.addEventListener('touchmove', handleTouchMove);
+    }
+
+    // Finally after the touch end we poll the scroll state every animation frame
+    // to determine when inertial scrolling has stopped.
+    function checkScrollEnded(lastOffset) {
+        frame = requestAnimationFrame(() => {
+            const newOffset = el.scrollLeft;
+            if (lastOffset !== newOffset) {
+                checkScrollEnded(newOffset);
+            } else {
+                cancelTouchStart();
+                fn(newOffset);
+                stage = 0;
+                el.addEventListener('touchmove', handleTouchMove);
+            }
+        });
+    }
+
+    function cancelTouchMove() {
+        el.removeEventListener('touchmove', handleTouchMove);
+    }
+
+    function cancelTouchEnd() {
+        el.removeEventListener('touchend', handleTouchEnd);
+    }
+
+    function cancelTouchStart() {
+        el.removeEventListener('touchstart', handleTouchStart);
+    }
+
+    function cancel() {
+        cancelAnimationFrame(frame);
+
+        switch (stage) {
+            case 0: cancelTouchMove(); break;
+            case 1: cancelTouchEnd(); break;
+            default: cancelTouchStart(); break;
+        }
+    }
+};

--- a/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
@@ -1,0 +1,79 @@
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const testUtils = require('../../../../../common/test-utils/browser');
+const onScrollEnd = require('../');
+
+describe('scroll-end', () => {
+    let scrollEl;
+
+    before(() => {
+        scrollEl = document.createElement('div');
+        scrollEl.style.overflowX = 'scroll';
+        scrollEl.innerHTML = `<div style="width: 200%; border: 25px dashed #000;"></div>`;
+        document.body.appendChild(scrollEl);
+    });
+
+    beforeEach(() => {
+        scrollEl.scrollLeft = 0;
+    });
+
+    after(() => {
+        document.body.removeChild(scrollEl);
+    });
+
+    it('calls a function when a scroll has ended', (done) => {
+        const scrollEndSpy = sinon.spy();
+        onScrollEnd(scrollEl, scrollEndSpy);
+        simulateScroll(scrollEl, 50);
+        setTimeout(() => {
+            simulateScroll(scrollEl, 100);
+            setTimeout(() => {
+                expect(scrollEndSpy.calledTwice).to.equal(true);
+                expect(scrollEndSpy.args[0][0]).to.equal(50);
+                expect(scrollEndSpy.args[1][0]).to.equal(100);
+                done();
+            }, 100);
+        }, 100);
+    });
+
+    it('groups scroll events with additional touches', (done) => {
+        const scrollEndSpy = sinon.spy();
+        onScrollEnd(scrollEl, scrollEndSpy);
+        simulateScroll(scrollEl, 50);
+        setTimeout(() => {
+            simulateScroll(scrollEl, 100);
+            setTimeout(() => {
+                expect(scrollEndSpy.calledOnce).to.equal(true);
+                expect(scrollEndSpy.args[0][0]).to.equal(100);
+                done();
+            }, 100);
+        }, 0);
+    });
+});
+
+/**
+ * Simulates a touch based scroll event over 100ms.
+ *
+ * @param {HTMLElement} el The element to scroll.
+ * @param {number} to The new scrollLeft for the element.
+ */
+function simulateScroll(el, to) {
+    const { scrollLeft } = el;
+    const distance = to - scrollLeft;
+    const duration = 10;
+    testUtils.triggerEvent(el, 'touchstart');
+    requestAnimationFrame(startTime => {
+        (function animate(curTime) {
+            const delta = curTime - startTime;
+            if (delta > duration) {
+                testUtils.triggerEvent(el, 'touchend');
+                el.scrollLeft = to;
+                return;
+            }
+
+            testUtils.triggerEvent(el, 'touchmove');
+            el.scrollLeft = (delta / duration) * distance + scrollLeft;
+            requestAnimationFrame(animate);
+        }());
+    });
+}

--- a/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
@@ -32,8 +32,8 @@ describe('scroll-end', () => {
                 expect(scrollEndSpy.args[0][0]).to.equal(50);
                 expect(scrollEndSpy.args[1][0]).to.equal(100);
                 done();
-            }, 100);
-        }, 100);
+            }, 300);
+        }, 150);
     });
 
     it('groups scroll events with additional touches', (done) => {
@@ -46,7 +46,7 @@ describe('scroll-end', () => {
                 expect(scrollEndSpy.calledOnce).to.equal(true);
                 expect(scrollEndSpy.args[0][0]).to.equal(100);
                 done();
-            }, 100);
+            }, 150);
         }, 0);
     });
 });

--- a/src/components/ebay-carousel/utils/scroll-transition/index.js
+++ b/src/components/ebay-carousel/utils/scroll-transition/index.js
@@ -1,0 +1,47 @@
+/**
+ * Utility to animate scroll position of an element using an `ease-out` curve over 250ms.
+ * Cancels the animation if the user touches back down.
+ *
+ * @param {HTMLElement} el The element to scroll.
+ * @param {number} to The offset to animate to.
+ * @param {function} fn A function that will be called after the transition completes.
+ * @return {function} A function that cancels the transition.
+ */
+module.exports = function scrollTransition(el, to, fn) {
+    const duration = 250;
+    el.addEventListener('touchstart', cancel);
+    let frame = requestAnimationFrame(startTime => {
+        const { scrollLeft } = el;
+        const distance = to - scrollLeft;
+        (function animate(curTime) {
+            const delta = curTime - startTime;
+            if (delta > duration) {
+                el.scrollLeft = to;
+                cancel();
+                return fn();
+            }
+
+            el.scrollLeft = easeOut(delta / duration) * distance + scrollLeft;
+            frame = requestAnimationFrame(animate);
+        }(startTime));
+    });
+
+    return cancel;
+
+    function cancel() {
+        el.removeEventListener('touchstart', cancel);
+        cancelAnimationFrame(frame);
+    }
+};
+
+/**
+ * Ease out timing function.
+ * Based on https://gist.github.com/gre/1650294.
+ *
+ * @param {number} val - A number between 0 and 1.
+ * @return {number}
+ */
+function easeOut(v) {
+    const t = v - 1;
+    return t * t * t + 1;
+}

--- a/src/components/ebay-carousel/utils/scroll-transition/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/scroll-transition/test/test.browser.js
@@ -1,0 +1,44 @@
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const testUtils = require('../../../../../common/test-utils/browser');
+const scrollTransition = require('../');
+
+describe('scroll-transition', () => {
+    let scrollEl;
+
+    before(() => {
+        scrollEl = document.createElement('div');
+        scrollEl.style.overflowX = 'scroll';
+        scrollEl.innerHTML = `<div style="width: 200%; border: 25px dashed #000;"></div>`;
+        document.body.appendChild(scrollEl);
+    });
+
+    beforeEach(() => {
+        scrollEl.scrollLeft = 0;
+    });
+
+    after(() => {
+        document.body.removeChild(scrollEl);
+    });
+
+    it('scrolls an element to an offset and calls a function once done', (done) => {
+        scrollTransition(scrollEl, 100, () => {
+            expect(scrollEl.scrollLeft).to.equal(100);
+            done();
+        });
+    });
+
+    it('cancels the transition on additional touches', (done) => {
+        const spy = sinon.spy();
+        scrollTransition(scrollEl, 100, spy);
+        setTimeout(() => {
+            testUtils.triggerEvent(scrollEl, 'touchstart');
+            setTimeout(() => {
+                expect(scrollEl.scrollLeft).to.not.equal(0);
+                expect(scrollEl.scrollLeft).to.not.equal(100);
+                expect(spy.callCount).to.equal(0);
+                done();
+            }, 200);
+        }, 50);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,8 +87,8 @@
   resolved "https://registry.npmjs.org/@ebay/browserslist-config/-/browserslist-config-1.0.0.tgz#06328378600156458dacb0278767ff8490f2074c"
 
 "@ebay/skin@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-5.1.0.tgz#fbbfa0ee136fae27795e13fde08fd42416108aa9"
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-5.1.1.tgz#f6e62145b5668bddad9b463a6733558a934a2d8e"
 
 "@lasso/marko-taglib@^1.0.10", "@lasso/marko-taglib@^1.0.9":
   version "1.0.10"
@@ -99,27 +99,27 @@
     raptor-logging "^1.1.3"
     raptor-util "^1.1.2"
 
-"@marko/compile@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/@marko/compile/-/compile-3.1.0.tgz#f4801c5e242e3566b43dfa4198d420d2d194f786"
+"@marko/compile@3.2.0-alpha.86e5e3fd":
+  version "3.2.0-alpha.86e5e3fd"
+  resolved "https://registry.npmjs.org/@marko/compile/-/compile-3.2.0-alpha.86e5e3fd.tgz#459eef8124a287a1bed41d64e5127f100bcf3a95"
   dependencies:
     babel-runtime "^6.26.0"
     glob "^7.1.2"
     lasso-package-root "^1.0.1"
     resolve-from "^4.0.0"
 
-"@marko/create@^3.1.6":
-  version "3.1.6"
-  resolved "https://registry.npmjs.org/@marko/create/-/create-3.1.6.tgz#7b6eae14a4cc6a30685b3c0d17070e5e502b3dff"
+"@marko/create@3.2.0-alpha.86e5e3fd":
+  version "3.2.0-alpha.86e5e3fd"
+  resolved "https://registry.npmjs.org/@marko/create/-/create-3.2.0-alpha.86e5e3fd.tgz#4130c52d1ea70a6b528d204f4651113a3fb9af9c"
   dependencies:
     babel-runtime "^6.26.0"
     got "^8.3.1"
     ora "^2.1.0"
     unzip "^0.1.11"
 
-"@marko/test@^3.1.6":
-  version "3.1.6"
-  resolved "https://registry.npmjs.org/@marko/test/-/test-3.1.6.tgz#a160c3db3c75ff19fd7bb0602f531e45faea9a81"
+"@marko/test@3.2.0-alpha.86e5e3fd":
+  version "3.2.0-alpha.86e5e3fd"
+  resolved "https://registry.npmjs.org/@marko/test/-/test-3.2.0-alpha.86e5e3fd.tgz#0d8efc6901388f89ea87543ba3d85be9a308cc63"
   dependencies:
     "@lasso/marko-taglib" "^1.0.10"
     async "^2.6.1"
@@ -130,7 +130,7 @@
     cheerio "^1.0.0-rc.2"
     child-process-promise "^2.2.1"
     chromedriver "^2.40.0"
-    complain "^1.2.0"
+    complain "^1.3.0"
     delay "^3.0.0"
     engine.io "^3.2.0"
     engine.io-client "^3.2.1"
@@ -138,18 +138,19 @@
     get-port "^3.2.0"
     is-port-free "^1.0.7"
     lasso "^3.2.0"
-    lasso-istanbul-instrument-transform "0.0.4"
+    lasso-istanbul-instrument-transform "2.0.0"
     lasso-marko "^2.4.2"
     lasso-require "^3.4.10"
-    marko "^4.11.1"
+    marko "^4.12.0"
     mocha "^5.2.0"
     mz "^2.7.0"
-    p-event "^2.0.0"
+    node-fetch "2.1.2"
+    p-event "^2.1.0"
     raptor-renderer "^1.5.0"
     resolve-from "^4.0.0"
     strip-ansi "^4.0.0"
     wdio-chromedriver-service "^0.1.3"
-    webdriverio "^4.13.0"
+    webdriverio "^4.13.1"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -248,7 +249,7 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.npmjs.org/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
-agent-base@4, agent-base@^4.1.0, agent-base@^4.2.0:
+agent-base@4, agent-base@^4.1.0, agent-base@^4.2.0, agent-base@~4.2.0:
   version "4.2.1"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   dependencies:
@@ -662,7 +663,7 @@ babel-core@^6.0.14, babel-core@^6.26.0, babel-core@^6.7.6:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-generator@^6.18.0, babel-generator@^6.26.0:
+babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
   dependencies:
@@ -1065,7 +1066,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -1075,7 +1076,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -1089,7 +1090,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1357,12 +1358,13 @@ browserify-cipher@^1.0.0:
     evp_bytestokey "^1.0.0"
 
 browserify-des@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz#3343124db6d7ad53e26a8826318712bdc8450f9c"
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
   dependencies:
     cipher-base "^1.0.1"
     des.js "^1.0.0"
     inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 browserify-rsa@^4.0.0:
   version "4.0.1"
@@ -1448,6 +1450,14 @@ browserslist@^3.2.6, browserslist@^3.2.8:
   dependencies:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
+
+browserslist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.0.0.tgz#48703f1ed7ef981c6719e39e9444f20632b06571"
+  dependencies:
+    caniuse-lite "^1.0.30000859"
+    electron-to-chromium "^1.3.50"
+    node-releases "^1.0.0-alpha.10"
 
 browserstack-local@^1.2.0:
   version "1.3.3"
@@ -1623,13 +1633,13 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-db@^1.0.30000846:
-  version "1.0.30000864"
-  resolved "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000864.tgz#35a4b2325a8d4553a46b516dbc233bf391d75555"
+caniuse-db@^1.0.30000865:
+  version "1.0.30000865"
+  resolved "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000865.tgz#82ffb64d40f7567620aac02d3a632079689abc6b"
 
-caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000864:
-  version "1.0.30000864"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000864.tgz#7a08c78da670f23c06f11aa918831b8f2dd60ddc"
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000859, caniuse-lite@^1.0.30000864:
+  version "1.0.30000865"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz#70026616e8afe6e1442f8bb4e1092987d81a2f25"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2619,9 +2629,9 @@ ejs@~2.5.6:
   version "2.5.9"
   resolved "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz#7ba254582a560d267437109a68354112475b0ce5"
 
-electron-to-chromium@^1.3.47:
-  version "1.3.51"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.51.tgz#6a42b49daaf7f22a5b37b991daf949f34dbdb9b5"
+electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.50:
+  version "1.3.52"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz#d2d9f1270ba4a3b967b831c40ef71fb4d9ab5ce0"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2852,13 +2862,13 @@ eslint-module-utils@^2.2.0:
     pkg-dir "^1.0.0"
 
 eslint-plugin-compat@^2.2.0:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-2.4.0.tgz#827a5c57491929860918fbbc97794ba7309b6990"
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-2.5.0.tgz#a35dd1249527eaf2170b5a063f33d4db1a1fc664"
   dependencies:
     babel-runtime "^6.26.0"
-    browserslist "^3.2.8"
-    caniuse-db "^1.0.30000846"
-    mdn-browser-compat-data "^0.0.36"
+    browserslist "^4.0.0"
+    caniuse-db "^1.0.30000865"
+    mdn-browser-compat-data "^0.0.40"
     requireindex "^1.2.0"
 
 eslint-plugin-import@^2.12.0:
@@ -2883,8 +2893,8 @@ eslint-plugin-mocha@^5.0.0:
     ramda "^0.25.0"
 
 eslint-scope@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  version "3.7.3"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -3515,8 +3525,8 @@ get-assigned-identifiers@^1.2.0:
   resolved "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz#6dbf411de648cbaf8d9169ebb0d2d576191e2ff1"
 
 get-caller-file@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
 
 get-func-name@^2.0.0:
   version "2.0.0"
@@ -4562,19 +4572,7 @@ istanbul-lib-hook@^1.1.0:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.4.2:
-  version "1.10.1"
-  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz#724b4b6caceba8692d3f1f9d0727e279c401af7b"
-  dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.18.0"
-    istanbul-lib-coverage "^1.2.0"
-    semver "^5.3.0"
-
-istanbul-lib-instrument@^2.1.0:
+istanbul-lib-instrument@^2.1.0, istanbul-lib-instrument@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.1.tgz#406406730a395acb2e50f0d98137ace16bd4a970"
   dependencies:
@@ -4638,12 +4636,16 @@ isurl@^1.0.0-alpha5:
     is-object "^1.0.1"
 
 js-base64@^2.1.9:
-  version "2.4.5"
-  resolved "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
+  version "2.4.6"
+  resolved "https://registry.npmjs.org/js-base64/-/js-base64-2.4.6.tgz#1d49f618bef43630cd191f4e122447acfdb947d8"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
 js-yaml@3.x, js-yaml@^3.11.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.12.0"
@@ -4864,11 +4866,11 @@ lasso-caching-fs@^1.0.0, lasso-caching-fs@^1.0.1, lasso-caching-fs@^1.0.2:
   dependencies:
     raptor-async "^1.1.2"
 
-lasso-istanbul-instrument-transform@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/lasso-istanbul-instrument-transform/-/lasso-istanbul-instrument-transform-0.0.4.tgz#14dc458aead2c8e11176b05792c1b4bc57386aa2"
+lasso-istanbul-instrument-transform@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/lasso-istanbul-instrument-transform/-/lasso-istanbul-instrument-transform-2.0.0.tgz#0a0d750b9e35fe85c02a540255b16c8befc3d385"
   dependencies:
-    istanbul-lib-instrument "^1.4.2"
+    istanbul-lib-instrument "^2.3.1"
     lasso-resolve-from "^1.2.0"
 
 lasso-less@^3.0.1:
@@ -4961,8 +4963,8 @@ lasso-resolve-from@^1.2.0:
     resolve-from "^2.0.0"
 
 lasso@^3.1.5, lasso@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/lasso/-/lasso-3.2.0.tgz#1b1e613f3916f0b5a926985c0c508c58aa4c650e"
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/lasso/-/lasso-3.2.1.tgz#7c36bd1f57a46cf2a462a9a294848acec33d8f65"
   dependencies:
     app-root-dir "^1.0.2"
     assert "^1.4.1"
@@ -5038,8 +5040,8 @@ lcov-parse@^0.0.10:
   resolved "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
 less@^3.0.4:
-  version "3.5.3"
-  resolved "https://registry.npmjs.org/less/-/less-3.5.3.tgz#108f656b5ee09a281b757a603a80aa091acf6384"
+  version "3.7.1"
+  resolved "https://registry.npmjs.org/less/-/less-3.7.1.tgz#192e9dcef456ba3181a4e8d78a200f72a75e5c30"
   optionalDependencies:
     errno "^0.1.1"
     graceful-fs "^4.1.2"
@@ -5177,8 +5179,8 @@ log-symbols@^2.0.0, log-symbols@^2.2.0:
     chalk "^2.0.1"
 
 log4js@^2.5.3:
-  version "2.10.0"
-  resolved "https://registry.npmjs.org/log4js/-/log4js-2.10.0.tgz#4980bd9148a030d69f9edde32a5b19c0a551e2c4"
+  version "2.11.0"
+  resolved "https://registry.npmjs.org/log4js/-/log4js-2.11.0.tgz#bf3902eff65c6923d9ce9cfbd2db54160e34005a"
   dependencies:
     circular-json "^0.5.4"
     date-format "^1.2.0"
@@ -5220,10 +5222,10 @@ longest@^1.0.1:
   resolved "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loose-envify@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
-    js-tokens "^3.0.0"
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -5371,13 +5373,13 @@ markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
-marko-cli@^3.1.4:
-  version "3.1.6"
-  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-3.1.6.tgz#8b85bf92398677b184ad3d919858ef09a8e4d17b"
+marko-cli@3.2.0-alpha.86e5e3fd:
+  version "3.2.0-alpha.86e5e3fd"
+  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-3.2.0-alpha.86e5e3fd.tgz#5926491ebd6e81f7c9578a42a47756a3ad9f1cba"
   dependencies:
-    "@marko/compile" "^3.1.0"
-    "@marko/create" "^3.1.6"
-    "@marko/test" "^3.1.6"
+    "@marko/compile" "3.2.0-alpha.86e5e3fd"
+    "@marko/create" "3.2.0-alpha.86e5e3fd"
+    "@marko/test" "3.2.0-alpha.86e5e3fd"
     app-root-dir "^1.0.2"
     argly "^1.2.0"
     babel-runtime "^6.26.0"
@@ -5457,9 +5459,9 @@ marko@^3:
     strip-json-comments "^2.0.1"
     try-require "^1.2.1"
 
-marko@^4.0.0, marko@^4.10.0, marko@^4.11.1:
-  version "4.11.5"
-  resolved "https://registry.npmjs.org/marko/-/marko-4.11.5.tgz#ac3bb9e515a0e041763492a5ee161cfa6dea118f"
+marko@^4.0.0, marko@^4.10.0, marko@^4.12.0:
+  version "4.12.0"
+  resolved "https://registry.npmjs.org/marko/-/marko-4.12.0.tgz#3fcd01744696f4b9f199daac75185c6477cf182d"
   dependencies:
     app-module-path "^2.2.0"
     argly "^1.0.0"
@@ -5532,9 +5534,9 @@ mdast-util-compact@^1.0.0:
     unist-util-modify-children "^1.0.0"
     unist-util-visit "^1.1.0"
 
-mdn-browser-compat-data@^0.0.36:
-  version "0.0.36"
-  resolved "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.36.tgz#d347c618b648981fd0310035e556fd6871fde2fe"
+mdn-browser-compat-data@^0.0.40:
+  version "0.0.40"
+  resolved "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.40.tgz#d7f13de64ff90e11062cfc0db92753674feb9800"
   dependencies:
     extend "3.0.1"
 
@@ -5665,8 +5667,8 @@ mimic-fn@^1.0.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
 mimic-response@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -5857,6 +5859,10 @@ nise@^1.3.3:
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
 
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
@@ -5871,6 +5877,12 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-releases@^1.0.0-alpha.10:
+  version "1.0.0-alpha.10"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.10.tgz#61c8d5f9b5b2e05d84eba941d05b6f5202f68a2a"
+  dependencies:
+    semver "^5.3.0"
 
 node-uuid@~1.4.7:
   version "1.4.8"
@@ -6227,7 +6239,7 @@ p-cancelable@^0.4.0:
   version "0.4.1"
   resolved "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
 
-p-event@^2.0.0:
+p-event@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/p-event/-/p-event-2.1.0.tgz#74de477a4e6b3aa8267240c7099e78ac52cb4db4"
   dependencies:
@@ -6695,8 +6707,8 @@ proxy-addr@~2.0.3:
     ipaddr.js "1.6.0"
 
 proxy-agent@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.0.0.tgz#f6768e202889b2285d39906d3a94768416f8f713"
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.0.1.tgz#4fb7b61b1476d0fe8e3a3384d90e2460bbded3f9"
   dependencies:
     agent-base "^4.2.0"
     debug "^3.1.0"
@@ -6705,7 +6717,7 @@ proxy-agent@~3.0.0:
     lru-cache "^4.1.2"
     pac-proxy-agent "^2.0.1"
     proxy-from-env "^1.0.0"
-    socks-proxy-agent "^3.0.0"
+    socks-proxy-agent "^4.0.1"
 
 proxy-from-env@^1.0.0:
   version "1.0.0"
@@ -7669,6 +7681,10 @@ smart-buffer@^1.0.13, smart-buffer@^1.0.4:
   version "1.1.15"
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz#7f114b5b65fab3e2a35aa775bb12f0d1c649bf16"
 
+smart-buffer@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz#07ea1ca8d4db24eb4cac86537d7d18995221ace3"
+
 smtp-connection@2.12.0:
   version "2.12.0"
   resolved "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz#d76ef9127cb23c2259edb1e8349c2e8d5e2d74c1"
@@ -7795,6 +7811,13 @@ socks-proxy-agent@^3.0.0:
     agent-base "^4.1.0"
     socks "^1.1.10"
 
+socks-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz#5936bf8b707a993079c6f37db2091821bffa6473"
+  dependencies:
+    agent-base "~4.2.0"
+    socks "~2.2.0"
+
 socks@1.1.9:
   version "1.1.9"
   resolved "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz#628d7e4d04912435445ac0b6e459376cb3e6d691"
@@ -7808,6 +7831,13 @@ socks@^1.1.10:
   dependencies:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
+
+socks@~2.2.0:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/socks/-/socks-2.2.1.tgz#68ad678b3642fbc5d99c64c165bc561eab0215f9"
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.0.1"
 
 sort-keys@^2.0.0:
   version "2.0.0"
@@ -8676,10 +8706,8 @@ url@^0.11.0, url@~0.11.0:
     querystring "0.2.0"
 
 use@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
-  dependencies:
-    kind-of "^6.0.2"
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
 user-home@^1.1.1:
   version "1.1.1"
@@ -8810,7 +8838,7 @@ wdio-dot-reporter@~0.0.8:
   version "0.0.10"
   resolved "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.10.tgz#facfb7c9c5984149951f59cbc3cd0752101cf0e0"
 
-webdriverio@^4.13.0:
+webdriverio@^4.13.1:
   version "4.13.1"
   resolved "https://registry.npmjs.org/webdriverio/-/webdriverio-4.13.1.tgz#624ef4ca569f3c9a5e8e9b11302b4431eda1fb8a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,81 +2,81 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz#becd805482734440c9d137e46d77340e64d7f51b"
+"@babel/code-frame@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz#bd71d9b192af978df915829d39d4094456439a0c"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.49"
+    "@babel/highlight" "7.0.0-beta.51"
 
-"@babel/generator@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz#e9cffda913996accec793bbc25ab91bc19d0bf7a"
+"@babel/generator@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz#6c7575ffde761d07485e04baedc0392c6d9e30f6"
   dependencies:
-    "@babel/types" "7.0.0-beta.49"
+    "@babel/types" "7.0.0-beta.51"
     jsesc "^2.5.1"
     lodash "^4.17.5"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/helper-function-name@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz#a25c1119b9f035278670126e0225c03041c8de32"
+"@babel/helper-function-name@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz#21b4874a227cf99ecafcc30a90302da5a2640561"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.49"
-    "@babel/template" "7.0.0-beta.49"
-    "@babel/types" "7.0.0-beta.49"
+    "@babel/helper-get-function-arity" "7.0.0-beta.51"
+    "@babel/template" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
 
-"@babel/helper-get-function-arity@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz#cf5023f32d2ad92d087374939cec0951bcb51441"
+"@babel/helper-get-function-arity@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz#3281b2d045af95c172ce91b20825d85ea4676411"
   dependencies:
-    "@babel/types" "7.0.0-beta.49"
+    "@babel/types" "7.0.0-beta.51"
 
-"@babel/helper-split-export-declaration@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz#40d78eda0968d011b1c52866e5746cfb23e57548"
+"@babel/helper-split-export-declaration@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz#8a6c3f66c4d265352fc077484f9f6e80a51ab978"
   dependencies:
-    "@babel/types" "7.0.0-beta.49"
+    "@babel/types" "7.0.0-beta.51"
 
-"@babel/highlight@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz#96bdc6b43e13482012ba6691b1018492d39622cc"
+"@babel/highlight@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz#e8844ae25a1595ccfd42b89623b4376ca06d225d"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/parser@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz#944d0c5ba2812bb159edbd226743afd265179bdc"
+"@babel/parser@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz#27cec2df409df60af58270ed8f6aa55409ea86f6"
 
-"@babel/template@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz#e38abe8217cb9793f461a5306d7ad745d83e1d27"
+"@babel/template@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz#9602a40aebcf357ae9677e2532ef5fc810f5fbff"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.49"
-    "@babel/parser" "7.0.0-beta.49"
-    "@babel/types" "7.0.0-beta.49"
+    "@babel/code-frame" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
     lodash "^4.17.5"
 
-"@babel/traverse@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz#4f2a73682a18334ed6625d100a8d27319f7c2d68"
+"@babel/traverse@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz#981daf2cec347a6231d3aa1d9e1803b03aaaa4a8"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.49"
-    "@babel/generator" "7.0.0-beta.49"
-    "@babel/helper-function-name" "7.0.0-beta.49"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.49"
-    "@babel/parser" "7.0.0-beta.49"
-    "@babel/types" "7.0.0-beta.49"
+    "@babel/code-frame" "7.0.0-beta.51"
+    "@babel/generator" "7.0.0-beta.51"
+    "@babel/helper-function-name" "7.0.0-beta.51"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
     debug "^3.1.0"
     globals "^11.1.0"
     invariant "^2.2.0"
     lodash "^4.17.5"
 
-"@babel/types@7.0.0-beta.49":
-  version "7.0.0-beta.49"
-  resolved "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz#b7e3b1c3f4d4cfe11bdf8c89f1efd5e1617b87a6"
+"@babel/types@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz#d802b7b543b5836c778aa691797abf00f3d97ea9"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.5"
@@ -172,6 +172,10 @@
   dependencies:
     samsam "1.3.0"
 
+"@sinonjs/samsam@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
+
 "@types/commander@^2.11.0":
   version "2.12.2"
   resolved "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz#183041a23842d4281478fa5d23c5ca78e6fd08ae"
@@ -179,8 +183,8 @@
     commander "*"
 
 "@types/node@*":
-  version "10.3.2"
-  resolved "https://registry.npmjs.org/@types/node/-/node-10.3.2.tgz#3840ec6c12556fdda6e0e6d036df853101d732a4"
+  version "10.5.2"
+  resolved "https://registry.npmjs.org/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
 
 "@types/semver@^5.4.0":
   version "5.5.0"
@@ -245,8 +249,8 @@ after@0.8.2:
   resolved "https://registry.npmjs.org/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
 agent-base@4, agent-base@^4.1.0, agent-base@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   dependencies:
     es6-promisify "^5.0.0"
 
@@ -268,8 +272,8 @@ ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     json-schema-traverse "^0.3.0"
 
 ajv@^6.0.1:
-  version "6.5.1"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz#88ebc1263c7133937d108b80c5572e64e1d9322d"
+  version "6.5.2"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -577,14 +581,14 @@ atob@^2.1.1:
   resolved "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 autoprefixer@^8.0.0:
-  version "8.6.2"
-  resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.2.tgz#51d42ff13243820a582a53ecca20dedaeb7f2efd"
+  version "8.6.5"
+  resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.5.tgz#343f3d193ed568b3208e00117a1b96eb691d4ee9"
   dependencies:
     browserslist "^3.2.8"
-    caniuse-lite "^1.0.30000851"
+    caniuse-lite "^1.0.30000864"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^6.0.22"
+    postcss "^6.0.23"
     postcss-value-parser "^3.2.3"
 
 aws-sign2@~0.6.0:
@@ -1620,16 +1624,12 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-db@^1.0.30000846:
-  version "1.0.30000851"
-  resolved "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000851.tgz#8a0d3ca4dde72068560acc98bacf75a359e8d3e3"
+  version "1.0.30000864"
+  resolved "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000864.tgz#35a4b2325a8d4553a46b516dbc233bf391d75555"
 
-caniuse-lite@^1.0.30000844:
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000864:
   version "1.0.30000864"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000864.tgz#7a08c78da670f23c06f11aa918831b8f2dd60ddc"
-
-caniuse-lite@^1.0.30000851:
-  version "1.0.30000851"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000851.tgz#3b498aebf9f92cf6cff4ab54d13b557c0b590533"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1955,11 +1955,11 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@*, commander@^2.9.0, commander@~2.16.0:
+commander@*, commander@^2.11.0, commander@^2.9.0, commander@~2.16.0:
   version "2.16.0"
   resolved "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
 
-commander@2.15.1, commander@^2.11.0:
+commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
@@ -2734,15 +2734,9 @@ errno@^0.1.1:
   dependencies:
     prr "~1.0.1"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
-  dependencies:
-    is-arrayish "^0.2.1"
-
-error-ex@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -2883,8 +2877,8 @@ eslint-plugin-import@^2.12.0:
     resolve "^1.6.0"
 
 eslint-plugin-mocha@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.0.0.tgz#43946a7ecaf39039eb3ee20635ebd4cc19baf6dd"
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-5.1.0.tgz#3637cdde93155e650591d7ab14e7a66485f0f7c1"
   dependencies:
     ramda "^0.25.0"
 
@@ -3331,8 +3325,8 @@ follow-redirects@1.0.0:
     debug "^2.2.0"
 
 follow-redirects@^1.0.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz#67a8f14f5a1f67f962c2c46469c79eaec0a90291"
   dependencies:
     debug "^3.1.0"
 
@@ -3626,13 +3620,9 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
-globals@^11.0.1:
+globals@^11.0.1, globals@^11.1.0:
   version "11.7.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
-
-globals@^11.1.0:
-  version "11.5.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -3860,11 +3850,11 @@ hash-base@^3.0.0:
     safe-buffer "^5.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz#8b50e1f35d51bd01e5ed9ece4dbe3549ccfa0a3c"
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
   dependencies:
     inherits "^2.0.3"
-    minimalistic-assert "^1.0.0"
+    minimalistic-assert "^1.0.1"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -3918,8 +3908,8 @@ home-or-tmp@^2.0.0:
     os-tmpdir "^1.0.1"
 
 hosted-git-info@^2.1.4:
-  version "2.6.1"
-  resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz#6e4cee78b01bb849dcf93527708c69fdbee410df"
+  version "2.7.1"
+  resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
 html-tags@^2.0.0:
   version "2.0.0"
@@ -4046,13 +4036,9 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.1.1, ignore@^3.3.3:
+ignore@^3.1.1, ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
-
-ignore@^3.3.5:
-  version "3.3.8"
-  resolved "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
 ignoring-watcher@^1.0.5:
   version "1.1.0"
@@ -4406,12 +4392,6 @@ is-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
 
-is-odd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
-  dependencies:
-    is-number "^4.0.0"
-
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -4572,9 +4552,9 @@ istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
-istanbul-lib-coverage@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#905e71212052ffb34f2eb008102230bff03940b5"
+istanbul-lib-coverage@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#2aee0e073ad8c5f6a0b00e0dfbf52b4667472eda"
 
 istanbul-lib-hook@^1.1.0:
   version "1.1.0"
@@ -4595,15 +4575,15 @@ istanbul-lib-instrument@^1.4.2:
     semver "^5.3.0"
 
 istanbul-lib-instrument@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.2.0.tgz#08091ae49d0b330be2a839dc25c250324c4bedaa"
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.1.tgz#406406730a395acb2e50f0d98137ace16bd4a970"
   dependencies:
-    "@babel/generator" "7.0.0-beta.49"
-    "@babel/parser" "7.0.0-beta.49"
-    "@babel/template" "7.0.0-beta.49"
-    "@babel/traverse" "7.0.0-beta.49"
-    "@babel/types" "7.0.0-beta.49"
-    istanbul-lib-coverage "^2.0.0"
+    "@babel/generator" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/template" "7.0.0-beta.51"
+    "@babel/traverse" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    istanbul-lib-coverage "^2.0.1"
     semver "^5.5.0"
 
 istanbul-lib-report@^1.1.3:
@@ -5058,8 +5038,8 @@ lcov-parse@^0.0.10:
   resolved "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
 less@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/less/-/less-3.0.4.tgz#d27dcedbac96031c9e7b76f1da1e4b7d83760814"
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/less/-/less-3.5.3.tgz#108f656b5ee09a281b757a603a80aa091acf6384"
   optionalDependencies:
     errno "^0.1.1"
     graceful-fs "^4.1.2"
@@ -5228,8 +5208,8 @@ lolex@1.3.2:
   resolved "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 lolex@^2.3.2, lolex@^2.4.2:
-  version "2.7.0"
-  resolved "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz#9c087a69ec440e39d3f796767cf1b2cdc43d5ea5"
+  version "2.7.1"
+  resolved "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz#e40a8c4d1f14b536aa03e42a537c7adbaf0c20be"
 
 longest-streak@^2.0.1:
   version "2.0.2"
@@ -5477,43 +5457,7 @@ marko@^3:
     strip-json-comments "^2.0.1"
     try-require "^1.2.1"
 
-marko@^4.0.0:
-  version "4.10.0"
-  resolved "https://registry.npmjs.org/marko/-/marko-4.10.0.tgz#959870f015545e54cad19287c751d7206bb02124"
-  dependencies:
-    app-module-path "^2.2.0"
-    argly "^1.0.0"
-    browser-refresh-client "^1.0.0"
-    char-props "~0.1.5"
-    complain "^1.2.0"
-    deresolve "^1.1.2"
-    escodegen "^1.8.1"
-    esprima "^4.0.0"
-    estraverse "^4.2.0"
-    events "^1.0.2"
-    events-light "^1.0.0"
-    he "^1.1.0"
-    htmljs-parser "^2.3.2"
-    lasso-caching-fs "^1.0.1"
-    lasso-modules-client "^2.0.4"
-    lasso-package-root "^1.0.1"
-    listener-tracker "^2.0.0"
-    minimatch "^3.0.2"
-    object-assign "^4.1.0"
-    property-handlers "^1.0.0"
-    raptor-json "^1.0.1"
-    raptor-polyfill "^1.0.0"
-    raptor-promises "^1.0.1"
-    raptor-regexp "^1.0.0"
-    raptor-util "^3.2.0"
-    resolve-from "^2.0.0"
-    shorthash "0.0.2"
-    simple-sha1 "^2.1.0"
-    strip-json-comments "^2.0.1"
-    try-require "^1.2.1"
-    warp10 "^1.0.0"
-
-marko@^4.10.0, marko@^4.11.1:
+marko@^4.0.0, marko@^4.10.0, marko@^4.11.1:
   version "4.11.5"
   resolved "https://registry.npmjs.org/marko/-/marko-4.11.5.tgz#ac3bb9e515a0e041763492a5ee161cfa6dea118f"
   dependencies:
@@ -5724,7 +5668,7 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
-minimalistic-assert@^1.0.0:
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
 
@@ -5860,15 +5804,14 @@ nan@^2.0.9, nan@^2.9.2:
   resolved "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nanomatch@^1.2.9:
-  version "1.2.9"
-  resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
+  version "1.2.13"
+  resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
     define-property "^2.0.2"
     extend-shallow "^3.0.2"
     fragment-cache "^0.2.1"
-    is-odd "^2.0.0"
     is-windows "^1.0.2"
     kind-of "^6.0.2"
     object.pick "^1.3.0"
@@ -5884,7 +5827,7 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-needle@^2.2.0:
+needle@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
   dependencies:
@@ -5915,12 +5858,12 @@ nise@^1.3.3:
     text-encoding "^0.6.4"
 
 node-pre-gyp@^0.10.0:
-  version "0.10.2"
-  resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.2.tgz#e8945c20ef6795a20aac2b44f036eb13cf5146e3"
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
-    needle "^2.2.0"
+    needle "^2.2.1"
     nopt "^4.0.1"
     npm-packlist "^1.1.6"
     npmlog "^4.0.2"
@@ -6621,10 +6564,10 @@ postcss-sass@^0.3.0:
     postcss "6.0.22"
 
 postcss-scss@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.5.tgz#40a10cfd03766accf0a3cf8e65a8af887b2bf6c4"
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.6.tgz#ab903f3bb20161bc177896462293a53d4bff5f7a"
   dependencies:
-    postcss "^6.0.21"
+    postcss "^6.0.23"
 
 postcss-selector-parser@^3.1.0:
   version "3.1.1"
@@ -6642,7 +6585,7 @@ postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
 
-postcss@6.0.22, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.21, postcss@^6.0.22, postcss@^6.0.6, postcss@^6.0.8:
+postcss@6.0.22:
   version "6.0.22"
   resolved "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
   dependencies:
@@ -6658,6 +6601,14 @@ postcss@^5.2.16:
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
+
+postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.23, postcss@^6.0.6, postcss@^6.0.8:
+  version "6.0.23"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
 
 pre-push@^0.1.1:
   version "0.1.1"
@@ -6682,8 +6633,8 @@ preserve@^0.2.0:
   resolved "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.8.2:
-  version "1.13.5"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz#7ae2076998c8edce79d63834e9b7b09fead6bfd0"
+  version "1.13.7"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
@@ -6769,8 +6720,8 @@ pseudomap@^1.0.1, pseudomap@^1.0.2:
   resolved "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 psl@^1.1.24:
-  version "1.1.27"
-  resolved "https://registry.npmjs.org/psl/-/psl-1.1.27.tgz#2b2c77019db86855170d903532400bf71ee085b6"
+  version "1.1.28"
+  resolved "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
 
 public-encrypt@^4.0.0:
   version "4.0.2"
@@ -7676,10 +7627,11 @@ sinon@^1.17.6:
     util ">=0.10.3 <1"
 
 sinon@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/sinon/-/sinon-6.1.0.tgz#9ee3d3900616333078464aa3969ba5688456fea3"
+  version "6.1.3"
+  resolved "https://registry.npmjs.org/sinon/-/sinon-6.1.3.tgz#98e7d716b7b11f7f1200e9c997e74f50ae094660"
   dependencies:
     "@sinonjs/formatio" "^2.0.0"
+    "@sinonjs/samsam" "^2.0.0"
     diff "^3.5.0"
     lodash.get "^4.4.2"
     lolex "^2.4.2"
@@ -8426,8 +8378,8 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     safe-regex "^1.1.0"
 
 tough-cookie@>=2.3.3:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz#aa9133154518b494efab98a58247bfc38818c00c"
+  version "2.4.3"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
@@ -8531,8 +8483,8 @@ uglify-js@^2.6:
     uglify-to-browserify "~1.0.0"
 
 uglify-js@^3.4.0:
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.3.tgz#a4fd757b6f34a95f717f7a7a0dccafcaaa60cf7f"
+  version "3.4.4"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.4.tgz#92e79532a3aeffd4b6c65755bdba8d5bad98d607"
   dependencies:
     commander "~2.16.0"
     source-map "~0.6.1"
@@ -9016,8 +8968,8 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
 yargs-parser@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz#c737c93de2567657750cb1f2c00be639fd19c994"
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   dependencies:
     camelcase "^4.1.0"
 


### PR DESCRIPTION
Alright, here is part one of my carousel PR.
This refactor was done primarily to normalize various options on the carousel, simplify it's rendering logic and to fix some pre existing issues.

## Fixes
* fixed #220 by exposing a new `gap` attribute to override the margin.
* fixed #197
* fixed #176 
* Partially fixes, #149  and fixed #241
* Previously if items were too large in the carousel the slide controls would be off after navigating.

## Improvements
* Carousel now re-renders less often than previously.
* Re-renders are now shallow and don't actually cause a re-render of the carousel items unless needed.
* Dot controls animation was tweaked to avoid transitioning background-color for better performance.
* The carousel is now forced onto a new layer (`translate3d`) which improves performance in the native scrolling mode quite a bit.

## Features
* On mobile: native scrolling now automatically snaps to the closest items and emits events.
* On mobile: the controls now work and animate properly (#176).
* You can now have any number of `items-per-slide` (previously capped at 5).
* Auto looping index, working toward #216, now when you set the `index` above the bounds it goes to the first item, and 0 goes to the last.

## Breaking Changes
The changes below are not absolutely mandatory however during this PR I had some time to think about what we really need. This will probably warrant more discussion and if there are concerns with these changes I can update the PR.

* The `type` attribute was removed. Everything that could be gleaned from this attribute can be determined from just checking if `items-per-slide` is set and I feel that having two types of carousel is slightly confusing. In this implementation `items-per-slide` automatically sizes the items and adds to slide controls.

* The `slide` attribute was removed. In the previous implementation there were several branches that were accounting for both a `slide` and an `index` attribute. The slide can always be found from the index, and is relevant in (what was previously) `discrete` and `continuous` carousels. In this PR the slide is always calculated from the `index` and there is now one source of truth and a simpler API.

* Exposed methods on the widget have changed. This is not something we are advertising on our public API but I know at one point we recommended using the `refresh` method. I believe anyone that was using that method was just using it while waiting for a patch to the carousel. Users should not need be aware of these methods anyways, however to achieve the same effect now you can use `widget.update()` instead.

* `move` event has been removed. This was mostly because the hooks required to implement this clutter the codebase and as far as I can tell little value is added. Users should mostly want to use the `carousel-update` event which provides the current active indexes. If users really want to know when the carousel moves they can also listen for the `update` event which effectively gives the same result.

## Context
I planned on just working toward #216 but managing state of the component and keeping track of things was becoming a bit tricky.