### PR TITLE
Menu: use onRender for update via parent state

### DIFF
--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -99,14 +99,13 @@ describe('given the carousel starts in the default state with items', () => {
         });
     });
 
-    // simulate parent state change
-    describe('when index is updated via state', () => {
+    describe('when index is updated via parent state', () => {
         let updateSpy;
         beforeEach(done => {
             updateSpy = sinon.spy();
             widget.on('carousel-update', updateSpy);
             widget.subscribeTo(list).once('transitionend', done);
-            widget.setState('index', 1);
+            widget.setProps({ index: '1', items: mock.sixItems });
         });
 
         it('then it emits the marko update event', () => {

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -160,22 +160,24 @@ function onRender(event) {
             });
         }
 
-        // TODO: move outside of firstRender, but must check before attaching observers on render
+        // FIXME: should be outside of firstRender, but only if observers haven't been attached yet
         const checkedObserverCallback = itemEl => this.processAfterStateChange([getItemElementIndex(itemEl)]);
         this.itemEls.forEach((itemEl, i) => {
             observer.observeInner(this, itemEl, 'checked', `items[${i}]`, 'items', checkedObserverCallback);
         });
-    }
 
-    if (!this.state.isFake) {
-        rovingTabindex.createLinear(this.contentEl, 'div', { index: 0, autoReset: 0 });
+        const expander = new Expander(this.el, { // eslint-disable-line no-unused-vars
+            hostSelector: buttonSelector,
+            focusManagement: 'focusable',
+            expandOnClick: true,
+            autoCollapse: true
+        });
+
+        // FIXME: should be outside of firstRender, but only when itemEls changes
+        if (!this.state.isFake) {
+            rovingTabindex.createLinear(this.contentEl, 'div', { index: 0, autoReset: 0 });
+        }
     }
-    const expander = new Expander(this.el, { // eslint-disable-line no-unused-vars
-        hostSelector: buttonSelector,
-        focusManagement: 'focusable',
-        expandOnClick: true,
-        autoCollapse: true
-    });
 }
 
 /**

--- a/src/components/ebay-menu/mock/index.js
+++ b/src/components/ebay-menu/mock/index.js
@@ -1,6 +1,6 @@
 const iconRenderBody = (stream) => stream.write('icon');
 const renderBody = text => stream => stream.write(text);
-const items = [{ renderBody: renderBody('1') }, { renderBody: renderBody('2') }];
-const items2 = [{ renderBody: renderBody('3') }];
+const twoItems = [{ renderBody: renderBody('1') }, { renderBody: renderBody('2') }];
+const threeItems = [{ renderBody: renderBody('1') }, { renderBody: renderBody('2') }, { renderBody: renderBody('3') }];
 
-module.exports = { iconRenderBody, renderBody, items, items2 };
+module.exports = { iconRenderBody, renderBody, twoItems, threeItems };

--- a/src/components/ebay-menu/mock/index.js
+++ b/src/components/ebay-menu/mock/index.js
@@ -1,6 +1,6 @@
 const iconRenderBody = (stream) => stream.write('icon');
-const renderBody = (stream) => stream.write('text');
-const item = { renderBody };
-const items = [item, item, item];
+const renderBody = text => stream => stream.write(text);
+const items = [{ renderBody: renderBody('1') }, { renderBody: renderBody('2') }];
+const items2 = [{ renderBody: renderBody('3') }];
 
-module.exports = { iconRenderBody, renderBody, item, items };
+module.exports = { iconRenderBody, renderBody, items, items2 };

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -59,7 +59,7 @@ describe('given the menu is in the default state', () => {
         });
     });
 
-    describe('when new item input is provided via parent state', () => {
+    describe('when items are updated via parent state', () => {
         let spy;
         let thirdItem;
         beforeEach(done => {

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -59,6 +59,28 @@ describe('given the menu is in the default state', () => {
         });
     });
 
+    describe('when new input is provided', () => {
+        const newLabel = 'label2';
+        let spy;
+        let firstItem;
+        beforeEach(() => {
+            widget.setProps({ label: newLabel, items: mock.items2 });
+            spy = sinon.spy();
+            widget.on('menu-select', spy);
+            firstItem = document.querySelector('.menu__item');
+            testUtils.triggerEvent(firstItem, 'click');
+        });
+
+        test('then it rerenders with the new input', (context, done) => {
+            setTimeout(() => {
+                expect(buttonLabel.innerText.trim()).to.equal(newLabel);
+                const eventData = spy.getCall(0).args[0];
+                expect(eventData.el.innerText).to.equal(firstItem.innerText);
+                done();
+            }, 10);
+        });
+    });
+
     describe('when the expanded property is set to false', () => {
         let spy;
         beforeEach(() => {

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -11,7 +11,7 @@ describe('given the menu is in the default state', () => {
     let buttonLabel;
 
     beforeEach(() => {
-        widget = renderer.renderSync({ label: 'label', items: mock.items }).appendTo(document.body).getWidget();
+        widget = renderer.renderSync({ label: 'label', items: mock.twoItems }).appendTo(document.body).getWidget();
         root = document.querySelector('span.menu');
         button = document.querySelector('.expand-btn');
         buttonLabel = root.querySelector('.expand-btn > span');
@@ -59,25 +59,23 @@ describe('given the menu is in the default state', () => {
         });
     });
 
-    describe('when new input is provided', () => {
-        const newLabel = 'label2';
+    describe('when new item input is provided via parent state', () => {
         let spy;
-        let firstItem;
-        beforeEach(() => {
-            widget.setProps({ label: newLabel, items: mock.items2 });
+        let thirdItem;
+        beforeEach(done => {
             spy = sinon.spy();
             widget.on('menu-select', spy);
-            firstItem = document.querySelector('.menu__item');
-            testUtils.triggerEvent(firstItem, 'click');
-        });
-
-        test('then it rerenders with the new input', (context, done) => {
+            widget.setProps({ items: mock.threeItems });
             setTimeout(() => {
-                expect(buttonLabel.innerText.trim()).to.equal(newLabel);
-                const eventData = spy.getCall(0).args[0];
-                expect(eventData.el.innerText).to.equal(firstItem.innerText);
+                thirdItem = document.querySelectorAll('.menu__item')[2];
+                testUtils.triggerEvent(thirdItem, 'click');
                 done();
             }, 10);
+        });
+
+        test('then it uses the new input in event data', () => {
+            const eventData = spy.getCall(0).args[0];
+            expect(eventData.el.innerText).to.equal(thirdItem.innerText);
         });
     });
 
@@ -129,7 +127,7 @@ describe('given the menu is in the expanded state', () => {
     let firstItem;
 
     beforeEach((done) => {
-        widget = renderer.renderSync({ items: mock.items }).appendTo(document.body).getWidget();
+        widget = renderer.renderSync({ items: mock.twoItems }).appendTo(document.body).getWidget();
         root = document.querySelector('span.menu');
         button = document.querySelector('.expand-btn');
         firstItem = document.querySelector('.menu__item');
@@ -218,7 +216,7 @@ describe('given the menu is in the expanded state with radio items', () => {
         widget = renderer.renderSync({
             expanded: true,
             type: 'radio',
-            items: mock.items }).appendTo(document.body).getWidget();
+            items: mock.twoItems }).appendTo(document.body).getWidget();
         [firstItem, secondItem] = document.querySelectorAll('.menu__item');
         firstItemInner = firstItem.querySelector('span');
         root = document.querySelector('span.menu');
@@ -395,7 +393,7 @@ describe('given the menu is in the expanded state with checkbox items', () => {
         widget = renderer.renderSync({
             expanded: true,
             type: 'checkbox',
-            items: mock.items }).appendTo(document.body).getWidget();
+            items: mock.twoItems }).appendTo(document.body).getWidget();
         [firstItem, secondItem] = document.querySelectorAll('.menu__item');
         root = document.querySelector('span.menu');
         root.expanded = true;

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -134,7 +134,7 @@ describe('menu', () => {
 
 describe('menu-item', () => {
     test('renders basic version', context => {
-        const input = { items: mock.items };
+        const input = { items: mock.twoItems };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('div.menu__item').length).to.equal(2);
     });

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -136,7 +136,7 @@ describe('menu-item', () => {
     test('renders basic version', context => {
         const input = { items: mock.items };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('div.menu__item').length).to.equal(3);
+        expect($('div.menu__item').length).to.equal(2);
     });
 
     test('renders fake version', context => {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- replace `init` with `onRender`
- add test case for menu items update via parent state
- minor updates to related code

## Context
<!--- Why did you make these changes, and why in this particular way? -->
We currently do client initialization via `init`, and set vars that we don't expect to change, like `this.itemEls`. However, when updating the items via parent state, `init()` does not get called again, which causes `itemEls` to be out of date, resulting in bad data in the events. I've fixed this by using `onRender` instead, with an internal code split depending on `firstRender`.

I added a `TODO` for an issue that's a related bug, but less important for now.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #327 