### PR TITLE
ie11 pagination fix

### DIFF
--- a/src/common/emit-and-fire/index.js
+++ b/src/common/emit-and-fire/index.js
@@ -7,7 +7,7 @@
 function emitAndFire(widget, eventName, eventArg) {
     const originalEmit = widget.emit;
     let event;
-    if (window.CustomEvent) {
+    if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
         event = new CustomEvent(eventName, { detail: eventArg });
     } else {
         event = document.createEvent('CustomEvent');


### PR DESCRIPTION
## Description
updated the if statement in emitAndFire as it would evaluate true on ie11 even though CustomEvent was not a function and threw and error after that.

## Context
to make pagination work in ie11 as the conditional check results in a false positive

## References
https://github.com/eBay/ebayui-core/issues/317
