### PR TITLE
Menu: collapse from button escape

### DIFF
--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -22,4 +22,5 @@ Name | Type | Stateful | Description
 
 Event | Data | Description
 --- | --- | ---
-`button-click` | `{ originalEvent }` | click
+`button-click` | `{ originalEvent }` | click or action key pressed (space and enter)
+`button-escape` | `{ originalEvent }` | escape key pressed

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -68,9 +68,14 @@ function handleClick(originalEvent) {
  * https://ebay.gitbooks.io/mindpatterns/content/input/button.html#keyboard
  * @param {MouseEvent} e
  */
-function handleKeydown(e) {
-    eventUtils.handleActionKeydown(e, () => {
-        this.handleClick(e);
+function handleKeydown(originalEvent) {
+    eventUtils.handleActionKeydown(originalEvent, () => {
+        this.handleClick(originalEvent);
+    });
+    eventUtils.handleEscapeKeydown(originalEvent, () => {
+        if (!this.state.disabled) {
+            emitAndFire(this, 'button-escape', { originalEvent });
+        }
     });
 }
 

--- a/src/components/ebay-button/test/test.browser.js
+++ b/src/components/ebay-button/test/test.browser.js
@@ -46,6 +46,20 @@ describe('given button is enabled', () => {
             testUtils.testOriginalEvent(spy);
         });
     });
+
+    describe('when escape key is pressed', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('button-escape', spy);
+            testUtils.triggerEvent(root, 'keydown', 27);
+        });
+
+        test('then it emits the event with correct data', () => {
+            expect(spy.calledOnce).to.equal(true);
+            testUtils.testOriginalEvent(spy);
+        });
+    });
 });
 
 describe('given button is disabled', () => {
@@ -61,6 +75,19 @@ describe('given button is disabled', () => {
             spy = sinon.spy();
             widget.on('button-click', spy);
             testUtils.triggerEvent(root, 'click');
+        });
+
+        test('then it doesn\'t emit the event', () => {
+            expect(spy.called).to.equal(false);
+        });
+    });
+
+    describe('when escape key is pressed', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('button-escape', spy);
+            testUtils.triggerEvent(root, 'keydown', 27);
         });
 
         test('then it doesn\'t emit the event', () => {

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -284,6 +284,10 @@ function handleItemKeydown(e) {
     });
 }
 
+function handleButtonEscape() {
+    this.setState('expanded', false);
+}
+
 function handleExpand() {
     this.setState('expanded', true);
     emitAndFire(this, 'menu-expand');
@@ -340,6 +344,7 @@ module.exports = markoWidgets.defineComponent({
     update_expanded,
     handleItemClick,
     handleItemKeydown,
+    handleButtonEscape,
     handleExpand,
     handleCollapse,
     setCheckedItem,

--- a/src/components/ebay-menu/template.marko
+++ b/src/components/ebay-menu/template.marko
@@ -1,5 +1,14 @@
 <span class=data.menuClass style=data.style w-bind w-on-expander-expand="handleExpand" w-on-expander-collapse="handleCollapse" ${data.htmlAttributes}>
-    <ebay-button w-id="button" class=data.buttonClass variant="expand" size=data.size priority=data.priority aria-expanded=String(data.expanded) aria-haspopup="true" aria-label=data.accessibilityText>
+    <ebay-button
+        w-id="button"
+        class=data.buttonClass
+        variant="expand"
+        size=data.size
+        priority=data.priority
+        aria-expanded=String(data.expanded)
+        aria-haspopup="true"
+        aria-label=data.accessibilityText
+        w-on-button-escape="handleButtonEscape">
         <span class="expand-btn__cell">
             <!-- Convoluted markup to satisfy both Skin and Marko -->
             <div if(data.icon) w-preserve-body class="expand-btn__icon">

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -186,12 +186,30 @@ describe('given the menu is in the expanded state', () => {
         });
     });
 
-    describe('when the escape key is pressed', () => {
+    describe('when the escape key is pressed from an item', () => {
         let spy;
         beforeEach((done) => {
             spy = sinon.spy();
             widget.on('menu-collapse', spy);
             testUtils.triggerEvent(firstItem, 'keydown', 27);
+            setTimeout(done);
+        });
+
+        test('then it collapses', () => {
+            expect(button.getAttribute('aria-expanded')).to.equal('false');
+        });
+
+        test('then it emits the marko collapse event', () => {
+            expect(spy.calledOnce).to.equal(true);
+        });
+    });
+
+    describe('when the escape key is pressed from the button', () => {
+        let spy;
+        beforeEach((done) => {
+            spy = sinon.spy();
+            widget.on('menu-collapse', spy);
+            testUtils.triggerEvent(button, 'keydown', 27);
             setTimeout(done);
         });
 


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- create `button-escape` event
- use `button-escape` to collapse menu
- update docs
- add tests

## Context
<!--- Why did you make these changes, and why in this particular way? -->
A more generic event would be `button-keydown`, but we're already firing `button-click` when action buttons are pressed. So, I created `button-escape` instead.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #212 
Follow up to #246

