### PR TITLE
Pagination: remove aria-current attribute when not needed

### DIFF
--- a/src/components/ebay-pagination/template.marko
+++ b/src/components/ebay-pagination/template.marko
@@ -19,7 +19,7 @@
     <ol class="pagination__items">
         <for(item in data.items)>
             <li>
-                <a aria-current=(item.current ? "page" : '')
+                <a aria-current=(item.current && "page")
                     href=item.href
                     role=item.role
                     class=item.class

--- a/src/components/ebay-pagination/test/test.server.js
+++ b/src/components/ebay-pagination/test/test.server.js
@@ -23,7 +23,7 @@ describe('pagination', () => {
 
     test('renders without a selected element when current page not defined', context => {
         const $ = testUtils.getCheerio(context.render(mock.basicLinksWithoutCurrent));
-        expect($('.pagination__item[aria-current="page"]').length).to.equal(0);
+        expect($('.pagination__item[aria-current]').length).to.equal(0);
     });
 
     test('renders with aria-disabled when navigation is disabled', context => {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- remove `aria-current` on `pagination` when not needed
- adjust tests

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This should resolve to a falsy value so that Marko doesn't render the attribute.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #302 