### PR TITLE
Process style attribute explicitly for pass-through

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -5,12 +5,15 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@heading-text": "string",
         "@heading-level": "string",
         "@hijax": "boolean",
         "@items <item>[]": {
             "@*": "expression",
             "@html-attributes": "expression",
+            "@class": "string",
+            "@style": "string",
             "@href": "string"
         }
     },
@@ -20,6 +23,7 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@type": "string",
         "@disabled": "boolean",
         "@partially-disabled": "boolean",
@@ -52,7 +56,8 @@
         "@accessibility-pause": "string",
         "@items <item>[]": {
             "@*": "expression",
-            "@html-attributes": "expression"
+            "@html-attributes": "expression",
+            "@class": "string"
         }
     },
     "<ebay-carousel-item>": {},

--- a/marko.json
+++ b/marko.json
@@ -58,7 +58,8 @@
         "@items <item>[]": {
             "@*": "expression",
             "@html-attributes": "expression",
-            "@class": "string"
+            "@class": "string",
+            "@style": "string"
         }
     },
     "<ebay-carousel-item>": {},

--- a/marko.json
+++ b/marko.json
@@ -39,6 +39,7 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@index": "string",
         "@type": "string",
         "@slide": "string",
@@ -61,12 +62,21 @@
         }
     },
     "<ebay-carousel-item>": {},
+    "<ebay-checkbox>": {
+        "renderer": "./src/components/ebay-checkbox/index.js",
+        "@*": "expression",
+        "@html-attributes": "expression",
+        "@class": "string",
+        "@style": "string",
+        "@disabled": "boolean"
+    },
     "<ebay-combobox>": {
         "renderer": "./src/components/ebay-combobox/index.js",
         "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@name": "string",
         "@grow": "boolean",
         "@borderless": "boolean",
@@ -75,6 +85,7 @@
             "@*": "expression",
             "@html-attributes": "expression",
             "@class": "string",
+            "@style": "string",
             "@value": "string",
             "@label": "string",
             "@selected": "boolean"
@@ -86,10 +97,23 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@open": "boolean",
         "@type": "string",
         "@focus": "string",
         "@aria-label-close": "string"
+    },
+    "<ebay-icon>": {
+        "renderer": "./src/components/ebay-icon/index.js",
+        "transformer": "./src/components/ebay-icon/transformer.js",
+        "@*": "expression",
+        "@html-attributes": "expression",
+        "@class": "string",
+        "@style": "string",
+        "@type": "string",
+        "@name": "string",
+        "@accessibility-text": "string",
+        "@no-skin-classes": "boolean"
     },
     "<ebay-menu>": {
         "renderer": "./src/components/ebay-menu/index.js",
@@ -97,6 +121,7 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@type": "string",
         "@label": "string",
         "@icon": "string",
@@ -113,6 +138,7 @@
             "@*": "expression",
             "@html-attributes": "expression",
             "@class": "string",
+            "@style": "string",
             "@href": "string",
             "@type": "string",
             "@checked": "boolean",
@@ -125,6 +151,7 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@type": "string",
         "@heading-level": "string",
         "@status": "string",
@@ -139,6 +166,7 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@accessibility-prev": "string",
         "@accessibility-next": "string",
         "@accessibility-current": "string",
@@ -147,6 +175,7 @@
             "@*": "expression",
             "@html-attributes": "expression",
             "@class": "string",
+            "@style": "string",
             "@current": "boolean",
             "@disabled": "boolean",
             "@href": "string",
@@ -155,29 +184,12 @@
         }
     },
     "<ebay-pagination-item>": {},
-    "<ebay-icon>": {
-        "renderer": "./src/components/ebay-icon/index.js",
-        "transformer": "./src/components/ebay-icon/transformer.js",
-        "@*": "expression",
-        "@html-attributes": "expression",
-        "@class": "string",
-        "@type": "string",
-        "@name": "string",
-        "@accessibility-text": "string",
-        "@no-skin-classes": "boolean"
-    },
     "<ebay-radio>": {
         "renderer": "./src/components/ebay-radio/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
-        "@disabled": "boolean"
-    },
-    "<ebay-checkbox>": {
-        "renderer": "./src/components/ebay-checkbox/index.js",
-        "@*": "expression",
-        "@html-attributes": "expression",
-        "@class": "string",
+        "@style": "string",
         "@disabled": "boolean"
     },
     "<ebay-select>": {
@@ -186,6 +198,7 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@grow": "boolean",
         "@borderless": "boolean",
         "@disabled": "boolean",
@@ -193,6 +206,7 @@
             "@*": "expression",
             "@html-attributes": "expression",
             "@class": "string",
+            "@style": "string",
             "@value": "string",
             "@label": "string",
             "@selected": "boolean"
@@ -203,7 +217,8 @@
         "renderer": "./src/components/ebay-switch/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
-        "@class": "string"
+        "@class": "string",
+        "@style": "string"
     },
     "<ebay-tab>": {
         "renderer": "./src/components/ebay-tab/index.js",
@@ -211,18 +226,21 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@index": "string",
         "@fake": "boolean",
         "@headings <heading>[]": {
             "@*": "expression",
             "@html-attributes": "expression",
             "@class": "string",
+            "@style": "string",
             "@href": "string"
         },
         "@panels <panel>[]": {
             "@*": "expression",
             "@html-attributes": "expression",
-            "@class": "string"
+            "@class": "string",
+            "@style": "string"
         }
     },
     "<ebay-tab-heading>": {},
@@ -232,6 +250,7 @@
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
+        "@style": "string",
         "@invalid": "boolean",
         "@fluid": "boolean",
         "@multiline": "boolean"

