### PR TITLE
Breadcrumb: Fixing accessibility to match Skin changes;

### DIFF
--- a/src/components/ebay-breadcrumb/index.js
+++ b/src/components/ebay-breadcrumb/index.js
@@ -8,18 +8,16 @@ function getTemplateData(state, input) {
     const inputItems = input.items || [];
     const hijax = input.hijax || false;
     const items = inputItems.map((item, index) => {
-        let tag = 'a';
         let ariaCurrent = null;
         let role;
         const href = item.href || null;
         const current = (inputItems.length - 1 === index);
         let shouldHandleClick = true;
         if (current && !href) {
-            tag = 'span';
-            ariaCurrent = 'page';
+            ariaCurrent = 'location';
             shouldHandleClick = false;
         }
-        if (hijax) {
+        if (hijax && href) {
             role = 'button';
         }
         return {
@@ -27,7 +25,6 @@ function getTemplateData(state, input) {
             class: item.class,
             style: item.style,
             renderBody: item.renderBody,
-            tag,
             role,
             href,
             ariaCurrent,

--- a/src/components/ebay-breadcrumb/template.marko
+++ b/src/components/ebay-breadcrumb/template.marko
@@ -2,7 +2,7 @@
     <${data.headingLevel} id="breadcrumb-heading" class="clipped">${data.headingText}</${data.headingLevel}>
     <ul>
         <li for(item in data.items)>
-            <${item.tag}
+            <a
                 class=item.class
                 style=item.style
                 href=item.href

--- a/src/components/ebay-breadcrumb/test/test.browser.js
+++ b/src/components/ebay-breadcrumb/test/test.browser.js
@@ -12,7 +12,7 @@ describe('given a basic breadcrumb', () => {
     beforeEach(() => {
         widget = renderer.renderSync(mock.basicItems).appendTo(document.body).getWidget();
         firstItem = document.querySelector('nav li a');
-        lastItem = document.querySelector('nav li span');
+        lastItem = document.querySelector('nav li a:not([href])');
     });
     afterEach(() => widget.destroy());
 
@@ -32,7 +32,7 @@ describe('given a basic breadcrumb', () => {
         });
     });
 
-    describe('when a <span> item is clicked', () => {
+    describe('when a <a> with no href is clicked', () => {
         let spy;
         beforeEach((done) => {
             spy = sinon.spy();

--- a/src/components/ebay-breadcrumb/test/test.server.js
+++ b/src/components/ebay-breadcrumb/test/test.server.js
@@ -10,7 +10,6 @@ describe('breadcrumb', () => {
         expect(h2Tag.length).to.equal(1);
         expect(h2Tag.html()).to.equal(mock.basicItems.headingText);
         expect($('nav li').length).to.equal(mock.basicItems.items.length);
-        expect($('nav li a').length).to.equal(mock.basicItems.items.length - 1);
     });
 
     test('should set item roles for hijax version', context => {
@@ -26,12 +25,12 @@ describe('breadcrumb', () => {
         expect(li.length).to.equal(mock.firstItemMissingHref.items.length);
     });
 
-    test('renders span tag if href is null on last item', context => {
+    test('renders a tag with no href attribute when href is null on last item', context => {
         const $ = testUtils.getCheerio(context.render(mock.basicItems));
         const li = $('nav li');
         expect(li.length).to.equal(mock.basicItems.items.length);
-        const currentElement = $('span', li[li.length - 1]);
-        expect(currentElement.attr('aria-current')).to.equal('page');
+        const currentElement = $('a', li[li.length - 1]);
+        expect(currentElement.attr('aria-current')).to.equal('location');
     });
 
     test('renders different heading tag when specified', context => {
@@ -45,6 +44,6 @@ describe('breadcrumb', () => {
 });
 
 describe('breadcrumb-item', () => {
-    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'li span', 'items'));
-    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'li span', 'items'));
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'li a', 'items'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'li a', 'items'));
 });


### PR DESCRIPTION
## Description
- Changes the `<span>` to `<a>` with no href
- The role in hijax scenarios now stays an anchor since it is not actionable
- The leaf `<a>` with no href now has `aria-current="location"`

## Context
This change more closely aligns with a11y guidelines, and keeps all the leaf and branch nodes the same element type, allowing focus, as well as providing the proper `aria-current`.

## References
Fixes https://github.com/eBay/skin/issues/296

## Screenshots

**Before**
<img width="675" alt="screen shot 2018-08-06 at 4 52 33 pm" src="https://user-images.githubusercontent.com/13157115/43746447-356cdcaa-9999-11e8-9048-4cfec9f2da7c.png">

**After**
![image](https://user-images.githubusercontent.com/105656/43803244-950b36d6-9a55-11e8-8d00-84e2ea06b434.png)

P.S.: @yomed, I actually believe the last two tests are not correct, although they pass. Should they have `li a:not([href])` as the selector?