### PR TITLE
Carousel: remove cursor:pointer

### DIFF
--- a/src/components/ebay-carousel/style-no-touch.less
+++ b/src/components/ebay-carousel/style-no-touch.less
@@ -7,7 +7,6 @@
 
             &[aria-disabled="true"] {
                 opacity: @ebay-carousel-control-disabled-opacity;
-                cursor: default;
             }
         }
 

--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -26,7 +26,6 @@
 
         &[aria-disabled="true"] {
             opacity: @ebay-carousel-control-disabled-opacity;
-            cursor: default;
         }
     }
 }

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -42,7 +42,6 @@
         width: 28px;
         z-index: 1;
         border: 1px solid @ds6-color-g206-gray;
-        cursor: pointer;
         position: absolute;
         top: 50%;
         transform: translateY(-50%);
@@ -78,7 +77,6 @@
 
             > button {
                 background-color: @ds6-color-g206-gray;
-                cursor: pointer;
                 border: 0;
                 border-radius: 50%;
                 display: inline-block;


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- remove `cursor:pointer` from the carousel controls and pagination
- remove the `cursor: default` override that was needed for disabled buttons

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This is the only usage of `cursor: pointer` in this repo. Others are from Skin.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixed #218 

