### PR TITLE
Dialog: Move a11y root of dialog to the window.

### DIFF
--- a/src/components/ebay-dialog/index.js
+++ b/src/components/ebay-dialog/index.js
@@ -81,8 +81,8 @@ function trap(opts) {
     const focusEl = (this.state.focus && document.getElementById(this.state.focus)) || this.closeEl;
 
     if (restoreTrap || (isTrapped && !wasTrapped)) {
-        screenReaderTrap.trap(this.dialogEl);
-        keyboardTrap.trap(this.dialogEl);
+        screenReaderTrap.trap(this.windowEl);
+        keyboardTrap.trap(this.windowEl);
     }
 
     // Ensure focus is set and body scroll prevented on initial render.
@@ -144,8 +144,8 @@ function trap(opts) {
 function release() {
     if (this.isTrapped) {
         this.restoreTrap = this.state.open;
-        screenReaderTrap.untrap(this.dialogEl);
-        keyboardTrap.untrap(this.dialogEl);
+        screenReaderTrap.untrap(this.windowEl);
+        keyboardTrap.untrap(this.windowEl);
     } else {
         this.restoreTrap = false;
     }

--- a/src/components/ebay-dialog/test/test.browser.js
+++ b/src/components/ebay-dialog/test/test.browser.js
@@ -6,6 +6,7 @@ const renderer = require('../');
 describe('given the dialog is in the default state', () => {
     let widget;
     let root;
+    let dialogWindow;
     let close;
     let sibling;
 
@@ -15,6 +16,7 @@ describe('given the dialog is in the default state', () => {
 
         widget = renderer.renderSync({}).appendTo(document.body).getWidget();
         root = widget.el;
+        dialogWindow = root.querySelector('.dialog__window');
         close = root.querySelector('.dialog__close');
     });
 
@@ -38,7 +40,7 @@ describe('given the dialog is in the default state', () => {
         });
 
         test('then it does not trap focus', () => {
-            expect(root.classList.contains('keyboard-trap--active')).to.equal(false);
+            expect(dialogWindow.classList.contains('keyboard-trap--active')).to.equal(false);
         });
     });
 
@@ -75,7 +77,7 @@ describe('given the dialog is in the default state', () => {
         });
 
         test('then it traps focus', () => {
-            expect(root.classList.contains('keyboard-trap--active')).to.equal(true);
+            expect(dialogWindow.classList.contains('keyboard-trap--active')).to.equal(true);
             expect(document.activeElement.className).to.eql(close.className);
         });
 
@@ -95,6 +97,7 @@ describe('given the dialog is in the default state', () => {
 describe('given the dialog is in the open state', () => {
     let widget;
     let root;
+    let dialogWindow;
     let close;
     let sibling;
 
@@ -104,6 +107,7 @@ describe('given the dialog is in the open state', () => {
 
         widget = renderer.renderSync({ open: true }).appendTo(document.body).getWidget();
         root = widget.el;
+        dialogWindow = root.querySelector('.dialog__window');
         close = root.querySelector('.dialog__close');
     });
 
@@ -124,7 +128,7 @@ describe('given the dialog is in the open state', () => {
         });
 
         test('then it traps focus', () => {
-            expect(root.classList.contains('keyboard-trap--active')).to.equal(true);
+            expect(dialogWindow.classList.contains('keyboard-trap--active')).to.equal(true);
             expect(document.activeElement.className).to.eql(close.className);
         });
     });
@@ -183,7 +187,7 @@ describe('given the dialog is in the open state', () => {
         });
 
         test('then it does not trap focus', () => {
-            expect(root.classList.contains('keyboard-trap--active')).to.equal(false);
+            expect(dialogWindow.classList.contains('keyboard-trap--active')).to.equal(false);
         });
 
         if (!skipRerender) {


### PR DESCRIPTION
## Description
This PR changes the focus and keyboard traps to use the dialog window instead of the root element.
Having these traps on the root element cause extra dom nodes to be inserted outside of the carousel which is causing issues when Marko goes to diff the parent.

This broke in 0.8.0 with #266 where previously the dialog element was insides a placeholder element which contained these new nodes.

## References
Fixes #334 

I have not confirmed the fix (ie testing it in the ui-marketplace) but am fairly confident this should do it. Even if this does not resolve #334 (almost certain it will) this change is still for the best.