--- a/src/common/test-utils/server.js
+++ b/src/common/test-utils/server.js
@@ -21,7 +21,6 @@ try {
  * @param {Object} output
  */
 function getCheerio(output) {
-    // console.log(output.html.toString());
     return cheerio.load(output.html.toString());
 }
 
@@ -52,6 +51,11 @@ function testCustomStyle(context, selector, arrayKey, baseInput, parentInput) {
     const input = setupInput({ style: { color: 'red' } }, arrayKey, baseInput, parentInput);
     const $ = getCheerio(context.render(input));
     expect($(`${selector}[style="color:red"]`).length).to.equal(1);
+}
+
+function testClassAndStyle(context, selector, arrayKey, baseInput, parentInput) {
+    testCustomClass(context, selector, arrayKey, baseInput, parentInput);
+    testCustomStyle(context, selector, arrayKey, baseInput, parentInput);
 }
 
 function testHtmlAttributes(context, selector, arrayKey, baseInput, parentInput) {
@@ -94,8 +98,7 @@ function runTransformer(transformer, srcString, componentPath) {
 
 module.exports = {
     getCheerio,
-    testCustomClass,
-    testCustomStyle,
+    testClassAndStyle,
     testHtmlAttributes,
     getTransformedTemplate,
     runTransformer

--- a/src/common/test-utils/server.js
+++ b/src/common/test-utils/server.js
@@ -41,22 +41,15 @@ function setupInput(input, arrayKey, baseInput, parentInput = {}) {
     return newInput;
 }
 
-function testCustomClass(context, selector, arrayKey, baseInput, parentInput) {
-    const input = setupInput({ class: { class1: true, class2: true } }, arrayKey, baseInput, parentInput);
-    const $ = getCheerio(context.render(input));
-    expect($(`${selector}.class1.class2`).length).to.equal(1);
-}
-
-function testCustomStyle(context, selector, arrayKey, baseInput, parentInput) {
-    const input = setupInput({ style: { color: 'red' } }, arrayKey, baseInput, parentInput);
-    const $ = getCheerio(context.render(input));
-    // v4 adds a semicolon
-    expect($(`${selector}[style="color:red"],${selector}[style="color:red;"]`).length).to.equal(1);
-}
-
 function testClassAndStyle(context, selector, arrayKey, baseInput, parentInput) {
-    testCustomClass(context, selector, arrayKey, baseInput, parentInput);
-    testCustomStyle(context, selector, arrayKey, baseInput, parentInput);
+    [
+        { input: { class: { class1: true, class2: true } }, test: '.class1.class2' },
+        { input: { style: { color: 'red' } }, test: '[style*="color:red"]' }
+    ].forEach(scenario => {
+        const input = setupInput(scenario.input, arrayKey, baseInput, parentInput);
+        const $ = getCheerio(context.render(input));
+        expect($(`${selector}${scenario.test}`).length).to.equal(1);
+    });
 }
 
 function testHtmlAttributes(context, selector, arrayKey, baseInput, parentInput) {
@@ -99,8 +92,6 @@ function runTransformer(transformer, srcString, componentPath) {
 
 module.exports = {
     getCheerio,
-    testCustomClass,
-    testCustomStyle,
     testClassAndStyle,
     testHtmlAttributes,
     getTransformedTemplate,

--- a/src/common/test-utils/server.js
+++ b/src/common/test-utils/server.js
@@ -50,7 +50,8 @@ function testCustomClass(context, selector, arrayKey, baseInput, parentInput) {
 function testCustomStyle(context, selector, arrayKey, baseInput, parentInput) {
     const input = setupInput({ style: { color: 'red' } }, arrayKey, baseInput, parentInput);
     const $ = getCheerio(context.render(input));
-    expect($(`${selector}[style="color:red"]`).length).to.equal(1);
+    // v4 adds a semicolon
+    expect($(`${selector}[style="color:red"],${selector}[style="color:red;"]`).length).to.equal(1);
 }
 
 function testClassAndStyle(context, selector, arrayKey, baseInput, parentInput) {
@@ -98,6 +99,8 @@ function runTransformer(transformer, srcString, componentPath) {
 
 module.exports = {
     getCheerio,
+    testCustomClass,
+    testCustomStyle,
     testClassAndStyle,
     testHtmlAttributes,
     getTransformedTemplate,

--- a/src/common/test-utils/server.js
+++ b/src/common/test-utils/server.js
@@ -21,6 +21,7 @@ try {
  * @param {Object} output
  */
 function getCheerio(output) {
+    // console.log(output.html.toString());
     return cheerio.load(output.html.toString());
 }
 
@@ -41,15 +42,16 @@ function setupInput(input, arrayKey, baseInput, parentInput = {}) {
     return newInput;
 }
 
-function testCustomClass(context, selector, arrayKey, isPassThrough, baseInput, parentInput) {
-    let input;
-    if (isPassThrough) {
-        input = setupInput({ '*': { class: 'class1 class2' } }, arrayKey, baseInput, parentInput);
-    } else {
-        input = setupInput({ class: 'class1 class2' }, arrayKey, baseInput, parentInput);
-    }
+function testCustomClass(context, selector, arrayKey, baseInput, parentInput) {
+    const input = setupInput({ class: { class1: true, class2: true } }, arrayKey, baseInput, parentInput);
     const $ = getCheerio(context.render(input));
     expect($(`${selector}.class1.class2`).length).to.equal(1);
+}
+
+function testCustomStyle(context, selector, arrayKey, baseInput, parentInput) {
+    const input = setupInput({ style: { color: 'red' } }, arrayKey, baseInput, parentInput);
+    const $ = getCheerio(context.render(input));
+    expect($(`${selector}[style="color:red"]`).length).to.equal(1);
 }
 
 function testHtmlAttributes(context, selector, arrayKey, baseInput, parentInput) {
@@ -93,6 +95,7 @@ function runTransformer(transformer, srcString, componentPath) {
 module.exports = {
     getCheerio,
     testCustomClass,
+    testCustomStyle,
     testHtmlAttributes,
     getTransformedTemplate,
     runTransformer

--- a/src/components/ebay-breadcrumb/index.js
+++ b/src/components/ebay-breadcrumb/index.js
@@ -7,13 +7,12 @@ const template = require('./template.marko');
 function getTemplateData(state, input) {
     const inputItems = input.items || [];
     const hijax = input.hijax || false;
-    let items = (inputItems).map((item, index) => {
-        const itemHtmlAttributes = processHtmlAttributes(item);
+    const items = inputItems.map((item, index) => {
         let tag = 'a';
         let ariaCurrent = null;
         let role;
         const href = item.href || null;
-        const current = ((inputItems.length - 1) === index);
+        const current = (inputItems.length - 1 === index);
         let shouldHandleClick = true;
         if (current && !href) {
             tag = 'span';
@@ -24,23 +23,25 @@ function getTemplateData(state, input) {
             role = 'button';
         }
         return {
+            htmlAttributes: processHtmlAttributes(item),
+            class: item.class,
+            style: item.style,
+            renderBody: item.renderBody,
             tag,
             role,
-            htmlAttributes: itemHtmlAttributes,
-            renderBody: item.renderBody,
             href,
             ariaCurrent,
             shouldHandleClick
         };
     });
-    items = Object.keys(items).length > 0 ? items : null;
     return {
+        htmlAttributes: processHtmlAttributes(input),
+        classes: ['breadcrumb', input.class],
+        style: input.style,
         items,
         hijax,
-        classes: ['breadcrumb', input.class],
         headingText: input.headingText || '',
-        headingLevel: input.headingLevel || 'h2',
-        htmlAttributes: processHtmlAttributes(input)
+        headingLevel: input.headingLevel || 'h2'
     };
 }
 

--- a/src/components/ebay-breadcrumb/template.marko
+++ b/src/components/ebay-breadcrumb/template.marko
@@ -1,8 +1,16 @@
-<nav if(data.items) aria-labelledby="breadcrumb-heading" class=data.classes role="navigation" ${data.htmlAttributes} w-bind>
+<nav w-bind aria-labelledby="breadcrumb-heading" class=data.classes style=data.style role="navigation" ${data.htmlAttributes}>
     <${data.headingLevel} id="breadcrumb-heading" class="clipped">${data.headingText}</${data.headingLevel}>
     <ul>
         <li for(item in data.items)>
-            <${item.tag} href=item.href aria-current=item.ariaCurrent role=item.role ${item.htmlAttributes} w-body=item.renderBody w-onclick=(item.shouldHandleClick && "handleClick")/>
+            <${item.tag}
+                class=item.class
+                style=item.style
+                href=item.href
+                aria-current=item.ariaCurrent
+                role=item.role
+                w-body=item.renderBody
+                w-onclick=(item.shouldHandleClick && "handleClick")
+                ${item.htmlAttributes}/>
         </li>
     </ul>
 </nav>

--- a/src/components/ebay-breadcrumb/test/test.server.js
+++ b/src/components/ebay-breadcrumb/test/test.server.js
@@ -2,53 +2,67 @@ const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/server');
 const mock = require('../mock');
 
-test('renders basic structure', context => {
-    const $ = testUtils.getCheerio(context.render(mock.basicItems));
-    expect($('nav.breadcrumb').length).to.equal(1);
-    const h2Tag = $('h2#breadcrumb-heading.clipped');
-    expect(h2Tag.length).to.equal(1);
-    expect(h2Tag.html()).to.equal(mock.basicItems.headingText);
-    expect($('nav li').length).to.equal(mock.basicItems.items.length);
-    expect($('nav li a').length).to.equal(mock.basicItems.items.length - 1);
+describe('breadcrumb', () => {
+    test('renders basic structure', context => {
+        const $ = testUtils.getCheerio(context.render(mock.basicItems));
+        expect($('nav.breadcrumb').length).to.equal(1);
+        const h2Tag = $('h2#breadcrumb-heading.clipped');
+        expect(h2Tag.length).to.equal(1);
+        expect(h2Tag.html()).to.equal(mock.basicItems.headingText);
+        expect($('nav li').length).to.equal(mock.basicItems.items.length);
+        expect($('nav li a').length).to.equal(mock.basicItems.items.length - 1);
+    });
+
+    test('should set item roles for hijax version', context => {
+        const input = mock.hijax;
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($('li a[role="button"]').length).to.equal(input.items.length - 1);
+    });
+
+    test('renders <a> without href for missing input href on non-last item', context => {
+        const $ = testUtils.getCheerio(context.render(mock.firstItemMissingHref));
+        const li = $('nav li');
+        expect($('a', li[0]).attr('href')).to.equal(undefined);
+        expect(li.length).to.equal(mock.firstItemMissingHref.items.length);
+    });
+
+    test('renders span tag if href is null on last item', context => {
+        const $ = testUtils.getCheerio(context.render(mock.basicItems));
+        const li = $('nav li');
+        expect(li.length).to.equal(mock.basicItems.items.length);
+        const currentElement = $('span', li[li.length - 1]);
+        expect(currentElement.attr('aria-current')).to.equal('page');
+    });
+
+    test('renders different heading tag when specified', context => {
+        const $ = testUtils.getCheerio(context.render(mock.itemsWithHeadingLevel));
+        expect($('h2').length).to.equal(0);
+        expect($('h3').length).to.equal(1);
+    });
+
+    test('handles pass-through html attributes', context => {
+        testUtils.testHtmlAttributes(context, 'nav.breadcrumb');
+    });
+
+    test('handles custom class', context => {
+        testUtils.testCustomClass(context, 'nav.breadcrumb');
+    });
+
+    test('handles custom style', context => {
+        testUtils.testCustomStyle(context, 'nav.breadcrumb');
+    });
 });
 
-test('should set item roles for hijax version', context => {
-    const input = mock.hijax;
-    const $ = testUtils.getCheerio(context.render(input));
-    expect($('li a[role="button"]').length).to.equal(input.items.length - 1);
-});
+describe('breadcrumb-item', () => {
+    test('handles pass-through html attributes', context => {
+        testUtils.testHtmlAttributes(context, 'li span', 'items');
+    });
 
-test('does not render with empty input', context => {
-    const input = {};
-    const $ = testUtils.getCheerio(context.render(input));
-    expect($('nav').length).to.equal(0);
-});
+    test('handles custom class', context => {
+        testUtils.testCustomClass(context, 'li span', 'items');
+    });
 
-test('renders <a> without href for missing input href on non-last item', context => {
-    const $ = testUtils.getCheerio(context.render(mock.firstItemMissingHref));
-    const li = $('nav li');
-    expect($('a', li[0]).attr('href')).to.equal(undefined);
-    expect(li.length).to.equal(mock.firstItemMissingHref.items.length);
-});
-
-test('renders span tag if href is null on last item', context => {
-    const $ = testUtils.getCheerio(context.render(mock.basicItems));
-    const li = $('nav li');
-    expect(li.length).to.equal(mock.basicItems.items.length);
-    const currentElement = $('span', li[li.length - 1]);
-    expect(currentElement.attr('aria-current')).to.equal('page');
-});
-
-test('renders different heading tag when specified', context => {
-    const $ = testUtils.getCheerio(context.render(mock.itemsWithHeadingLevel));
-    expect($('h2').length).to.equal(0);
-    expect($('h3').length).to.equal(1);
-});
-
-test('handles pass-through html attributes for item', context => {
-    testUtils.testHtmlAttributes(context, 'li span', 'items');
-});
-
-test('handles custom class for item', context => {
-    testUtils.testCustomClass(context, 'li span', 'items', true);
+    test('handles custom style', context => {
+        testUtils.testCustomStyle(context, 'li span', 'items');
+    });
 });

--- a/src/components/ebay-breadcrumb/test/test.server.js
+++ b/src/components/ebay-breadcrumb/test/test.server.js
@@ -40,29 +40,11 @@ describe('breadcrumb', () => {
         expect($('h3').length).to.equal(1);
     });
 
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, 'nav.breadcrumb');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, 'nav.breadcrumb');
-    });
-
-    test('handles custom style', context => {
-        testUtils.testCustomStyle(context, 'nav.breadcrumb');
-    });
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'nav'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'nav'));
 });
 
 describe('breadcrumb-item', () => {
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, 'li span', 'items');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, 'li span', 'items');
-    });
-
-    test('handles custom style', context => {
-        testUtils.testCustomStyle(context, 'li span', 'items');
-    });
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'li span', 'items'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'li span', 'items'));
 });

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -46,12 +46,13 @@ function getTemplateData(state, input) {
         classes.push(`${mainClass}--fluid`);
     }
 
+    model.htmlAttributes = processHtmlAttributes(input);
+    model.classes = classes;
+    model.style = input.style;
     model.tag = tag;
     model.type = input.type || 'button';
-    model.classes = classes;
     model.disabled = state.disabled;
     model.partiallyDisabled = input.partiallyDisabled ? 'true' : null; // for aria-disabled
-    model.htmlAttributes = processHtmlAttributes(input);
 
     return model;
 }

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -5,6 +5,7 @@
     w-onkeydown="handleKeydown"
     type=data.type
     class=data.classes
+    style=data.style
     href=data.href
     disabled=data.disabled
     aria-disabled=data.partiallyDisabled

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -88,3 +88,7 @@ test('handles pass-through html attributes', context => {
 test('handles custom class', context => {
     testUtils.testCustomClass(context, 'button.btn');
 });
+
+test('handles custom style', context => {
+    testUtils.testCustomStyle(context, 'button.btn');
+});

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -81,14 +81,5 @@ test('renders cta variant', context => {
     expect($('.cta-btn').length).to.equal(1);
 });
 
-test('handles pass-through html attributes', context => {
-    testUtils.testHtmlAttributes(context, 'button.btn');
-});
-
-test('handles custom class', context => {
-    testUtils.testCustomClass(context, 'button.btn');
-});
-
-test('handles custom style', context => {
-    testUtils.testCustomStyle(context, 'button.btn');
-});
+test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'button.btn'));
+test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'button.btn'));

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -29,6 +29,7 @@ function getInitialState(input) {
         htmlAttributes: processHtmlAttributes(input),
         items: (input.items || []).map(item => ({
             htmlAttributes: processHtmlAttributes(item),
+            class: item.class,
             renderBody: item.renderBody
         }))
     };

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -31,6 +31,7 @@ function getInitialState(input) {
         items: (input.items || []).map(item => ({
             htmlAttributes: processHtmlAttributes(item),
             class: item.class,
+            style: item.style,
             renderBody: item.renderBody
         }))
     };
@@ -78,9 +79,8 @@ function getTemplateData(state) {
         itemWidth = 'auto';
     }
 
-    // FIXME: does not accept custom style correctly
     items.forEach((item, i) => {
-        const { htmlAttributes: { style }, transform } = item;
+        const { style, transform } = item;
         const marginRight = i !== items.length && `${gap}px`;
 
         // Account for users providing a style string or object for each item.

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -13,11 +13,13 @@ const RIGHT = 1;
 
 function getInitialState(input) {
     const state = {
+        htmlAttributes: processHtmlAttributes(input),
+        classes: ['carousel', input.class],
+        style: input.style,
         config: {}, // A place to store values that should not trigger an update by themselves.
         gap: input.gap || 16,
         noDots: input.noDots,
         index: parseInt(input.index, 10) || 0,
-        classes: ['carousel', input.class],
         itemsPerSlide: parseInt(input.itemsPerSlide, 10) || undefined,
         accessibilityPrev: input.accessibilityPrev || 'Previous Slide',
         accessibilityNext: input.accessibilityNext || 'Next Slide',
@@ -26,7 +28,6 @@ function getInitialState(input) {
         accessibilityOther: input.accessibilityOther || 'Slide {slide} - Carousel',
         accessibilityPause: input.accessibilityPause || 'Pause - Carousel',
         accessibilityPlay: input.accessibilityPlay || 'Play - Carousel',
-        htmlAttributes: processHtmlAttributes(input),
         items: (input.items || []).map(item => ({
             htmlAttributes: processHtmlAttributes(item),
             class: item.class,
@@ -77,6 +78,7 @@ function getTemplateData(state) {
         itemWidth = 'auto';
     }
 
+    // FIXME: does not accept custom style correctly
     items.forEach((item, i) => {
         const { htmlAttributes: { style }, transform } = item;
         const marginRight = i !== items.length && `${gap}px`;

--- a/src/components/ebay-carousel/mock/index.js
+++ b/src/components/ebay-carousel/mock/index.js
@@ -1,12 +1,12 @@
 const renderBody = (stream) => stream.write('text');
 const itemWidth = 200;
-const item = { renderBody, '*': { style: `width:${itemWidth}px` } };
+const item = { renderBody, style: `width:${itemWidth}px` };
 const threeItems = [item, item, item];
 const sixItems = threeItems.concat(threeItems);
 const twelveItems = sixItems.concat(sixItems);
 
 // mocks for visual debugging
-const debugItem = { renderBody, '*': { style: `height:200px;width:400px;background:gray` } };
+const debugItem = { renderBody, style: 'height:200px;width:400px;background:gray' };
 const debugItems = [debugItem, debugItem, debugItem, debugItem, debugItem, debugItem];
 
 module.exports = { renderBody, itemWidth, item, threeItems, sixItems, twelveItems, debugItems };

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -27,6 +27,7 @@
             })>
             <for(item in data.items)>
                 <li ${item.htmlAttributes}
+                    class=item.class
                     style=item.style
                     w-body=item.renderBody
                     aria-hidden=(!item.fullyVisible && 'true')

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -1,4 +1,4 @@
-<div class=data.classes w-bind ${data.htmlAttributes}>
+<div class=data.classes style=data.style w-bind ${data.htmlAttributes}>
     <var config=data.config/>
     <var statusId=("carousel-status-" + widget.id)/>
     <div w-id="container" class=["carousel__container", data.bothControlsDisabled && "carousel__container--controls-disabled"]>

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -83,6 +83,10 @@ describe('carousel', () => {
     test('handles custom class', context => {
         testUtils.testCustomClass(context, '.carousel');
     });
+
+    test('handles custom style', context => {
+        testUtils.testCustomStyle(context, '.carousel');
+    });
 });
 
 describe('carousel-item', () => {

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -76,25 +76,11 @@ describe('carousel', () => {
         expect($('.carousel__play').attr('aria-label')).to.equal('play');
     });
 
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, '.carousel');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.carousel');
-    });
-
-    test('handles custom style', context => {
-        testUtils.testCustomStyle(context, '.carousel');
-    });
+    test('handles pass-through html attributes', c => testUtils.testHtmlAttributes(c, '.carousel'));
+    test('handles custom class and style', c => testUtils.testClassAndStyle(c, '.carousel'));
 });
 
 describe('carousel-item', () => {
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, '.carousel__list > li', 'items');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.carousel__list > li', 'items');
-    });
+    test('handles pass-through html attributes', c => testUtils.testHtmlAttributes(c, '.carousel__list > li', 'items'));
+    test('handles custom class and style', c => testUtils.testClassAndStyle(c, '.carousel__list > li', 'items'));
 });

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -91,6 +91,6 @@ describe('carousel-item', () => {
     });
 
     test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.carousel__list > li', 'items', true);
+        testUtils.testCustomClass(context, '.carousel__list > li', 'items');
     });
 });

--- a/src/components/ebay-checkbox/README.md
+++ b/src/components/ebay-checkbox/README.md
@@ -12,7 +12,7 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `disabled` | Boolean | No |
 
-Note: For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
+Note: For this component, `class`/`style` are applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 
 ## ebay-checkbox Events
 

--- a/src/components/ebay-checkbox/index.js
+++ b/src/components/ebay-checkbox/index.js
@@ -5,9 +5,10 @@ const template = require('./template.marko');
 
 function getInitialState(input) {
     return {
+        htmlAttributes: processHtmlAttributes(input),
         classes: ['checkbox', input.class],
-        disabled: Boolean(input.disabled),
-        htmlAttributes: processHtmlAttributes(input)
+        style: input.style,
+        disabled: Boolean(input.disabled)
     };
 }
 

--- a/src/components/ebay-checkbox/template.marko
+++ b/src/components/ebay-checkbox/template.marko
@@ -1,7 +1,8 @@
 <span
     w-bind
     w-onclick="handleClick"
-    class=data.classes>
+    class=data.classes
+    style=data.style>
     <input
         class="checkbox__control"
         type="checkbox"

--- a/src/components/ebay-checkbox/test/test.server.js
+++ b/src/components/ebay-checkbox/test/test.server.js
@@ -17,10 +17,5 @@ test('renders disabled checkbox', context => {
     expect($(`${inputSelector}[disabled]`).length).to.equal(1);
 });
 
-test('handles pass-through html attributes', context => {
-    testUtils.testHtmlAttributes(context, inputSelector);
-});
-
-test('handles custom class', context => {
-    testUtils.testCustomClass(context, rootSelector);
-});
+test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, inputSelector));
+test('handles custom class and style', context => testUtils.testClassAndStyle(context, rootSelector));

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -14,18 +14,15 @@ const comboboxBtnClass = 'combobox__control';
 const comboboxOptionSelector = '.combobox__option[role=option]';
 
 function getInitialState(input) {
-    const options = (input.options || []).map(option => {
-        const selected = option.selected;
-
-        return {
-            class: option.class,
-            value: option.value,
-            label: option.label,
-            selected: Boolean(selected),
-            htmlAttributes: processHtmlAttributes(option),
-            renderBody: option.renderBody
-        };
-    });
+    const options = (input.options || []).map(option => ({
+        htmlAttributes: processHtmlAttributes(option),
+        class: option.class,
+        style: option.style,
+        value: option.value,
+        label: option.label,
+        selected: Boolean(option.selected),
+        renderBody: option.renderBody
+    }));
 
     const selectedOption = options.filter(option => option.selected)[0] || options[0];
 
@@ -34,14 +31,15 @@ function getInitialState(input) {
     }
 
     return {
-        name: input.name,
+        htmlAttributes: processHtmlAttributes(input),
         class: input.class,
+        style: input.style,
+        name: input.name,
         options,
         selected: selectedOption,
         grow: input.grow,
         disabled: input.disabled,
-        borderless: Boolean(input.borderless),
-        htmlAttributes: processHtmlAttributes(input)
+        borderless: Boolean(input.borderless)
     };
 }
 
@@ -55,15 +53,16 @@ function getTemplateData(state) {
     }
 
     return {
+        htmlAttributes: state.htmlAttributes,
         class: comboboxClass,
+        style: state.style,
         btnClass,
         optionsClass,
         name: state.name,
         selectedOption: state.selected,
         options: state.options,
         grow: state.grow,
-        disabled: state.disabled,
-        htmlAttributes: state.htmlAttributes
+        disabled: state.disabled
     };
 }
 

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -1,5 +1,6 @@
 <span
     class=data.class
+    style=data.style
     ${data.htmlAttributes}
     w-on-expander-expand='handleExpand'
     w-on-expander-collapse='handleCollapse'
@@ -27,8 +28,9 @@
             for(option in data.options)
             role='option'
             class=['combobox__option', option.class]
-            tabindex="-1"
+            style=option.style
             ${option.htmlAttributes}
+            tabindex="-1"
             w-on-click='handleOptionClick'
             w-preserve-attrs="tabindex,data-makeup-index"
             aria-selected=String(option.selected)

--- a/src/components/ebay-combobox/test/test.server.js
+++ b/src/components/ebay-combobox/test/test.server.js
@@ -54,21 +54,11 @@ describe('select', () => {
         expect($('.combobox__control.combobox__control--borderless').length).to.equal(0);
     });
 
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, 'span.combobox');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, 'span.combobox');
-    });
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'span.combobox'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'span.combobox'));
 });
 
 describe('select-option', () => {
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, '.combobox__option', 'options');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.combobox__option', 'options');
-    });
+    test('handles pass-through html attributes', c => testUtils.testHtmlAttributes(c, '.combobox__option', 'options'));
+    test('handles custom class and style', c => testUtils.testClassAndStyle(c, '.combobox__option', 'options'));
 });

