### PR TITLE
Carousel: a11y fixes

### DIFF
--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -6,9 +6,8 @@
             if(data.totalSlides >= 1)
             id=statusId
             class="clipped"
-            role="status"
-            aria-live="polite">
-            ${data.accessibilityStatus}
+            aria-live=(data.autoplayInterval && !data.paused ? "off" : "polite")>
+            <span>${data.accessibilityStatus}</span>
         </span>
         <button
             class="carousel__control carousel__control--prev"
@@ -66,7 +65,7 @@
         </if>
     </div>
 
-    <ul class="carousel__dots" role="navigation" if(!data.noDots && data.totalSlides > 1)>
+    <ul class="carousel__dots" if(!data.noDots && data.totalSlides > 1)>
         <li for(i from 0 to data.totalSlides - 1)>
             <var isActive=(i === data.slide)/>
             <button

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -27,7 +27,7 @@ describe('carousel', () => {
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.carousel__control--prev[aria-label="prev"]').length).to.equal(1);
         expect($('.carousel__control--next[aria-label="next"]').length).to.equal(1);
-        expect($('.clipped[role="status"]').text()).to.equal('1 of 6');
+        expect($('.clipped[aria-live] span').text()).to.equal('1 of 6');
         expect($('[data-slide="0"][aria-label="slide 1"]').length).to.equal(1);
         expect($('[data-slide="1"][aria-label="other 2"]').length).to.equal(1);
     });


### PR DESCRIPTION
## Description
Misc a11y fixes for the carousel including:

1. Change `polite` to `off` when autoplaying.
2. Add an extra span in the carousel status.
3. Remove `role=status`.
4. Remove `role=navigation` from the dots controls.

## References
Fixes #294 
Fixes #296
