### PR TITLE
CI: fix on scroll end grouped

### DIFF
--- a/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
@@ -24,7 +24,6 @@ describe('scroll-end', () => {
     it('calls a function when a scroll has ended', (done) => {
         const scrollEndSpy = sinon.spy();
         onScrollEnd(scrollEl, scrollEndSpy);
-        simulateScroll(scrollEl, 50);
         setTimeout(() => {
             simulateScroll(scrollEl, 100);
             setTimeout(() => {
@@ -34,12 +33,12 @@ describe('scroll-end', () => {
                 done();
             }, 300);
         }, 150);
+        simulateScroll(scrollEl, 50);
     });
 
     it('groups scroll events with additional touches', (done) => {
         const scrollEndSpy = sinon.spy();
         onScrollEnd(scrollEl, scrollEndSpy);
-        simulateScroll(scrollEl, 50);
         setTimeout(() => {
             simulateScroll(scrollEl, 100);
             setTimeout(() => {
@@ -48,6 +47,7 @@ describe('scroll-end', () => {
                 done();
             }, 150);
         }, 0);
+        simulateScroll(scrollEl, 50);
     });
 });
 


### PR DESCRIPTION
## Description
Ensures that the timeouts are setup before simulated scroll transitions run.

## Context
This caused the CI to fail intermittently because previously the simulated scroll animation frame could (if the browser is running slowly) finish before the `setTimeout` of `0`.

Moving the transition to be after the timeout ensures that the timeout is always called first.