### PR TITLE
Remove dialog placeholder element.

### DIFF
--- a/src/components/ebay-dialog/index.js
+++ b/src/components/ebay-dialog/index.js
@@ -9,7 +9,7 @@ const transition = require('../../common/transition');
 const template = require('./template.marko');
 
 function init() {
-    this.dialogEl = this.getEl('dialog');
+    this.dialogEl = this.getEl();
     this.windowEl = this.getEl('window');
     this.closeEl = this.getEl('close');
     this.bodyEl = this.getEl('body');
@@ -104,7 +104,7 @@ function trap(opts) {
                 // Reset dialog scroll position lazily to avoid jank.
                 // Note since the dialog is not in the dom at this point none of the scroll methods will work.
                 this.cancelScrollReset = setTimeout(() => {
-                    this.el.replaceChild(this.dialogEl, this.dialogEl);
+                    this.dialogEl.parentNode.replaceChild(this.dialogEl, this.dialogEl);
                     this.cancelScrollReset = undefined;
                 }, 20);
             }

--- a/src/components/ebay-dialog/template.marko
+++ b/src/components/ebay-dialog/template.marko
@@ -1,12 +1,10 @@
 
-<div class="dialog-placeholder" w-bind>
-    <div w-id="dialog" class=data.dialogClass hidden=!data.open role="dialog" w-preserve-attrs="hidden" ${data.htmlAttributes} w-onclick="handleDialogClick">
-        <div w-id="window" class=data.windowClass role="document">
-            <button w-id="close" class="dialog__close" type="button" aria-label=data.ariaLabelClose w-onclick="handleCloseButtonClick">
-                <ebay-icon type="inline" name="close"/>
-            </button>
+<div w-bind class=data.dialogClass hidden=!data.open role="dialog" w-preserve-attrs="hidden" ${data.htmlAttributes} w-onclick="handleDialogClick">
+    <div w-id="window" class=data.windowClass role="document">
+        <button w-id="close" class="dialog__close" type="button" aria-label=data.ariaLabelClose w-onclick="handleCloseButtonClick">
+            <ebay-icon type="inline" name="close"/>
+        </button>
 
-            <div class="dialog__body" w-id="body" w-body/>
-        </div>
+        <div class="dialog__body" w-id="body" w-body/>
     </div>
 </div>

--- a/src/components/ebay-dialog/test/test.browser.js
+++ b/src/components/ebay-dialog/test/test.browser.js
@@ -4,7 +4,6 @@ const renderer = require('../');
 describe('given the dialog is in the default state', () => {
     let widget;
     let root;
-    let dialog;
     let close;
     let sibling;
 
@@ -14,15 +13,14 @@ describe('given the dialog is in the default state', () => {
 
         widget = renderer.renderSync({}).appendTo(document.body).getWidget();
         root = widget.el;
-        dialog = root.querySelector('.dialog');
-        close = dialog.querySelector('.dialog__close');
+        close = root.querySelector('.dialog__close');
     });
 
     afterEach(() => widget.destroy());
 
     describe('when it is rendered', () => {
         test('then it is hidden in the DOM', () => {
-            expect(dialog.hidden).to.equal(true);
+            expect(root.hidden).to.equal(true);
         });
 
         test('then <body> is scrollable', () => {
@@ -38,7 +36,7 @@ describe('given the dialog is in the default state', () => {
         });
 
         test('then it does not trap focus', () => {
-            expect(dialog.classList.contains('keyboard-trap--active')).to.equal(false);
+            expect(root.classList.contains('keyboard-trap--active')).to.equal(false);
         });
     });
 
@@ -62,8 +60,8 @@ describe('given the dialog is in the default state', () => {
 
     function thenItIsOpen(skipRerender) {
         test('then it is visible in the DOM', () => {
-            expect(dialog.hidden).to.equal(false);
-            expect(dialog.getAttribute('aria-hidden')).to.equal('false');
+            expect(root.hidden).to.equal(false);
+            expect(root.getAttribute('aria-hidden')).to.equal('false');
         });
 
         test('then it\'s siblings are hidden', () => {
@@ -75,7 +73,7 @@ describe('given the dialog is in the default state', () => {
         });
 
         test('then it traps focus', () => {
-            expect(dialog.classList.contains('keyboard-trap--active')).to.equal(true);
+            expect(root.classList.contains('keyboard-trap--active')).to.equal(true);
             expect(document.activeElement.className).to.eql(close.className);
         });
 
@@ -95,7 +93,6 @@ describe('given the dialog is in the default state', () => {
 describe('given the dialog is in the open state', () => {
     let widget;
     let root;
-    let dialog;
     let close;
     let sibling;
 
@@ -105,16 +102,15 @@ describe('given the dialog is in the open state', () => {
 
         widget = renderer.renderSync({ open: true }).appendTo(document.body).getWidget();
         root = widget.el;
-        dialog = root.querySelector('.dialog');
-        close = dialog.querySelector('.dialog__close');
+        close = root.querySelector('.dialog__close');
     });
 
     afterEach(() => widget.destroy());
 
     describe('when it is rendered', () => {
         test('then it is visible in the DOM', () => {
-            expect(dialog.hidden).to.equal(false);
-            expect(dialog.getAttribute('aria-hidden')).to.equal('false');
+            expect(root.hidden).to.equal(false);
+            expect(root.getAttribute('aria-hidden')).to.equal('false');
         });
 
         test('then it\'s siblings are hidden', () => {
@@ -126,7 +122,7 @@ describe('given the dialog is in the open state', () => {
         });
 
         test('then it traps focus', () => {
-            expect(dialog.classList.contains('keyboard-trap--active')).to.equal(true);
+            expect(root.classList.contains('keyboard-trap--active')).to.equal(true);
             expect(document.activeElement.className).to.eql(close.className);
         });
     });
@@ -161,7 +157,7 @@ describe('given the dialog is in the open state', () => {
     describe('when the mask is clicked', () => {
         beforeEach((done) => {
             widget.subscribeTo(root).once('dialog-close', done);
-            dialog.click(); // simulate clicking outside the dialog.
+            root.click(); // simulate clicking outside the dialog.
         });
 
         thenItIsClosed();
@@ -169,7 +165,7 @@ describe('given the dialog is in the open state', () => {
 
     function thenItIsClosed(skipRerender) {
         test('then it is hidden in the DOM', () => {
-            expect(dialog.hidden).to.equal(true);
+            expect(root.hidden).to.equal(true);
         });
 
         test('then <body> is scrollable', () => {
@@ -185,7 +181,7 @@ describe('given the dialog is in the open state', () => {
         });
 
         test('then it does not trap focus', () => {
-            expect(dialog.classList.contains('keyboard-trap--active')).to.equal(false);
+            expect(root.classList.contains('keyboard-trap--active')).to.equal(false);
         });
 
         if (!skipRerender) {


### PR DESCRIPTION
## Description
This removes the extra `.dialog-placeholder` element for the `ebay-dialog` component.

## Context
This placeholder was added back when the plan was to implement the dialog using a portal to the document body. As I have mentioned before I think It makes the most sense to hold off on that implementation (also it's working fairly well as is) until we upgrade to Marko v4. On top of that when we upgrade to Marko v4 it no longer requires that I have this placeholder anyway.

## References
Fixes #262 