### PR TITLE
Carousel: Add `gap` attribute to `marko.json`.

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -37,6 +37,7 @@
         "@index": "string",
         "@type": "string",
         "@slide": "string",
+        "@gap": "string",
         "@items-per-slide": "string",
         "@accessibility-prev": "string",
         "@accessibility-next": "string",


### PR DESCRIPTION
## Description
Currently it is still impossible to set the gap property on the carousel because it is missing from the `marko.json`.