### PR TITLE
Carousel: Peek functionality

### DIFF
--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -66,3 +66,4 @@ Notes:
 
 * The `carousel` will manipulate the `tabindex` property of nested focusable elements inside `<ebay-carousel-item>`.
 * The `autoplay` carousel currently does not support native scrolling and will use transforms instead.
+* The `items-per-slide` attribute can be set to a float such as `3.5` to show 3 items, and half of the 4th item. This also automatically enables the `no-dots` attribute.

--- a/src/components/ebay-carousel/examples/11-items-per-slide-partial-item/template.marko
+++ b/src/components/ebay-carousel/examples/11-items-per-slide-partial-item/template.marko
@@ -1,0 +1,25 @@
+<style>
+    .demo11-card {
+        color: #cdf4fd;
+        background: #a1208b;
+        font-size: 24px;
+        font-weight: bold;
+        height: 150px;
+        line-height: 150px;
+        text-align: center;
+    }
+</style>
+<ebay-carousel items-per-slide="3.25">
+    <ebay-carousel-item class="demo11-card">Card 1</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 2</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 3</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 4</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 5</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 6</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 7</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 8</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 9</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 10</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 11</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 12</ebay-carousel-item>
+</ebay-carousel>

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -763,6 +763,73 @@ describe('given a discrete carousel with three half width items', () => {
     });
 });
 
+describe('given a discrete carousel with a partial slide', () => {
+    const input = { itemsPerSlide: 2.1, items: mock.sixItems };
+    let widget;
+    let root;
+    let list;
+    let nextButton;
+
+    beforeEach(done => {
+        widget = renderer.renderSync(input).appendTo(document.body).getWidget();
+        root = document.querySelector('.carousel');
+        list = root.querySelector('.carousel__list');
+        nextButton = root.querySelector('.carousel__control--next');
+        waitForUpdate(widget, done);
+    });
+    afterEach(() => widget.destroy());
+
+    describe('when it is rendered', () => {
+        it('then it shows part of the next slide', () => {
+            const { right: slideRight } = list.getBoundingClientRect();
+            const { left: itemLeft, right: itemRight } = list.children[2].getBoundingClientRect();
+            expect(itemLeft).lt(slideRight);
+            expect(itemRight).gt(slideRight);
+        });
+    });
+
+    describe('when next button is clicked', () => {
+        let nextSpy;
+        let slideSpy;
+        let updateSpy;
+        beforeEach(done => {
+            nextSpy = sinon.spy();
+            slideSpy = sinon.spy();
+            updateSpy = sinon.spy();
+            widget.on('carousel-next', nextSpy);
+            widget.on('carousel-slide', slideSpy);
+            widget.on('carousel-update', updateSpy);
+            testUtils.triggerEvent(nextButton, 'click');
+            widget.subscribeTo(list).once('transitionend', done);
+        });
+
+        it('then it emits the marko next event', () => testControlEvent(nextSpy));
+
+        it('then it emits the marko slide event', () => {
+            expect(slideSpy.calledOnce).to.equal(true);
+            const eventData = slideSpy.getCall(0).args[0];
+            expect(eventData.slide).to.equal(2);
+        });
+
+        it('then it emits the marko update event', () => {
+            expect(updateSpy.calledOnce).to.equal(true);
+            const eventData = updateSpy.getCall(0).args[0];
+            expect(eventData.visibleIndexes).to.deep.equal([2, 3]);
+        });
+
+        it('then it applies a translation', () => {
+            const { offsetLeft } = list.children[2];
+            expect(getTranslateX(list)).to.equal(offsetLeft);
+        });
+
+        it('then it calculates item visibility correctly', () => {
+            const { state: { items } } = widget;
+            const visibleIndexes = getVisibleIndexes(items);
+            expect(visibleIndexes).to.deep.equal([2, 3]);
+        });
+    });
+});
+
 describe('given an autoplay carousel in the default state', () => {
     const input = { itemsPerSlide: 2, items: mock.sixItems, autoplay: 200 };
     let widget;


### PR DESCRIPTION
## Description
This PR updates the `items-per-slide` option of the carousel to accept fractions to display part of the next slide. IE: `items-per-slide="2.5"` shows two items and half of the third item.

Note: this also automatically hide's the `dot` controls if we are doing partial slides as per the design system.

## Context
Originally I was going to create a separate `peek` attribute, however I think just using item's per slide is intuitive enough. Also you can only have a `peek` style carousel if `items-per-slide` is set, so this saves us some checks.

## Screenshots
<!-- Upload screenshots if appropriate. -->
![image](https://user-images.githubusercontent.com/4985201/44047256-b08f38c6-9ee2-11e8-94d5-62632a0661bf.png)

![image](https://user-images.githubusercontent.com/4985201/44047274-be0e4a6e-9ee2-11e8-9916-9a24c2cd1e84.png)
