### PR TITLE
Carousel: Remove prev/next for discrete carousels on touch devices.

### DIFF
--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -29,6 +29,7 @@ function getInitialState(input) {
     // Remove any extra items when using explicit itemsPerSlide.
     const { items, itemsPerSlide } = state;
     if (itemsPerSlide) {
+        state.classes.push('carousel--slides');
         items.length -= items.length % itemsPerSlide;
     }
 

--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -1,5 +1,13 @@
 .carousel {
-    &__control {
+    &--slides &__control, // show controls on touch since there's no hover.
+    &__control:focus { // also show controls on focus for a11y.
+        opacity: @ebay-carousel-control-enabled-opacity;
+        pointer-events: auto;
+
+        &[aria-disabled="true"] {
+            opacity: @ebay-carousel-control-disabled-opacity;
+        }
+
         &:active:not([aria-disabled="true"]) {
             background-color: @ds6-color-g205-gray;
 
@@ -16,16 +24,6 @@
 
         &::-webkit-scrollbar {
             display: none;
-        }
-    }
-
-    // show controls on touch since there's no hover
-    .carousel__control {
-        opacity: @ebay-carousel-control-enabled-opacity;
-        pointer-events: auto;
-
-        &[aria-disabled="true"] {
-            opacity: @ebay-carousel-control-disabled-opacity;
         }
     }
 }

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -10,7 +10,8 @@
             aria-live="polite">
             ${data.accessibilityStatus}
         </span>
-        <button class="carousel__control carousel__control--prev"
+        <button
+            class="carousel__control carousel__control--prev"
             w-onclick=(!data.prevControlDisabled && "handleMove")
             data-direction=-1
             aria-describedby=statusId


### PR DESCRIPTION
## Description
Adds a new `--slides` modifier to the carousel element to detect with css when we have slides (continuous carousels do not have slides).
Uses this to only show the prev/next button when we have slides or the buttons are focused for a11y.

## References
#278 