### PR TITLE
Fix CustomEvent usage in IE11

### DIFF
--- a/src/common/emit-and-fire/index.js
+++ b/src/common/emit-and-fire/index.js
@@ -7,7 +7,7 @@
 function emitAndFire(widget, eventName, eventArg) {
     const originalEmit = widget.emit;
     let event;
-    if (window.CustomEvent) {
+    if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
         event = new CustomEvent(eventName, { detail: eventArg });
     } else {
         event = document.createEvent('CustomEvent');


### PR DESCRIPTION
## Description

small try-catch wrap in emitAndFire for if statement that evals true in ie11 even though the contents of the if statement do not work in ie11

## Context
to make pagination work in ie11 as the conditional check results in a false positive

## References
https://github.com/eBay/ebayui-core/issues/317
