### PR TITLE
Docs: remove class from attributes lists

### DIFF
--- a/src/components/ebay-breadcrumb/README.md
+++ b/src/components/ebay-breadcrumb/README.md
@@ -13,7 +13,6 @@
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | custom class
 `heading-text` | String | No | heading for breadcrumb which will be clipped
 `heading-level` | String | No | heading level(h1-h4) for breadcrumb and default is `h2`
 `hijax` | Boolean | No | Prevent link navigation; for use with ajax

--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -10,7 +10,6 @@
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | custom class
 `priority` | String | No | "primary" / "secondary" (default) / "none"
 `size` | String | No | "small" or "large" (default: medium)
 `href` | String | No | for link that looks like a button

--- a/src/components/ebay-combobox/README.md
+++ b/src/components/ebay-combobox/README.md
@@ -30,7 +30,6 @@ When a selected option is specified:
 
 Name | Required | Type | Stateful | Description
 --- | --- | --- | --- | ---
-`class` | No | String | No | custom class
 `name` | Yes | String | No | used for the `name` attribute of the native `<select>`
 `selected` | n/a | Number | Yes | allows you to set the selected index option to `selected`
 `borderless` | No | Boolean | No | whether button has borders
@@ -57,7 +56,6 @@ Event | Data |  Description
 
 Name | Required | Type | Stateful | Description
 --- | --- | --- | --- | ---
-`class` | No | String | No | custom class
 `label` | No | String | No | string label for use in the button
 `selected` | No | Boolean | Yes | whether or not the option is selected (**Note:** use the root `ebay-combobox` element's `selected` property to set this property)
 `value` | Yes | String | Yes | used for the `value` attribute of the native `<option>`

--- a/src/components/ebay-dialog/README.md
+++ b/src/components/ebay-dialog/README.md
@@ -9,7 +9,6 @@
 ## Attributes
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | A custom class.
 `type` | String | No | Can be "full" / "fill" / "left" / "right".
 `open` | Boolean | Yes | Whether dialog is open.
 `focus` | String | No | An id for an element which will receive focus when the dialog opens (defaults to close button).

--- a/src/components/ebay-icon/README.md
+++ b/src/components/ebay-icon/README.md
@@ -30,7 +30,6 @@ The `inline` icon will include the actual SVG markup in the HTML and then refere
 ## ebay-icon Attributes
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | custom class
 `type` | String | No | "background" via CSS (default) or "inline" via HTML
 `name` | String | No | name of the icon from Skin
 `no-skin-classes` | Boolean | No | Used for special cases where `icon` classes from Skin should not be applied

--- a/src/components/ebay-menu/README.md
+++ b/src/components/ebay-menu/README.md
@@ -16,7 +16,6 @@
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | custom class
 `label` | String | Yes | button label
 `icon` | String | No | name of an `<ebay-icon>` to show to the left of the label
 `accessibility-text` | String | No | accessibility text for the button, especially for cases without label text
@@ -59,7 +58,6 @@ Method | Parameters | Description
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | custom class
 `href` (fake menu) | String | No | for link that looks like a menu-item
 `type` (fake menu) | String | No | Set to "button" for fake menu-item `<button>`
 `checked` (radio or checkbox) | Boolean | Yes | whether or not the item is checked (**Note:** use the root `ebay-menu` element's `checked` property for radio type menus, or `setCheckedList()` method for checkbox type menus, to set this property.)

--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -18,7 +18,6 @@ For the dismissible use case, if the parent of `<ebay-notice>` wants to close it
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | custom class
 `type` | String | No | "inline" or "page" (default)
 `status`  | String | No | "priority" (default), "confirmation" or "information"
 `aria-text` | String | No | adding description for the notice for a11y users

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -20,7 +20,6 @@ The `<ebay-pagination>` is a tag used to create a pagination navigation.
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | custom class
 `accessibility-prev` | String | No | aria-label for previous arrow button
 `accessibility-next` | String | No | aria-label for next arrow button
 `accessibility-current` | String | No | Description for the current page (e.g. Results of Page 1)
@@ -47,7 +46,6 @@ Event | Data | Description
 Name | Type | Stateful | Description
 --- | --- | --- | ---
 `disabled` | Boolean | No | Previous/next button is disabled or not
-`class` | String | No | custom class
 `href` | String | No | for link that looks like a menu-item
 `current` | Boolean | No | the current page
 `type` | String | No | "previous", "next" or "page"(default). To specify if the information entered is for the previous or next arrrow button or a page. If the `type='previous|next'` isn't provided the previous/next arrow buttons will be taken as `disabled`

--- a/src/components/ebay-select/README.md
+++ b/src/components/ebay-select/README.md
@@ -30,7 +30,6 @@ When a selected option is specified:
 
 Name | Required | Type | Stateful | Description
 --- | --- | --- | --- | ---
-`class` | No | String | No | custom class
 `selected` | n/a | Number | Yes | allows you to set the selected index option to `selected`
 `borderless` | No | Boolean | No | whether button has borders
 
@@ -59,7 +58,6 @@ Event | Data |  Description
 
 Name | Required | Type | Stateful | Description
 --- | --- | --- | --- | ---
-`class` | No | String | No | custom class
 `label` | No | String | No | string label for use in the button
 `selected` | No | Boolean | Yes | whether or not the option is selected (**Note:** use the root `ebay-select` element's `selected` property to set this property)
 `value` | Yes | String | Yes | used for the `value` attribute of the native `<option>`

--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -12,7 +12,6 @@ Default input textbox:
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`class` | String | No | define custom class
 `fluid` | Boolean | No |
 `multiline` | Boolean | No | renders a multi-line texbox if true
 `invalid` | Boolean | No | indicates a field-level error with red border if true


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- removes `class` from attributes lists where it existed (most components)

## Context
<!--- Why did you make these changes, and why in this particular way? -->
All HTML attributes should be treated the same, so we don't need to document individual ones. I wanted to clean this up in preparation for #132 
