### PR TITLE
Combobox: move htmlAttributes to input tag

### DIFF
--- a/src/components/ebay-combobox/README.md
+++ b/src/components/ebay-combobox/README.md
@@ -35,6 +35,8 @@ Name | Required | Type | Stateful | Description
 `selected` | n/a | Number | Yes | allows you to set the selected index option to `selected`
 `borderless` | No | Boolean | No | whether button has borders
 
+Note: For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
+
 ### ebay-combobox Events
 
 Event | Data |  Description

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -1,6 +1,5 @@
 <span
     class=data.class
-    ${data.htmlAttributes}
     w-on-expander-expand='handleExpand'
     w-on-expander-collapse='handleCollapse'
     w-bind>
@@ -15,7 +14,8 @@
             aria-owns=widget.elId('combobox__options')
             aria-expanded='false'
             w-on-keydown='handleComboboxKeyDown'
-            w-preserve-attrs="aria-expanded"/>
+            w-preserve-attrs="aria-expanded"
+            ${data.htmlAttributes}/>
         <span class="combobox__icon" aria-hidden="true"></span>
     </span>
     <div

--- a/src/components/ebay-combobox/test/test.server.js
+++ b/src/components/ebay-combobox/test/test.server.js
@@ -55,7 +55,7 @@ describe('select', () => {
     });
 
     test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, 'span.combobox');
+        testUtils.testHtmlAttributes(context, 'input');
     });
 
     test('handles custom class', context => {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- move `htmlAttributes` from root tag to input tag of combobox
- update README.md
- update tests

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This is a typical pattern we use for components with a prominent `input` tag. Just to note, this is a breaking change, as we don't know if anyone was relying on its placement in the root tag.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #288 