### PR TITLE
CI: Update marko-cli for running local chrome on fork PR's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+sudo: required
+addons:
+  chrome: stable
+
 language: node_js
 node_js:
   - "8"

--- a/marko-cli.js
+++ b/marko-cli.js
@@ -8,7 +8,7 @@ module.exports = ({ config }) => {
     config.lassoOptions = {
         flags: ['skin-ds6'],
         plugins: ['lasso-less'],
-        require: {
+        require: isTravis && {
             transforms: [{
                 transform: 'lasso-babel-transform'
             }]

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lasso-marko": "^2.4.2",
     "lintspaces-cli": "^0.6.0",
     "marko": "^3",
-    "marko-cli": "^4.0.0",
+    "marko-cli": "^4.0.1",
     "marko-prettyprint": "^1.4.1",
     "marko-widgets": "^6",
     "mobile-detect": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lasso-marko": "^2.4.2",
     "lintspaces-cli": "^0.6.0",
     "marko": "^3",
-    "marko-cli": "^3.2.0",
+    "marko-cli": "^4.0.0",
     "marko-prettyprint": "^1.4.1",
     "marko-widgets": "^6",
     "mobile-detect": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,9 +124,9 @@
     ora "^2.1.0"
     unzip "^0.1.11"
 
-"@marko/test@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/@marko/test/-/test-4.0.0.tgz#fc485d2d0e31aa0275b4d96094ad7b937993dba2"
+"@marko/test@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@marko/test/-/test-4.0.1.tgz#3c2bf4ce7c2d8bb1a1afe775a95f8d9f26f399ea"
   dependencies:
     "@lasso/marko-taglib" "^1.0.10"
     async "^2.6.1"
@@ -5380,13 +5380,13 @@ markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
-marko-cli@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-4.0.0.tgz#0fc6bbdb944902615cbd26a45dfe911b49717339"
+marko-cli@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-4.0.1.tgz#d261c97a7035da1b1a2c5ad513daa7384ae5bd17"
   dependencies:
     "@marko/compile" "^3.2.0"
     "@marko/create" "^3.1.6"
-    "@marko/test" "^4.0.0"
+    "@marko/test" "^4.0.1"
     app-root-dir "^1.0.2"
     argly "^1.2.0"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,9 +124,9 @@
     ora "^2.1.0"
     unzip "^0.1.11"
 
-"@marko/test@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/@marko/test/-/test-3.2.0.tgz#7997c26c39d630a4af79461f6ff4e3ca5a610c7c"
+"@marko/test@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@marko/test/-/test-4.0.0.tgz#fc485d2d0e31aa0275b4d96094ad7b937993dba2"
   dependencies:
     "@lasso/marko-taglib" "^1.0.10"
     async "^2.6.1"
@@ -5380,13 +5380,13 @@ markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
-marko-cli@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-3.2.0.tgz#3f928b6a1708bf1880141d0aa923be29c0482da1"
+marko-cli@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-4.0.0.tgz#0fc6bbdb944902615cbd26a45dfe911b49717339"
   dependencies:
     "@marko/compile" "^3.2.0"
     "@marko/create" "^3.1.6"
-    "@marko/test" "^3.2.0"
+    "@marko/test" "^4.0.0"
     app-root-dir "^1.0.2"
     argly "^1.2.0"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
## Description
Updates marko-cli which provides flags needed for local chrome driver to run in containers/travis-ci.
This PR also configures travis to provide it's built in chrome instance.

The benefit of this is that for fork PR's they will still be ran against the local chrome driver, just not our browser stack list of drivers.

## References
Fixes #324