--- a/src/components/ebay-dialog/index.js
+++ b/src/components/ebay-dialog/index.js
@@ -20,19 +20,20 @@ function init() {
 }
 
 function getInitialState(input) {
-    const { open = false, type, focus, ariaLabelClose } = input;
+    const { style, open = false, type, focus, ariaLabelClose } = input;
     return {
+        htmlAttributes: processHtmlAttributes(input),
+        class: input.class,
+        style,
         open,
         type,
         focus,
-        ariaLabelClose,
-        class: input.class,
-        htmlAttributes: processHtmlAttributes(input)
+        ariaLabelClose
     };
 }
 
 function getTemplateData(state) {
-    const { open, type, ariaLabelClose, htmlAttributes } = state;
+    const { style, open, type, ariaLabelClose, htmlAttributes } = state;
     const dialogClass = [state.class, 'dialog'];
     const windowClass = ['dialog__window'];
 
@@ -58,12 +59,13 @@ function getTemplateData(state) {
     }
 
     return {
+        htmlAttributes,
+        dialogClass,
+        style,
         open,
         type,
         ariaLabelClose,
-        dialogClass,
-        windowClass,
-        htmlAttributes
+        windowClass
     };
 }
 

--- a/src/components/ebay-dialog/template.marko
+++ b/src/components/ebay-dialog/template.marko
@@ -1,5 +1,5 @@
 
