### PR TITLE
Carousel: native scroll event

### DIFF
--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -57,6 +57,11 @@ Event | Data | Description
 `carousel-play` | `{ originalEvent }` | called when the autoplay play button is pressed
 `carousel-pause` | `{ originalEvent }` | called when the autoplay pause button is pressed
 
+### Additional Events for touch devices.
+Event | Data | Description
+--- | --- | ---
+`carousel-scroll` | `{ index }` | new index is navigated to by native scrolling
+
 Notes:
 
 * The `carousel` will manipulate the `tabindex` property of nested focusable elements inside `<ebay-carousel-item>`.

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -307,6 +307,7 @@ function handleScrollEnd(scrollLeft) {
     config.preserveItems = true;
     this.setStateDirty('index', closest);
     this.once('update', this.emitUpdate);
+    emitAndFire(this, 'carousel-scroll', { index: closest });
 }
 
 /**

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -993,14 +993,17 @@ describe('given a carousel in the default state with native scrolling', () => {
     describe('when scrolling an item to the right', () => {
         let nextSpy;
         let slideSpy;
+        let scrollSpy;
         let updateSpy;
 
         beforeEach(done => {
             nextSpy = sinon.spy();
             slideSpy = sinon.spy();
+            scrollSpy = sinon.spy();
             updateSpy = sinon.spy();
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-slide', slideSpy);
+            widget.on('carousel-scroll', scrollSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.simulateScroll(list, list.children[2].offsetLeft);
             waitForUpdate(widget, done);
@@ -1009,6 +1012,12 @@ describe('given a carousel in the default state with native scrolling', () => {
         it('then it does not emit next or slide events', () => {
             expect(nextSpy.notCalled).to.equal(true);
             expect(slideSpy.notCalled).to.equal(true);
+        });
+
+        it('then it emits the carousel scroll event', () => {
+            expect(scrollSpy.calledOnce).to.equal(true);
+            const eventData = scrollSpy.getCall(0).args[0];
+            expect(eventData.index).to.deep.equal(2);
         });
 
         it('then it emits the marko update event', () => {


### PR DESCRIPTION
## Description
Adds an event for the native touch scroll event for the carousel, similar to `carousel-{prev,next,slide}`.
