### PR TITLE
Carousel: Allow uneven slides when `items-per-slide` is set.

### DIFF
--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -36,8 +36,6 @@ function getInitialState(input) {
     const { items, itemsPerSlide } = state;
     if (itemsPerSlide) {
         state.classes.push('carousel--slides');
-        // Remove any extra items when using explicit itemsPerSlide.
-        items.length -= items.length % itemsPerSlide;
         // Only allow autoplay option for discrete carousels.
         if (input.autoplay) {
             const isSingleSlide = items.length <= itemsPerSlide;
@@ -423,7 +421,7 @@ function getNextIndex({ index, items, slideWidth }, delta) {
 
     // If going left, go as far left as possible while keeping this item fully in view.
     const targetOffset = item.right - slideWidth;
-    do item = items[--i]; while (item && item.left >= targetOffset);
+    do item = items[--i]; while (item && item.left > targetOffset);
     return i + 1;
 }
 

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -406,7 +406,7 @@ function getSlide({ index, itemsPerSlide }, i = index) {
  * @param {-1|1} delta 1 for right and -1 for left.
  * @return {number}
  */
-function getNextIndex({ index, items, slideWidth }, delta) {
+function getNextIndex({ index, items, slideWidth, itemsPerSlide }, delta) {
     let i = index;
     let item;
 
@@ -419,9 +419,12 @@ function getNextIndex({ index, items, slideWidth }, delta) {
     // If going right, then we just want the next item not fully in view.
     if (delta === RIGHT) return i % items.length;
 
-    // If going left, go as far left as possible while keeping this item fully in view.
+    // If items per slide is set we must show the same items on the same slide.
+    if (itemsPerSlide) return i;
+
+    // If going left without items per slide, go as far left as possible while keeping this item fully in view.
     const targetOffset = item.right - slideWidth;
-    do item = items[--i]; while (item && item.left > targetOffset);
+    do item = items[--i]; while (item && item.left >= targetOffset);
     return i + 1;
 }
 

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -710,6 +710,64 @@ describe('given a discrete carousel with half width items', () => {
     });
 });
 
+describe('given a discrete carousel with three half width items', () => {
+    const input = { itemsPerSlide: 2, items: mock.threeItems };
+    let widget;
+    let root;
+    let list;
+    let nextButton;
+
+    beforeEach(done => {
+        widget = renderer.renderSync(input).appendTo(document.body).getWidget();
+        root = document.querySelector('.carousel');
+        list = root.querySelector('.carousel__list');
+        nextButton = root.querySelector('.carousel__control--next');
+        waitForUpdate(widget, done);
+    });
+    afterEach(() => widget.destroy());
+
+    describe('when next button is clicked', () => {
+        let nextSpy;
+        let slideSpy;
+        let updateSpy;
+        beforeEach(done => {
+            nextSpy = sinon.spy();
+            slideSpy = sinon.spy();
+            updateSpy = sinon.spy();
+            widget.on('carousel-next', nextSpy);
+            widget.on('carousel-slide', slideSpy);
+            widget.on('carousel-update', updateSpy);
+            testUtils.triggerEvent(nextButton, 'click');
+            widget.subscribeTo(list).once('transitionend', done);
+        });
+
+        it('then it emits the marko next event', () => testControlEvent(nextSpy));
+
+        it('then it emits the marko slide event', () => {
+            expect(slideSpy.calledOnce).to.equal(true);
+            const eventData = slideSpy.getCall(0).args[0];
+            expect(eventData.slide).to.equal(2);
+        });
+
+        it('then it emits the marko update event', () => {
+            expect(updateSpy.calledOnce).to.equal(true);
+            const eventData = updateSpy.getCall(0).args[0];
+            expect(eventData.visibleIndexes).to.deep.equal([1, 2]);
+        });
+
+        it('then it applies a translation', () => {
+            const { offsetLeft } = list.children[1];
+            expect(getTranslateX(list)).to.equal(offsetLeft);
+        });
+
+        it('then it calculates item visibility correctly', () => {
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([1, 2]);
+        });
+    });
+});
+
 describe('given an autoplay carousel in the default state', () => {
     const input = { itemsPerSlide: 2, items: mock.sixItems, autoplay: 200 };
     let widget;


### PR DESCRIPTION
## Description
Currently the carousel automatically truncates non packed slides from the end when `items-per-slide` is set. In this PR that no longer happens and partial slides are allowed. There was also a check which was off by one which I have fixed.

## References
Fixes #316 