-<div w-bind class=data.dialogClass hidden=!data.open role="dialog" w-preserve-attrs="hidden" ${data.htmlAttributes} w-onclick="handleDialogClick">
+<div w-bind class=data.dialogClass style=data.style hidden=!data.open role="dialog" w-preserve-attrs="hidden" w-onclick="handleDialogClick" ${data.htmlAttributes}>
     <div w-id="window" class=data.windowClass role="document">
         <button w-id="close" class="dialog__close" type="button" aria-label=data.ariaLabelClose w-onclick="handleCloseButtonClick">
             <ebay-icon type="inline" name="close"/>

--- a/src/components/ebay-dialog/test/test.server.js
+++ b/src/components/ebay-dialog/test/test.server.js
@@ -28,12 +28,6 @@ describe('dialog', () => {
         expect($('.dialog').prop('hidden')).to.equal(false);
     });
 
-    test('renders with a custom dialog class', context => {
-        const input = { 'class': 'custom-class' };
-        const $ = testUtils.getCheerio(context.render(input));
-        expect($('.dialog').hasClass('custom-class')).to.equal(true);
-    });
-
     [undefined, 'fill', 'full'].forEach(type => {
         test(`renders with ${type || 'default'} type`, context => {
             const input = { type: type };
@@ -67,4 +61,7 @@ describe('dialog', () => {
             expect($window.hasClass('dialog__window--slide')).to.equal(true);
         });
     });
+
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, '.dialog'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, '.dialog'));
 });

