### PR TITLE
Menu: close the Menu when esc button is pressed.

### DIFF
--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -68,6 +68,13 @@ function handleKeydown(e) {
     eventUtils.handleActionKeydown(e, () => {
         this.handleClick();
     });
+    // handle escape key for ebay-menu
+    eventUtils.handleEscapeKeydown(e, () => {
+        this.el.focus();
+        if (this.el.hasAttribute("aria-expanded")) {
+            this.el.setAttribute("aria-expanded", "false");
+        }
+    });
 }
 
 module.exports = markoWidgets.defineComponent({

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -71,8 +71,8 @@ function handleKeydown(e) {
     // handle escape key for ebay-menu
     eventUtils.handleEscapeKeydown(e, () => {
         this.el.focus();
-        if (this.el.hasAttribute("aria-expanded")) {
-            this.el.setAttribute("aria-expanded", "false");
+        if (this.el.hasAttribute('aria-expanded')) {
+            this.el.setAttribute('aria-expanded', 'false');
         }
     });
 }


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
In order to handle the esc button on ebay-menu. ebay-menu uses ebay-button so I have added `handleEscapeKeydown` on `handleKeydown` to handle esc key.

## Context
The menu should closes when you press escape key whether the focus is on the menu item or on the main button. In order to acheive this,
On `handleEscapeKeydown` method, if the element has  `aria-expanded` attribute, then make it false to close the menu.

## References
https://github.com/eBay/ebayui-core/issues/212

## Screenshots
Before after pressing esc key, menu doesn't close.
<img width="250" alt="ebay-menu-before" src="https://user-images.githubusercontent.com/21375014/42491168-9c8bd864-83c8-11e8-9da7-58b508788804.png">
After making the change, menu closes when you press esc key
<img width="162" alt="ebay-menu-after" src="https://user-images.githubusercontent.com/21375014/42491170-9e24f1c4-83c8-11e8-8eec-df89dcdb1292.png">

