### PR TITLE
Adding <span> to match Skin updates;

### DIFF
--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -12,4 +12,5 @@
             ${option.label}
         </option>
     </select>
+    <span class="select__icon"/>
 </span>


### PR DESCRIPTION
## Description
Added the empty span to use for the icon.

## Context
The current Skin implementation uses a `::after` pseudo-element, but that implementation had limitations which were undesirable. Skin has been updated to use a `<span>` with a background SVG, or `<svg>` with a foreground SVG. This allows for much better control, and in the case of the foreground SVG, full customization of the icon.

## References
Related to https://github.com/eBay/skin/issues/222