--- a/src/components/ebay-icon/index.js
+++ b/src/components/ebay-icon/index.js
@@ -52,6 +52,9 @@ function getTemplateData(state, input, out) {
     }
 
     return {
+        htmlAttributes: processHtmlAttributes(input),
+        classes: input.noSkinClasses ? [input.class] : ['icon', `icon--${name}`, input.class],
+        style: input.style,
         name,
         type,
         renderDefs,
@@ -59,9 +62,7 @@ function getTemplateData(state, input, out) {
         isInline,
         accessibilityText,
         accessibilityAttributes,
-        titleId,
-        htmlAttributes: processHtmlAttributes(input),
-        classes: input.noSkinClasses ? [input.class] : ['icon', `icon--${name}`, input.class]
+        titleId
     };
 }
 

--- a/src/components/ebay-icon/template.marko
+++ b/src/components/ebay-icon/template.marko
@@ -1,9 +1,9 @@
 <!-- TODO: prefer to use single w-bind, but dynamic tag breaks clientside rendering in marko v4 -->
 <if(data.isBackground)>
-    <span w-bind ${data.htmlAttributes} class=data.classes/>
+    <span w-bind class=data.classes style=data.style ${data.htmlAttributes}/>
 </if>
 <else-if(data.isInline)>
-    <svg w-bind ${data.htmlAttributes} ${data.accessibilityAttributes} focusable="false" class=data.classes>
+    <svg w-bind class=data.classes style=data.style ${data.htmlAttributes} ${data.accessibilityAttributes} focusable="false">
         <defs w-id="defs" w-body if(data.renderDefs)/>
         <title if(data.accessibilityText) id=data.titleId>${data.accessibilityText}</title>
         <use xlink:href="#icon-${data.name}"/>

--- a/src/components/ebay-icon/test/test.server.js
+++ b/src/components/ebay-icon/test/test.server.js
@@ -44,9 +44,7 @@ describe('icon', () => {
         testUtils.testHtmlAttributes(context, '.icon', null, { type: 'inline', name: iconName });
     });
 
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.icon');
-    });
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, '.icon'));
 });
 
 describe('transformer', () => {

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -56,19 +56,23 @@ function getInitialState(input) {
         }
 
         return {
-            tag,
+            htmlAttributes: processHtmlAttributes(item),
             classes,
+            style: item.style,
+            renderBody: item.renderBody,
+            tag,
             role,
             href,
             useCheckIcon: isRadio || isCheckbox,
             checked: (!isRadio && !isCheckbox) ? false : Boolean(checked),
-            current: Boolean(current),
-            htmlAttributes: processHtmlAttributes(item),
-            renderBody: item.renderBody
+            current: Boolean(current)
         };
     });
 
     return {
+        htmlAttributes: processHtmlAttributes(input),
+        class: input.class,
+        style: input.style,
         type,
         isRadio,
         isCheckbox,
@@ -78,14 +82,12 @@ function getInitialState(input) {
         iconTag: input.iconTag && input.iconTag.renderBody,
         accessibilityText: input.accessibilityText,
         noToggleIcon: input.noToggleIcon,
-        class: input.class,
         reverse: Boolean(input.reverse),
         fixWidth: Boolean(input.fixWidth),
         borderless: Boolean(input.borderless),
         size: input.size,
         priority: input.priority,
         expanded: false,
-        htmlAttributes: processHtmlAttributes(input),
         items,
         checked: checkedItems
     };
@@ -116,6 +118,9 @@ function getTemplateData(state) {
     }
 
     return {
+        htmlAttributes: state.htmlAttributes,
+        menuClass,
+        style: state.style,
         type: state.type,
         isRadio: state.isRadio,
         isCheckbox: state.isCheckbox,
@@ -128,12 +133,10 @@ function getTemplateData(state) {
         expanded: state.expanded,
         size: state.size,
         priority: state.priority,
-        menuClass,
         buttonClass: state.borderless && 'expand-btn--borderless',
         itemsClass,
         role: !state.isFake ? 'menu' : null,
-        items: state.items,
-        htmlAttributes: state.htmlAttributes
+        items: state.items
     };
 }
 

--- a/src/components/ebay-menu/template.marko
+++ b/src/components/ebay-menu/template.marko
@@ -1,4 +1,4 @@
-<span class=data.menuClass w-bind w-on-expander-expand="handleExpand" w-on-expander-collapse="handleCollapse" ${data.htmlAttributes}>
+<span class=data.menuClass style=data.style w-bind w-on-expander-expand="handleExpand" w-on-expander-collapse="handleCollapse" ${data.htmlAttributes}>
     <ebay-button w-id="button" class=data.buttonClass variant="expand" size=data.size priority=data.priority aria-expanded=String(data.expanded) aria-haspopup="true" aria-label=data.accessibilityText>
         <span class="expand-btn__cell">
             <!-- Convoluted markup to satisfy both Skin and Marko -->
@@ -14,6 +14,7 @@
         <for(item in data.items)>
             <${item.tag}
                 class=item.classes
+                style=item.style
                 aria-checked=(data.isNotCheckable ? false : String(item.checked))
                 aria-current=((data.isNotCheckable && item.current) ? 'page' : false)
                 href=item.href

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -162,8 +162,8 @@ describe('menu-item', () => {
         });
     });
 
