### PR TITLE
Button: fix originalEvent for keydown

### DIFF
--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -68,7 +68,7 @@ function handleClick(originalEvent) {
  */
 function handleKeydown(e) {
     eventUtils.handleActionKeydown(e, () => {
-        this.handleClick();
+        this.handleClick(e);
     });
 }
 

--- a/src/components/ebay-button/test/test.browser.js
+++ b/src/components/ebay-button/test/test.browser.js
@@ -32,6 +32,20 @@ describe('given button is enabled', () => {
             testUtils.testOriginalEvent(spy);
         });
     });
+
+    describe('when button is clicked via action key', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('button-click', spy);
+            testUtils.triggerEvent(root, 'keydown', 32);
+        });
+
+        test('then it emits the event with correct data', () => {
+            expect(spy.calledOnce).to.equal(true);
+            testUtils.testOriginalEvent(spy);
+        });
+    });
 });
 
 describe('given button is disabled', () => {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- pass `originalEvent` for action keydown in the `button`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Minor oversight.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #295 
