### PR TITLE
Carousel: Improve test coverage

### DIFF
--- a/src/common/event-utils/test/test.browser.js
+++ b/src/common/event-utils/test/test.browser.js
@@ -81,21 +81,21 @@ describe('resizeEventUtil', () => {
         resizeUtil.addEventListener('resize', mockCallback.bind(this));
         expect(mockCallback.callCount).to.equal(0);
         testUtils.triggerEvent(window, 'resize');
-        setTimeout(() => {
+        testUtils.waitFrames(2, () => {
             expect(mockCallback.callCount).to.equal(1);
             done();
-        }, 26);
+        });
     });
 
-    test('the root element does not listen for a window resize, after eventListner is removed', (context, done) => {
+    test('the root element does not listen for a window resize, after eventListener is removed', (context, done) => {
         const mockCallback = sinon.spy();
         resizeUtil.addEventListener('resize', mockCallback.bind(this));
         resizeUtil.removeEventListener('resize', mockCallback.bind(this));
         expect(mockCallback.callCount).to.equal(0);
         testUtils.triggerEvent(window, 'resize');
-        setTimeout(() => {
+        testUtils.waitFrames(2, () => {
             expect(mockCallback.callCount).to.equal(0);
             done();
-        }, 26);
+        });
     });
 });

--- a/src/common/test-utils/browser.js
+++ b/src/common/test-utils/browser.js
@@ -21,7 +21,35 @@ function testOriginalEvent(spy) {
     expect(spy.getCall(0).args[0].originalEvent instanceof Event).to.equal(true);
 }
 
+/**
+ * Simulates a touch based scroll event over 100ms.
+ *
+ * @param {HTMLElement} el The element to scroll.
+ * @param {number} to The new scrollLeft for the element.
+ */
+function simulateScroll(el, to) {
+    const { scrollLeft } = el;
+    const distance = to - scrollLeft;
+    const duration = 100;
+    triggerEvent(el, 'touchstart');
+    requestAnimationFrame(startTime => {
+        (function animate(curTime) {
+            const delta = curTime - startTime;
+            if (delta > duration) {
+                triggerEvent(el, 'touchend');
+                el.scrollLeft = to;
+                return;
+            }
+
+            triggerEvent(el, 'touchmove');
+            el.scrollLeft = (delta / duration) * distance + scrollLeft;
+            requestAnimationFrame(animate);
+        }(startTime));
+    });
+}
+
 module.exports = {
     triggerEvent,
-    testOriginalEvent
+    testOriginalEvent,
+    simulateScroll
 };

--- a/src/common/transition/test/test.browser.js
+++ b/src/common/transition/test/test.browser.js
@@ -1,5 +1,6 @@
 const sinon = require('sinon');
 const expect = require('chai').expect;
