### PR TITLE
Fix not accounting for multiple src -> dist replacements.

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -24,7 +24,7 @@ fs.readdirSync(`${__dirname}/../dist/components`).map(component => ({
     path: `${__dirname}/../dist/components/${component}/browser.json`
 })).filter(isFile).map(obj => {
     const data = fs.readFileSync(obj.path, 'utf-8');
-    fs.writeFileSync(obj.path, data.replace('src/components', 'dist/components'), 'utf-8');
+    fs.writeFileSync(obj.path, data.replace(/src\/components/g, 'dist/components'), 'utf-8');
 });
 
 // update marko.json


### PR DESCRIPTION
## Description
Currently the build script will only replace the first instance of `src/components` found in each `browser.json`. `ebay-menu` recently got updated to have two and this broke the build.

## Context
This caused the marketplace build to fail (and broke the `ebay-menu` in general on npm). In this PR all instances are replaced.

Note: We should merge/publish this soon as currently the 0.7.0-0 prerelease is broken.