-    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, '.menu__item', 'items'));
-    test('handles custom class and style', context => testUtils.testClassAndStyle(context, '.menu__item', 'items'));
+    test('handles pass-through html attributes', c => testUtils.testHtmlAttributes(c, '.menu__item', 'items'));
+    test('handles custom class and style', c => testUtils.testClassAndStyle(c, '.menu__item', 'items'));
 });
 
 describe('transformer', () => {

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -123,13 +123,8 @@ describe('menu', () => {
         expect($('svg.expand-btn__icon').length).to.equal(0);
     });
 
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, 'span.menu');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, 'span.menu');
-    });
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'span.menu'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'span.menu'));
 });
 
 describe('menu-item', () => {
@@ -167,13 +162,8 @@ describe('menu-item', () => {
         });
     });
 
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, '.menu__item', 'items');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.menu__item', 'items');
-    });
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, '.menu__item', 'items'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, '.menu__item', 'items'));
 });
 
 describe('transformer', () => {

--- a/src/components/ebay-notice/index.js
+++ b/src/components/ebay-notice/index.js
@@ -31,6 +31,9 @@ function getInitialState(input) {
     const dismissible = (input.dismissible && type === 'page') || defaults.dismissible;
 
     return {
+        htmlAttributes: processHtmlAttributes(input),
+        mainClass: [`${type}-notice`, `${type}-notice--${status}`, input.class],
+        style: input.style,
         mainTag: constants[type].mainTag,
         headingTag: headingTag,
         contentTag: constants[type].contentTag,
@@ -40,8 +43,6 @@ function getInitialState(input) {
         hidden,
         ariaText: input.ariaText || '',
         ariaLabelClose: input.ariaLabelClose || '',
-        htmlAttributes: processHtmlAttributes(input),
-        mainClass: [`${type}-notice`, `${type}-notice--${status}`, input.class],
         headingClass: `${type}-notice__status`,
         contentClass: `${type}-notice__content`
     };

--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -2,6 +2,7 @@
     w-bind
     aria-labelledby="${data.status}-status-${widget.elId()}"
     class=data.mainClass
+    style=data.style
     ${data.htmlAttributes}
     if(!data.hidden)>
         <${data.headingTag}

--- a/src/components/ebay-notice/test/test.server.js
+++ b/src/components/ebay-notice/test/test.server.js
@@ -49,10 +49,5 @@ test('renders page notice with dismiss button', context => {
     expect($('button.page-notice__close').length).to.equal(1);
 });
 
-test('handles pass-through html attributes', context => {
-    testUtils.testHtmlAttributes(context, 'section.page-notice');
-});
-
-test('handles custom class', context => {
-    testUtils.testCustomClass(context, 'section.page-notice');
-});
+test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'section.page-notice'));
+test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'section.page-notice'));

--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -28,11 +28,12 @@ function getInitialState(input) {
         const current = item.current;
 
         const tempItem = {
+            htmlAttributes: processHtmlAttributes(item),
+            style: item.style,
+            renderBody: item.renderBody,
             role,
             href,
-            current: Boolean(current) || false,
-            htmlAttributes: processHtmlAttributes(item),
-            renderBody: item.renderBody
+            current: Boolean(current) || false
         };
         if (item.type === 'previous') {
             prevItem = tempItem;
@@ -51,15 +52,16 @@ function getInitialState(input) {
     }
 
     return {
+        htmlAttributes: processHtmlAttributes(input),
+        classes: ['pagination', input.class],
+        style: input.style,
         hijax,
         nextItem: nextItem || { class: 'pagination__next', disabled: true, htmlAttributes: {} },
         prevItem: prevItem || { class: 'pagination__previous', disabled: true, htmlAttributes: {} },
         items,
         accessibilityPrev: input.accessibilityPrev || 'Previous page',
         accessibilityNext: input.accessibilityNext || 'Next page',
-        accessibilityCurrent: input.accessibilityCurrent || 'Results Pagination - Page 1',
-        classes: ['pagination', input.class],
-        htmlAttributes: processHtmlAttributes(input)
+        accessibilityCurrent: input.accessibilityCurrent || 'Results Pagination - Page 1'
     };
 }
 

--- a/src/components/ebay-pagination/template.marko
+++ b/src/components/ebay-pagination/template.marko
@@ -1,4 +1,4 @@
-<nav class=data.classes ${data.htmlAttributes} w-bind aria-labelledby="pagination-heading-${widget.elId()}" role="navigation">
+<nav class=data.classes style=data.style ${data.htmlAttributes} w-bind aria-labelledby="pagination-heading-${widget.elId()}" role="navigation">
     <span aria-live="polite" role="status">
         <h2 class="clipped"
             id="pagination-heading-${widget.elId()}">
@@ -8,6 +8,7 @@
     <a aria-disabled=String(data.prevItem.disabled)
         aria-label=data.accessibilityPrev
         class=data.prevItem.class
+        style=data.prevItem.style
         href=data.prevItem.href
         role=data.role
         w-onkeydown="handlePreviousPageKeyDown"
@@ -23,9 +24,10 @@
                     href=item.href
                     role=item.role
                     class=item.class
+                    style=item.style
+                    ${item.htmlAttributes}
                     w-onkeydown="handlePageKeyDown"
                     w-onclick="handlePageClick"
-                    ${item.htmlAttributes}
                     w-body=item.renderBody>
                 </a>
             </li>
@@ -34,6 +36,7 @@
     <a aria-disabled=String(data.nextItem.disabled)
         aria-label=data.accessibilityNext
         class=data.nextItem.class
+        style=data.nextItem.style
         href=data.nextItem.href
         role=data.role
         w-onkeydown="handleNextPageKeyDown"

--- a/src/components/ebay-pagination/test/test.server.js
+++ b/src/components/ebay-pagination/test/test.server.js
@@ -67,10 +67,10 @@ describe('pagination-item', () => {
     });
 
     test('handles custom class for previous control', context => {
-        testUtils.testCustomClass(context, '.pagination__previous', 'items', false, previousControlInput);
+        testUtils.testCustomClass(context, '.pagination__previous', 'items', previousControlInput);
     });
 
     test('handles custom class for next control', context => {
-        testUtils.testCustomClass(context, '.pagination__next', 'items', false, nextControlInput);
+        testUtils.testCustomClass(context, '.pagination__next', 'items', nextControlInput);
     });
 });