+const testUtils = require('../../test-utils/browser');
 const transition = require('../');
 
 describe('transition', () => {
@@ -42,7 +43,7 @@ describe('transition', () => {
         transitionEl.removeAttribute('hidden');
         expect(transitionEl.classList.contains('show-init')).to.equal(true);
 
-        setTimeout(() => {
+        testUtils.waitFrames(2, () => {
             const handleEnd = () => {
                 transitionEl.removeEventListener('transitionend', handleEnd);
                 expect(transitionEl.classList.contains('show')).to.equal(false);
@@ -51,18 +52,16 @@ describe('transition', () => {
             expect(transitionEl.classList.contains('show-init')).to.equal(false);
             expect(transitionEl.classList.contains('show')).to.equal(true);
             transitionEl.addEventListener('transitionend', handleEnd);
-        }, 30);
+        });
     });
 
     it('triggers a callback once complete', (done) => {
         const spy = sinon.spy();
         transition({ el: transitionEl, className: 'show', waitFor: [transitionEl] }, spy);
         transitionEl.removeAttribute('hidden');
-        transitionEl.addEventListener('transitionend', spy);
-        setTimeout(() => {
-            transitionEl.removeEventListener('transitionend', spy);
-            expect(spy.callCount).to.equal(2);
+        transitionEl.addEventListener('transitionend', () => setTimeout(() => {
+            expect(spy.callCount).to.equal(1);
             done();
-        }, 200);
+        }));
     });
 });

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -305,6 +305,7 @@ function handleScrollEnd(scrollLeft) {
     // Always update with the new index to ensure the scroll animations happen.
     config.preserveItems = true;
     this.setStateDirty('index', closest);
+    this.once('update', this.emitUpdate);
 }
 
 /**

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -486,16 +486,12 @@ describe('given a discrete carousel', () => {
     });
 
     describe('when the window is resized', () => {
-        let originalFrame;
-
-        beforeEach(done => {
-            originalFrame = widget.renderFrame;
+        beforeEach(() => {
             testUtils.triggerEvent(window, 'resize');
-            delay(done);
         });
 
-        it('then it causes the widget to render', () => {
-            expect(widget.renderFrame).to.not.equal(originalFrame);
+        it('then it causes the widget to render', (done) => {
+            widget.once('update', () => done());
         });
     });
 });

--- a/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
@@ -24,28 +24,25 @@ describe('scroll-end', () => {
     it('calls a function when a scroll has ended', (done) => {
         const scrollEndSpy = sinon.spy();
         onScrollEnd(scrollEl, scrollEndSpy);
-        setTimeout(() => {
-            testUtils.simulateScroll(scrollEl, 100);
-            setTimeout(() => {
+        testUtils.simulateScroll(scrollEl, 50, () => {
+            testUtils.simulateScroll(scrollEl, 100, () => {
                 expect(scrollEndSpy.calledTwice).to.equal(true);
                 expect(scrollEndSpy.args[0][0]).to.equal(50);
                 expect(scrollEndSpy.args[1][0]).to.equal(100);
                 done();
-            }, 300);
-        }, 150);
-        testUtils.simulateScroll(scrollEl, 50);
+            });
+        });
     });
 
     it('groups scroll events with additional touches', (done) => {
         const scrollEndSpy = sinon.spy();
         onScrollEnd(scrollEl, scrollEndSpy);
         setTimeout(() => {
-            testUtils.simulateScroll(scrollEl, 100);
-            setTimeout(() => {
+            testUtils.simulateScroll(scrollEl, 100, () => {
                 expect(scrollEndSpy.calledOnce).to.equal(true);
                 expect(scrollEndSpy.args[0][0]).to.equal(100);
                 done();
-            }, 150);
+            });
         }, 0);
         testUtils.simulateScroll(scrollEl, 50);
     });
@@ -54,11 +51,12 @@ describe('scroll-end', () => {
         const scrollEndSpy = sinon.spy();
         const cancel = onScrollEnd(scrollEl, scrollEndSpy);
         testUtils.simulateScroll(scrollEl, 100);
-        cancel();
-        setTimeout(() => {
+        testUtils.waitFrames(5, () => {
             expect(scrollEndSpy.notCalled).to.equal(true);
             done();
-        }, 150);
+        });
+
+        cancel();
     });
 
     it('can be canceled after scrolling starts', (done) => {
@@ -66,13 +64,13 @@ describe('scroll-end', () => {
         const cancel = onScrollEnd(scrollEl, scrollEndSpy);
         const startLeft = scrollEl.scrollLeft;
         testUtils.simulateScroll(scrollEl, 100);
-        setTimeout(() => {
+        testUtils.waitFrames(2, () => {
             cancel();
-            setTimeout(() => {
+            testUtils.waitFrames(3, () => {
                 expect(scrollEndSpy.notCalled).to.equal(true);
                 expect(scrollEl.scrollLeft).to.not.equal(startLeft);
                 done();
-            }, 100);
-        }, 50);
+            });
+        });
     });
 });

--- a/src/components/ebay-carousel/utils/scroll-transition/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/scroll-transition/test/test.browser.js
@@ -42,4 +42,25 @@ describe('scroll-transition', () => {
 
         scrollTransition(scrollEl, 100, spy);
     });
+
+    it('continues a canceled transition if the touch event does not move', (done) => {
+        const spy = sinon.spy();
+        setTimeout(() => {
+            testUtils.triggerEvent(scrollEl, 'touchstart');
+            setTimeout(() => {
+                expect(scrollEl.scrollLeft).to.not.equal(0);
+                expect(scrollEl.scrollLeft).to.not.equal(100);
+                expect(spy.callCount).to.equal(0);
+                testUtils.triggerEvent(scrollEl, 'touchend');
+
+                setTimeout(() => {
+                    expect(scrollEl.scrollLeft).to.equal(100);
+                    expect(spy.callCount).to.equal(1);
+                    done();
+                }, 300);
+            }, 300);
+        }, 50);
+
+        scrollTransition(scrollEl, 100, spy);
+    });
 });


### PR DESCRIPTION
## Description
This PR adds additional tests for the mobile scrolling version of the carousel and the two utilities `on-scroll-end` and `scroll-transition` associated with mobile scrolling.

While adding these tests I noticed that in the scroll end case the `carousel-update` event was not firing and that fix is included in this PR.

## References
Resolves #309 