### PR TITLE
Carousel: Disable native scrolling for autoplay carousel.

### DIFF
--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -57,4 +57,7 @@ Event | Data | Description
 `carousel-play` | `{ originalEvent }` | called when the autoplay play button is pressed
 `carousel-pause` | `{ originalEvent }` | called when the autoplay pause button is pressed
 
-Note: The `carousel` will manipulate the `tabindex` property of nested focusable elements inside `<ebay-carousel-item>`.
+Notes:
+
+* The `carousel` will manipulate the `tabindex` property of nested focusable elements inside `<ebay-carousel-item>`.
+* The `autoplay` carousel currently does not support native scrolling and will use transforms instead.

--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -17,7 +17,7 @@
         }
     }
 
-    &__list {
+    &:not(&__autoplay) &__list {
         overflow-x: auto; // also used in js to determine scroll behavior
         -webkit-overflow-scrolling: touch;
         -ms-overflow-style: none;


### PR DESCRIPTION
## Description
Currently the infinite scrolling of the autoplay carousel causes native scrolling to break on mobile.

## Context
This PR disables native scrolling for autoplay carousels in mobile to sidestep the issue. This should probably be supported in the future however the native scrolling for discrete carousels is a recent addition anyways.

## References
Fixes #291 