--- a/src/components/ebay-pagination/test/test.server.js
+++ b/src/components/ebay-pagination/test/test.server.js
@@ -37,13 +37,8 @@ describe('pagination', () => {
         expect($('.pagination__next[aria-disabled=true]').length).to.equal(1);
     });
 
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, '.pagination');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.pagination');
-    });
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, '.pagination'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, '.pagination'));
 });
 
 describe('pagination-item', () => {
@@ -62,15 +57,15 @@ describe('pagination-item', () => {
         testUtils.testHtmlAttributes(context, '.pagination__next', 'items', nextControlInput);
     });
 
-    test('handles custom class for item', context => {
-        testUtils.testCustomClass(context, '.pagination__item', 'items');
+    test('handles custom class and style for item', context => {
+        testUtils.testClassAndStyle(context, '.pagination__item', 'items');
     });
 
-    test('handles custom class for previous control', context => {
-        testUtils.testCustomClass(context, '.pagination__previous', 'items', previousControlInput);
+    test('handles custom class and style for previous control', context => {
+        testUtils.testClassAndStyle(context, '.pagination__previous', 'items', previousControlInput);
     });
 
-    test('handles custom class for next control', context => {
-        testUtils.testCustomClass(context, '.pagination__next', 'items', nextControlInput);
+    test('handles custom class and style for next control', context => {
+        testUtils.testClassAndStyle(context, '.pagination__next', 'items', nextControlInput);
     });
 });

--- a/src/components/ebay-radio/README.md
+++ b/src/components/ebay-radio/README.md
@@ -12,7 +12,7 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `disabled` | Boolean | No |
 
-Note: For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
+Note: For this component, `class`/`style` are applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 
 ## ebay-radio Events
 

--- a/src/components/ebay-radio/index.js
+++ b/src/components/ebay-radio/index.js
@@ -5,9 +5,10 @@ const template = require('./template.marko');
 
 function getInitialState(input) {
     return {
+        htmlAttributes: processHtmlAttributes(input),
         classes: ['radio', input.class],
-        disabled: Boolean(input.disabled),
-        htmlAttributes: processHtmlAttributes(input)
+        style: input.style,
+        disabled: Boolean(input.disabled)
     };
 }
 

--- a/src/components/ebay-radio/template.marko
+++ b/src/components/ebay-radio/template.marko
@@ -1,7 +1,8 @@
 <span
     w-bind
     w-onclick="handleClick"
-    class=data.classes>
+    class=data.classes
+    style=data.style>
     <input
         type="radio"
         class="radio__control"

--- a/src/components/ebay-radio/test/test.server.js
+++ b/src/components/ebay-radio/test/test.server.js
@@ -17,10 +17,5 @@ test('renders disabled radio', context => {
     expect($(`${inputSelector}[disabled]`).length).to.equal(1);
 });
 
-test('handles pass-through html attributes', context => {
-    testUtils.testHtmlAttributes(context, inputSelector);
-});
-
-test('handles custom class', context => {
-    testUtils.testCustomClass(context, rootSelector);
-});
+test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, inputSelector));
+test('handles custom class and style', context => testUtils.testClassAndStyle(context, rootSelector));

--- a/src/components/ebay-select/README.md
+++ b/src/components/ebay-select/README.md
@@ -33,8 +33,7 @@ Name | Required | Type | Stateful | Description
 `selected` | n/a | Number | Yes | allows you to set the selected index option to `selected`
 `borderless` | No | Boolean | No | whether button has borders
 
-Note: For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `select` tag.
-Be sure to include typical HTML attributes for the `select` tag, like `name`.
+Note: For this component, `class`/`style` are applied to the root tag, while all other HTML attributes are applied to the `select` tag. Be sure to include typical HTML attributes for the `select` tag, like `name`.
 
 ### ebay-select Events
 

--- a/src/components/ebay-select/index.js
+++ b/src/components/ebay-select/index.js
@@ -11,11 +11,12 @@ function getInitialState(input) {
         const selected = option.selected;
 
         return {
+            htmlAttributes: processHtmlAttributes(option),
             class: option.class,
+            style: option.style,
             value: option.value,
             label: option.label,
-            selected: Boolean(selected),
-            htmlAttributes: processHtmlAttributes(option)
+            selected: Boolean(selected)
         };
     });
 
@@ -26,12 +27,13 @@ function getInitialState(input) {
     }
 
     return {
+        htmlAttributes: processHtmlAttributes(input),
         class: input.class,
+        style: input.style,
         options,
         selected: selectedOption,
         borderless: Boolean(input.borderless),
-        disabled: Boolean(input.disabled),
-        htmlAttributes: processHtmlAttributes(input)
+        disabled: Boolean(input.disabled)
     };
 }
 
@@ -43,11 +45,12 @@ function getTemplateData(state) {
     }
 
     return {
+        htmlAttributes: state.htmlAttributes,
         class: selectClass,
+        style: state.style,
         selectedOption: state.selected,
         options: state.options,
-        disabled: state.disabled,
-        htmlAttributes: state.htmlAttributes
+        disabled: state.disabled
     };
 }
 

--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -1,4 +1,4 @@
-<span class=data.class w-bind>
+<span class=data.class style=data.style w-bind>
     <select
         disabled=data.disabled
         w-onchange="optionChanged"
@@ -8,6 +8,7 @@
             value=option.value
             selected=option.selected
             class=option.class
+            style=option.style
             ${option.htmlAttributes}>
             ${option.label}
         </option>

--- a/src/components/ebay-select/test/test.server.js
+++ b/src/components/ebay-select/test/test.server.js
@@ -44,6 +44,6 @@ describe('select', () => {
         expect($('.select.select--borderless').length).to.equal(0);
     });
 
-    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'span.select select'));
-    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'span.select'));
+    test('handles pass-through html attributes', c => testUtils.testHtmlAttributes(c, 'span.select select'));
+    test('handles custom class and style', c => testUtils.testClassAndStyle(c, 'span.select'));
 });

--- a/src/components/ebay-select/test/test.server.js
+++ b/src/components/ebay-select/test/test.server.js
@@ -44,11 +44,6 @@ describe('select', () => {
         expect($('.select.select--borderless').length).to.equal(0);
     });
 
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, 'span.select select');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, 'span.select');
-    });
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'span.select select'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'span.select'));
 });

--- a/src/components/ebay-switch/README.md
+++ b/src/components/ebay-switch/README.md
@@ -12,7 +12,7 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `disabled` | Boolean | No |
 
-Note: For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
+Note: For this component, `class`/`style` are applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 
 ## ebay-radio Events
 

--- a/src/components/ebay-switch/index.js
+++ b/src/components/ebay-switch/index.js
@@ -5,9 +5,10 @@ const template = require('./template.marko');
 
 function getInitialState(input) {
     return {
+        htmlAttributes: processHtmlAttributes(input),
         classes: ['switch', input.class],
-        disabled: Boolean(input.disabled),
-        htmlAttributes: processHtmlAttributes(input)
+        style: input.style,
+        disabled: Boolean(input.disabled)
     };
 }
 

--- a/src/components/ebay-switch/template.marko
+++ b/src/components/ebay-switch/template.marko
@@ -1,4 +1,4 @@
-<span w-bind class=data.classes w-onclick="handleClick">
+<span w-bind class=data.classes style=data.style w-onclick="handleClick">
     <input type="checkbox" disabled=data.disabled ${data.htmlAttributes}/>
     <span/>
 </span>

--- a/src/components/ebay-switch/test/test.server.js
+++ b/src/components/ebay-switch/test/test.server.js
@@ -14,10 +14,5 @@ test('renders disabled switch', context => {
     expect($('.switch > input[disabled]').length).to.equal(1);
 });
 
-test('handles pass-through html attributes', context => {
-    testUtils.testHtmlAttributes(context, '.switch > input');
-});
-
-test('handles custom class', context => {
-    testUtils.testCustomClass(context, '.switch');
-});
+test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, '.switch > input'));
+test('handles custom class and style', context => testUtils.testClassAndStyle(context, '.switch'));

