### PR TITLE
Icon: Use relative path for icon symbol requires.

### DIFF
--- a/src/components/ebay-icon/transformer.js
+++ b/src/components/ebay-icon/transformer.js
@@ -18,7 +18,7 @@ function transform(el, context) {
     const isInline = typeAttribute && typeAttribute.value.value === 'inline';
     const iconName = nameAttribute && nameAttribute.value.value;
     if (isInline && iconName) {
-        const templatePath = path.join(__dirname, `symbols/${iconName}.marko`);
+        const templatePath = context.getRequirePath(path.join(__dirname, `symbols/${iconName}.marko`));
         el.prependChild(context.createNodeForEl('include', {}, JSON.stringify(templatePath)));
     }
 


### PR DESCRIPTION
## Description
Currently the ebay icon automatically includes the absolute path of the symbol to use at compile time in order to ensure that only the used symbols are sent to the browser. Lasso also creates a comment for the actual require path for every require. This is fine, however the resource server is generating the hash for these files based off of their unminified source which includes the absolute path comment. The issue occurs when there are multiple machines with different file paths and since the resource server is using the source with these comments to generate the hash, two or more bundles are created.

## Context
This changes the ebay-icon to always use a relative path to the `symbol` file which won't cause different comments to be created on different machines.