### PR TITLE
Speed up tests by forcing all transitions to be faster.

### DIFF
--- a/src/common/test-utils/transitions.js
+++ b/src/common/test-utils/transitions.js
@@ -1,0 +1,4 @@
+// Adds an style to the document which forces all transitions to run more quickly for the tests.
+const style = document.createElement('style');
+style.innerHTML = `* { transition-duration: 0.1s !important; }`;
+document.head.appendChild(style);

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -1,12 +1,10 @@
+require('../../../common/test-utils/transitions');
+
 const sinon = require('sinon');
 const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/browser');
 const mock = require('../mock');
 const renderer = require('../');
-const styleOverrides = document.createElement('style');
-// No need to run the full length animation when testing the carousel.
-styleOverrides.innerHTML = `.carousel__list { transition: transform 0.05s linear; }`;
-document.head.appendChild(styleOverrides);
 
 function delay(callback) {
     setTimeout(callback, 42);

--- a/src/components/ebay-dialog/test/test.browser.js
+++ b/src/components/ebay-dialog/test/test.browser.js
@@ -1,3 +1,5 @@
+require('../../../common/test-utils/transitions');
+
 const expect = require('chai').expect;
 const renderer = require('../');
 


### PR DESCRIPTION
## Description
Currently in the carousel tests we are overriding the transition timings for all carousels to make the tests run faster. In this PR I have extracted that out and made it more generic such that it applies to the dialog as well.

## Context
Locally this causes the tests to run ~15s quicker 🎉.