--- a/src/components/ebay-tab/index.js
+++ b/src/components/ebay-tab/index.js
@@ -10,24 +10,27 @@ function getInitialState(input) {
     const fake = Boolean(input.fake);
     const index = parseInt(input.index) || 0;
     const headings = (input.headings || []).map(heading => ({
-        renderBody: heading.renderBody,
+        htmlAttributes: processHtmlAttributes(heading),
         classes: fake ? heading.class : [heading.class, 'tabs__item'],
-        href: heading.href,
-        htmlAttributes: processHtmlAttributes(heading)
+        style: heading.style,
+        renderBody: heading.renderBody,
+        href: heading.href
     }));
     const panels = (input.panels || []).map(panel => ({
-        renderBody: panel.renderBody,
+        htmlAttributes: processHtmlAttributes(panel),
         classes: [panel.class, prefix(fake, 'tabs__panel')],
-        htmlAttributes: processHtmlAttributes(panel)
+        style: panel.style,
+        renderBody: panel.renderBody
     }));
 
     return {
+        htmlAttributes: processHtmlAttributes(input),
+        classes: [input.class, prefix(fake, 'tabs')],
+        style: input.style,
         index,
         fake,
         headings,
-        panels,
-        classes: [input.class, prefix(fake, 'tabs')],
-        htmlAttributes: processHtmlAttributes(input)
+        panels
     };
 }
 

--- a/src/components/ebay-tab/template.marko
+++ b/src/components/ebay-tab/template.marko
@@ -1,10 +1,11 @@
-<div w-bind class=data.classes ${data.htmlAttributes}>
+<div w-bind class=data.classes style=data.style ${data.htmlAttributes}>
     <if(data.fake)>
         <ul class="fake-tabs__items">
             <for(i, heading in data.headings)>
                 <var isCurrentHeading=parseInt(i) === data.index/>
                 <li
                     class=[heading.classes, 'fake-tabs__item', isCurrentHeading ? 'fake-tabs__item--current' : null]
+                    style=heading.style
                     ${heading.htmlAttributes}>
                     <a
                         aria-current=(isCurrentHeading && "page")
@@ -15,7 +16,7 @@
         </ul>
         <div class="fake-tabs__content">
             <var panel=data.panels[0]/>
-            <div class=panel.classes ${panel.htmlAttributes}>
+            <div class=panel.classes style=panel.style ${panel.htmlAttributes}>
                 <div class="fake-tabs__cell">
                     <div w-body=panel.renderBody/>
                 </div>
@@ -31,6 +32,7 @@
                     role="tab"
                     aria-selected=String(parseInt(i) === data.index)
                     class=heading.classes
+                    style=heading.style
                     w-onclick="handleHeadingClick"
                     w-onkeydown="handleHeadingKeydown"
                     w-preserve-attrs="tabindex,data-makeup-index"
@@ -46,6 +48,7 @@
                     id="${widget.id}-tabpanel-${i}"
                     role="tabpanel"
                     class=panel.classes
+                    style=panel.style
                     hidden=(parseInt(i) !== data.index)
                     ${panel.htmlAttributes}>
                     <div class="tabs__cell">

--- a/src/components/ebay-tab/test/test.server.js
+++ b/src/components/ebay-tab/test/test.server.js
@@ -80,7 +80,7 @@ describe('tab-heading', () => {
 
     test('handles custom class when fake', context => {
         const parentInput = { fake: true, panels: mock.panels };
-        testUtils.testCustomClass(context, '.fake-tabs__item', 'headings', false, {}, parentInput);
+        testUtils.testCustomClass(context, '.fake-tabs__item', 'headings', {}, parentInput);
     });
 });
 
@@ -100,6 +100,6 @@ describe('tab-panel', () => {
 
     test('handles custom class when fake', context => {
         const parentInput = { fake: true, headings: mock.fakeHeadings };
-        testUtils.testCustomClass(context, '.fake-tabs__panel', 'panels', false, {}, parentInput);
+        testUtils.testCustomClass(context, '.fake-tabs__panel', 'panels', {}, parentInput);
     });
 });

--- a/src/components/ebay-tab/test/test.server.js
+++ b/src/components/ebay-tab/test/test.server.js
@@ -55,13 +55,8 @@ describe('tab', () => {
         expect($('div.fake-tabs__panel').length).to.equal(1);
     });
 
-    test('handles pass-through html attributes', context => {
-        testUtils.testHtmlAttributes(context, '.tabs');
-    });
-
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.tabs');
-    });
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, '.tabs'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, '.tabs'));
 });
 
 describe('tab-heading', () => {
@@ -69,8 +64,8 @@ describe('tab-heading', () => {
         testUtils.testHtmlAttributes(context, '.tabs__item', 'headings');
     });
 
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.tabs__item', 'headings');
+    test('handles custom class and style', context => {
+        testUtils.testClassAndStyle(context, '.tabs__item', 'headings');
     });
 
     test('handles pass-through html attributes when fake', context => {
@@ -78,9 +73,9 @@ describe('tab-heading', () => {
         testUtils.testHtmlAttributes(context, '.fake-tabs__item', 'headings', {}, parentInput);
     });
 
-    test('handles custom class when fake', context => {
+    test('handles custom class and style when fake', context => {
         const parentInput = { fake: true, panels: mock.panels };
-        testUtils.testCustomClass(context, '.fake-tabs__item', 'headings', {}, parentInput);
+        testUtils.testClassAndStyle(context, '.fake-tabs__item', 'headings', {}, parentInput);
     });
 });
 
@@ -89,8 +84,8 @@ describe('tab-panel', () => {
         testUtils.testHtmlAttributes(context, '.tabs__panel', 'panels');
     });
 
-    test('handles custom class', context => {
-        testUtils.testCustomClass(context, '.tabs__panel', 'panels');
+    test('handles custom class and style', context => {
+        testUtils.testClassAndStyle(context, '.tabs__panel', 'panels');
     });
 
     test('handles pass-through html attributes when fake', context => {
@@ -98,8 +93,8 @@ describe('tab-panel', () => {
         testUtils.testHtmlAttributes(context, '.fake-tabs__panel', 'panels', {}, parentInput);
     });
 
-    test('handles custom class when fake', context => {
+    test('handles custom class and style when fake', context => {
         const parentInput = { fake: true, headings: mock.fakeHeadings };
-        testUtils.testCustomClass(context, '.fake-tabs__panel', 'panels', {}, parentInput);
+        testUtils.testClassAndStyle(context, '.fake-tabs__panel', 'panels', {}, parentInput);
     });
 });

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -8,9 +8,10 @@ function getInitialState(input) {
         classes.push('textbox__control--fluid');
     }
     return {
-        classes,
         htmlAttributes: processHtmlAttributes(input),
         rootClass: ['textbox', input.class],
+        style: input.style,
+        classes,
         tag: input.fluid ? 'div' : 'span',
         textboxTag: Boolean(input.multiline) ? 'textarea' : 'input',
         invalid: String(Boolean(input.invalid))

--- a/src/components/ebay-textbox/template.marko
+++ b/src/components/ebay-textbox/template.marko
@@ -1,4 +1,4 @@
-<${data.tag} class=data.rootClass w-bind>
+<${data.tag} class=data.rootClass style=data.style w-bind>
     <${data.textboxTag}
     class=data.classes
     type="text"

--- a/src/components/ebay-textbox/test/test.server.js
+++ b/src/components/ebay-textbox/test/test.server.js
@@ -32,10 +32,5 @@ test('renders a textarea element', context => {
     expect($(textareaSelector).length).to.equal(1);
 });
 
-test('handles pass-through html attributes', context => {
-    testUtils.testHtmlAttributes(context, inputSelector);
-});
-
-test('handles custom class', context => {
-    testUtils.testCustomClass(context, '.textbox');
-});
+test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, inputSelector));
+test('handles custom class and style', context => testUtils.testClassAndStyle(context, '.textbox'));


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- added `style` as an explicit attribute to every tag
- updated renderers/templates to process `style`
- update testUtils
- update docs around pass-through of class/style vs other attributes
- minor cleanup and reordering

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Currently, `style` gets processed as a normal HTML attribute. However, Marko has special treatment for `class` and `style` to allow object/array input rather than just string. To allow users to use the Marko helpers, we have to process it explicitly.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #132 
