### PR TITLE
Breadcrumb: fix event; clean up tests

### DIFF
--- a/src/components/ebay-breadcrumb/examples/5-hijax/template.marko
+++ b/src/components/ebay-breadcrumb/examples/5-hijax/template.marko
@@ -2,7 +2,7 @@
     <ebay-breadcrumb-item href="http://www.ebay.com/">eBay</ebay-breadcrumb-item>
     <ebay-breadcrumb-item href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches & Accessories</ebay-breadcrumb-item>
     <ebay-breadcrumb-item href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</ebay-breadcrumb-item>
-    <ebay-breadcrumb-item href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906">Smart Watch Bands</ebay-breadcrumb-item>
+    <ebay-breadcrumb-item>Smart Watch Bands</ebay-breadcrumb-item>
 </ebay-breadcrumb>
 
 <script>(function() {

--- a/src/components/ebay-breadcrumb/index.js
+++ b/src/components/ebay-breadcrumb/index.js
@@ -14,9 +14,11 @@ function getTemplateData(state, input) {
         let role;
         const href = item.href || null;
         const current = ((inputItems.length - 1) === index);
+        let shouldHandleClick = true;
         if (current && !href) {
             tag = 'span';
             ariaCurrent = 'page';
+            shouldHandleClick = false;
         }
         if (hijax) {
             role = 'button';
@@ -27,7 +29,8 @@ function getTemplateData(state, input) {
             htmlAttributes: itemHtmlAttributes,
             renderBody: item.renderBody,
             href,
-            ariaCurrent
+            ariaCurrent,
+            shouldHandleClick
         };
     });
     items = Object.keys(items).length > 0 ? items : null;

--- a/src/components/ebay-breadcrumb/mock/index.js
+++ b/src/components/ebay-breadcrumb/mock/index.js
@@ -1,6 +1,9 @@
-const item = { href: 'https://www.ebay.com/', navSrc: '{"actionKind":"NAVSRC","operationId":"2489527"}', _sp: 'p2489527.m4340.l9751.c1' };
-
 const getItem = (text, href) => {
+    const item = {
+        href: 'https://www.ebay.com/',
+        navSrc: '{"actionKind":"NAVSRC","operationId":"2489527"}',
+        _sp: 'p2489527.m4340.l9751.c1'
+    };
     const clonedItem = JSON.parse(JSON.stringify(item));
     clonedItem.renderBody = (stream) => stream.write(text);
     clonedItem.href = href;
@@ -8,43 +11,28 @@ const getItem = (text, href) => {
 };
 const basicItems = [getItem('eBay', 'https://www.ebay.com'),
     getItem('Auto Parts and Vehicles', 'https://www.ebay.com/b/Auto-Parts-and-Vehicles/6000/bn_1865334'),
-    getItem('Motors Parts & Accessories', 'https://www.ebay.com/rpp/motors-parts-accessories'),
-    getItem('Motorcycle Parts', 'https://www.ebay.com/b/Motorcycle-Parts/10063/bn_557636')];
+    getItem('Motors Parts & Accessories', null)];
 
-const itemsWithMissingLinks = [getItem('eBay', null),
+const firstItemMissingHref = [getItem('eBay', null),
     getItem('Auto Parts and Vehicles', 'https://www.ebay.com/b/Auto-Parts-and-Vehicles/6000/bn_1865334'),
-    getItem('Motors Parts & Accessories', 'https://www.ebay.com/rpp/motors-parts-accessories'),
-    getItem('Motorcycle Parts', 'https://www.ebay.com/b/Motorcycle-Parts/10063/bn_557636')];
-
-const itemsWithNoHref = [getItem('eBay', 'https://www.ebay.com/'),
-    getItem('Auto Parts and Vehicles', 'https://www.ebay.com/b/Auto-Parts-and-Vehicles/6000/bn_1865334'),
-    getItem('Motors Parts & Accessories', 'https://www.ebay.com/rpp/motors-parts-accessories'),
-    getItem('Motorcycle Parts', null)];
+    getItem('Motors Parts & Accessories', null)];
 
 module.exports = {
     basicItems: {
         headingText: 'Page navigation',
-        items: basicItems,
-        '*': { dataview: 'data-view tracking' }
+        items: basicItems
     },
     hijax: {
         hijax: true,
         items: basicItems
     },
-    itemsWithMissingLinks: {
+    firstItemMissingHref: {
         headingText: 'Page navigation',
-        items: itemsWithMissingLinks,
-        '*': { dataview: 'data-view tracking' }
-    },
-    itemsWithNoHref: {
-        headingText: 'Page navigation',
-        items: itemsWithNoHref,
-        '*': { dataview: 'data-view tracking' }
+        items: firstItemMissingHref
     },
     itemsWithHeadingLevel: {
         headingText: 'Page navigation',
         headingLevel: 'h3',
-        items: basicItems,
-        '*': { dataview: 'data-view tracking' }
+        items: basicItems
     }
 };

--- a/src/components/ebay-breadcrumb/template.marko
+++ b/src/components/ebay-breadcrumb/template.marko
@@ -1,8 +1,8 @@
-<nav if(data.items) aria-labelledby="breadcrumb-heading" class=data.classes role="navigation" ${data.htmlAttributes} w-bind w-onclick="handleClick">
+<nav if(data.items) aria-labelledby="breadcrumb-heading" class=data.classes role="navigation" ${data.htmlAttributes} w-bind>
     <${data.headingLevel} id="breadcrumb-heading" class="clipped">${data.headingText}</${data.headingLevel}>
     <ul>
         <li for(item in data.items)>
-            <${item.tag} href=item.href aria-current=item.ariaCurrent role=item.role ${item.htmlAttributes} w-body=item.renderBody/>
+            <${item.tag} href=item.href aria-current=item.ariaCurrent role=item.role ${item.htmlAttributes} w-body=item.renderBody w-onclick=(item.shouldHandleClick && "handleClick")/>
         </li>
     </ul>
 </nav>

--- a/src/components/ebay-breadcrumb/test/test.browser.js
+++ b/src/components/ebay-breadcrumb/test/test.browser.js
@@ -7,14 +7,16 @@ const renderer = require('../');
 describe('given a basic breadcrumb', () => {
     let widget;
     let firstItem;
+    let lastItem;
 
     beforeEach(() => {
         widget = renderer.renderSync(mock.basicItems).appendTo(document.body).getWidget();
-        firstItem = document.querySelectorAll('nav li a')[0];
+        firstItem = document.querySelector('nav li a');
+        lastItem = document.querySelector('nav li span');
     });
     afterEach(() => widget.destroy());
 
-    describe('when item is clicked', () => {
+    describe('when an <a> item is clicked', () => {
         let spy;
         beforeEach((done) => {
             spy = sinon.spy();
@@ -27,6 +29,20 @@ describe('given a basic breadcrumb', () => {
             expect(spy.calledOnce).to.equal(true);
             expect(spy.getCall(0).args[0].el).to.deep.equal(firstItem);
             testUtils.testOriginalEvent(spy);
+        });
+    });
+
+    describe('when a <span> item is clicked', () => {
+        let spy;
+        beforeEach((done) => {
+            spy = sinon.spy();
+            widget.on('breadcrumb-select', spy);
+            testUtils.triggerEvent(lastItem, 'click');
+            setTimeout(done);
+        });
+
+        it('then it does not emit the breadcrumb-select event', () => {
+            expect(spy.called).equal(false);
         });
     });
 });

--- a/src/components/ebay-breadcrumb/test/test.server.js
+++ b/src/components/ebay-breadcrumb/test/test.server.js
@@ -2,67 +2,53 @@ const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/server');
 const mock = require('../mock');
 
-describe('should render with basic breadcrumb and ', () => {
-    test('return nav element with input', context => {
-        const $ = testUtils.getCheerio(context.render(mock.basicItems));
-        const nav = $('nav');
-        expect(nav.length).to.equal(1);
-        expect(nav.attr('role')).to.equal('navigation');
-        expect(nav.attr('dataview')).to.equal('data-view tracking');
-        expect(nav.attr('class')).to.equal('breadcrumb');
-        expect(nav.attr('aria-labelledby')).to.equal('breadcrumb-heading');
-    });
-    test('return h2 tag', context => {
-        const $ = testUtils.getCheerio(context.render(mock.basicItems));
-        const h2Tag = $('h2');
-        expect(h2Tag.length).to.equal(1);
-        expect(h2Tag.attr('id')).to.equal('breadcrumb-heading');
-        expect(h2Tag.attr('class')).to.equal('clipped');
-        expect(h2Tag.html()).to.equal('Page navigation');
-    });
-    test('create <a> tag if href is NOT null for last item', context => {
-        const $ = testUtils.getCheerio(context.render(mock.basicItems));
-        const li = $('nav li');
-        expect(li.length).to.equal(4);
-        const anchor = $('nav li a');
-        expect(anchor.length).to.equal(4);
-    });
-    test('handles pass-through html attributes for item', context => {
-        testUtils.testHtmlAttributes(context, 'li span', 'items');
-    });
-
-    test('handles custom class for item', context => {
-        testUtils.testCustomClass(context, 'li span', 'items', true);
-    });
+test('renders basic structure', context => {
+    const $ = testUtils.getCheerio(context.render(mock.basicItems));
+    expect($('nav.breadcrumb').length).to.equal(1);
+    const h2Tag = $('h2#breadcrumb-heading.clipped');
+    expect(h2Tag.length).to.equal(1);
+    expect(h2Tag.html()).to.equal(mock.basicItems.headingText);
+    expect($('nav li').length).to.equal(mock.basicItems.items.length);
+    expect($('nav li a').length).to.equal(mock.basicItems.items.length - 1);
 });
 
 test('should set item roles for hijax version', context => {
     const input = mock.hijax;
     const $ = testUtils.getCheerio(context.render(input));
-    expect($('li a[role="button"]').length).to.equal(input.items.length);
+    expect($('li a[role="button"]').length).to.equal(input.items.length - 1);
 });
-test('should return zero nav element in the page', context => {
+
+test('does not render with empty input', context => {
     const input = {};
     const $ = testUtils.getCheerio(context.render(input));
     expect($('nav').length).to.equal(0);
 });
-test('should create <a> without href if href attr is passed null unless its last item', context => {
-    const $ = testUtils.getCheerio(context.render(mock.itemsWithMissingLinks));
+
+test('renders <a> without href for missing input href on non-last item', context => {
+    const $ = testUtils.getCheerio(context.render(mock.firstItemMissingHref));
     const li = $('nav li');
-    expect($('a', li[0]).attr('href')).to.be.an('undefined');
-    expect(li.length).to.equal(4);
+    expect($('a', li[0]).attr('href')).to.equal(undefined);
+    expect(li.length).to.equal(mock.firstItemMissingHref.items.length);
 });
-test('should create span tag if href is null ', context => {
-    const $ = testUtils.getCheerio(context.render(mock.itemsWithNoHref));
+
+test('renders span tag if href is null on last item', context => {
+    const $ = testUtils.getCheerio(context.render(mock.basicItems));
     const li = $('nav li');
-    expect(li.length).to.equal(4);
+    expect(li.length).to.equal(mock.basicItems.items.length);
     const currentElement = $('span', li[li.length - 1]);
     expect(currentElement.attr('aria-current')).to.equal('page');
 });
-test('return headingLevel', context => {
+
+test('renders different heading tag when specified', context => {
     const $ = testUtils.getCheerio(context.render(mock.itemsWithHeadingLevel));
-    const h2Tag = $('h2');
-    expect(h2Tag.length).to.equal(0);
-    const h3Tag = $('h3');
-    expect(h3Tag.length).to.equal(1);
+    expect($('h2').length).to.equal(0);
+    expect($('h3').length).to.equal(1);
+});
+
+test('handles pass-through html attributes for item', context => {
+    testUtils.testHtmlAttributes(context, 'li span', 'items');
+});
+
+test('handles custom class for item', context => {
+    testUtils.testCustomClass(context, 'li span', 'items', true);
 });


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- fix event so it doesn't fire from `<span>` breadcrumbs
- clean up tests/mocks

## Context
<!--- Why did you make these changes, and why in this particular way? -->
I moved the `handleClick` to each breadcrumb element (conditionally), since Marko handles delegation anyway.

In verifying the changes, I cleaned up the current test suite. I stripped the mock down to the basics, and reduced some of the clutter in the tests. Coverage for the component is unchanged at 100%.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixed #125 
