### PR TITLE
Demo: Set correct font family for DS4 components

### DIFF
--- a/demo/style.less
+++ b/demo/style.less
@@ -5,6 +5,10 @@ html {
 body {
     font-family: 'Market Sans', Arial;
     margin: 15px;
+
+    .ds4 & {
+        font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
+    }
 }
 
 h1 {

--- a/demo/template.marko
+++ b/demo/template.marko
@@ -1,5 +1,5 @@
 <lasso-page name="demo" package-path="./browser.json" flags=data.lassoFlags dependencies=data.model.dependencies/>
-<html class="${data.params.designSystem}">
+<html class=data.params.designSystem>
     <head>
         <lasso-head/>
         <title>ebayui-core</title>

--- a/demo/template.marko
+++ b/demo/template.marko
@@ -1,5 +1,5 @@
 <lasso-page name="demo" package-path="./browser.json" flags=data.lassoFlags dependencies=data.model.dependencies/>
-<html>
+<html class="${data.params.designSystem}">
     <head>
         <lasso-head/>
         <title>ebayui-core</title>


### PR DESCRIPTION
## Description
- adds a `.ds4` class to the page when we're in DS4 system
- new rule for DS4 font family

## Context
Viewing the DS4 components with the Market Sans font (DS6 font family) was having improper results. Specifically, we were viewing the pages with Arial (because Market Sans was removed for the DS4 JS bundle). Changing the font family for DS4 rules fixes the components' font.