### PR TITLE
Carousel: add support for a11y status tag

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -51,6 +51,7 @@
         "@a11y-previous-text": "string",
         "@a11y-next-text": "string",
         "@a11y-status-text": "string",
+        "@a11y-status-tag": "string",
         "@a11y-current-text": "string",
         "@a11y-other-text": "string",
         "@a11y-play-text": "string",

--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -27,6 +27,7 @@ Name | Type | Stateful | Description
 Name | Type | Stateful | Description
 --- | --- | --- | ---
 `a11y-status-text` | String | No | status text (default: "Showing Slide {currentSlide} of {totalSlides} - Carousel")
+`a11y-status-tag` | String | No | use h1-h6 when there isn't a visible heading before the carousel (default: "span")
 `a11y-current-text` | String | No | pagination current slide text (default: "Current Slide {currentSlide} - Carousel")
 `a11y-other-text` | String | No | pagination other slide text (default: "Slide {slide} - Carousel")
 `autoplay` | Boolean or Number | No | automatically slides the carousel on an interval. If a number is supplied that is used as the interval in ms, defaults to 4000ms.

--- a/src/components/ebay-carousel/examples/09-a11y-text/template.marko
+++ b/src/components/ebay-carousel/examples/09-a11y-text/template.marko
@@ -15,6 +15,7 @@
     a11y-previous-text="Go to previous slide - Top Products"
     a11y-next-text="Go to next slide - Top Products"
     a11y-status-text="Showing slide {currentSlide} of {totalSlides} - Top Products - Carousel"
+    a11y-status-tag="h2"
     a11y-current-text="Current Slide {currentSlide} - Top Products - Carousel"
     a11y-other-text="Slide {slide} - Top Products - Carousel">
     <ebay-carousel-item class="demo9-card"><a href="#">Card 1</a></ebay-carousel-item>

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -24,6 +24,7 @@ function getInitialState(input) {
         a11yPreviousText: input.a11yPreviousText || 'Previous Slide',
         a11yNextText: input.a11yNextText || 'Next Slide',
         a11yStatusText: input.a11yStatusText || 'Showing Slide {currentSlide} of {totalSlides} - Carousel',
+        a11yStatusTag: input.a11yStatusTag || 'span',
         a11yCurrentText: input.a11yCurrentText || 'Current Slide {currentSlide} - Carousel',
         a11yOtherText: input.a11yOtherText || 'Slide {slide} - Carousel',
         a11yPauseText: input.a11yPauseText || 'Pause - Carousel',

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -2,13 +2,13 @@
     <var config=data.config/>
     <var statusId=("carousel-status-" + widget.id)/>
     <div w-id="container" class=["carousel__container", data.bothControlsDisabled && "carousel__container--controls-disabled"]>
-        <span
+        <${data.a11yStatusTag}
             if(data.totalSlides >= 1)
             id=statusId
             class="clipped"
             aria-live=(data.autoplayInterval && !data.paused ? "off" : "polite")>
             <span>${data.a11yStatusText}</span>
-        </span>
+        </>
         <button
             class="carousel__control carousel__control--prev"
             w-onclick=(!data.prevControlDisabled && "handleMove")

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -2,16 +2,27 @@ const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/server');
 const mock = require('../mock');
 
+function testStructure($) {
+    expect($('.carousel').length).to.equal(1);
+    expect($('.carousel__control--prev').length).to.equal(1);
+    expect($('.carousel__control--next').length).to.equal(1);
+    expect($('ul.carousel__list').length).to.equal(1);
+    expect($('ul.carousel__list > li').length).to.equal(mock.sixItems.length);
+    expect($('ul.carousel__list > li:not([aria-hidden="true"])').length).to.equal(mock.sixItems.length);
+}
+
 describe('carousel', () => {
-    test('renders basic version', context => {
+    test('renders default version', context => {
         const input = { items: mock.sixItems };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('.carousel').length).to.equal(1);
-        expect($('.carousel__control--prev').length).to.equal(1);
-        expect($('.carousel__control--next').length).to.equal(1);
-        expect($('ul.carousel__list').length).to.equal(1);
-        expect($('ul.carousel__list > li').length).to.equal(mock.sixItems.length);
-        expect($('ul.carousel__list > li:not([aria-hidden="true"])').length).to.equal(mock.sixItems.length);
+        testStructure($);
+    });
+
+    test('renders discrete version', context => {
+        const input = { items: mock.sixItems, itemsPerSlide: 3 };
+        const $ = testUtils.getCheerio(context.render(input));
+        testStructure($);
+        expect($('span.clipped').length).to.equal(1);
     });
 
     test('renders a11y text', context => {
@@ -21,13 +32,14 @@ describe('carousel', () => {
             a11yPreviousText: 'prev',
             a11yNextText: 'next',
             a11yStatusText: '{currentSlide} of {totalSlides}',
+            a11yStatusTag: 'h2',
             a11yCurrentText: 'slide {currentSlide}',
             a11yOtherText: 'other {slide}'
         };
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.carousel__control--prev[aria-label="prev"]').length).to.equal(1);
         expect($('.carousel__control--next[aria-label="next"]').length).to.equal(1);
-        expect($('.clipped[aria-live] span').text()).to.equal('1 of 6');
+        expect($('h2.clipped[aria-live] span').text()).to.equal('1 of 6');
         expect($('[data-slide="0"][aria-label="slide 1"]').length).to.equal(1);
         expect($('[data-slide="1"][aria-label="other 2"]').length).to.equal(1);
     });


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- add `a11y-status-tag` attribute
- update tests and docs

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This attribute is similar to the `a11y-heading-tag` used elsewhere, but in this case it can be either span or h1-h6, so I kept the `status` name.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #325 