### PR TITLE
Menu: change class on non-toggle icon

### DIFF
--- a/src/components/ebay-menu/examples/11-icon-without-toggle/template.marko
+++ b/src/components/ebay-menu/examples/11-icon-without-toggle/template.marko
@@ -3,7 +3,7 @@
  * Below we have added an empty class to force this to be the case.
  */
 class {};
-<ebay-menu icon="settings" a11y-text="Settings" no-toggle-icon>
+<ebay-menu icon="mic" a11y-text="Microphone" no-toggle-icon>
     <ebay-menu-item>item 1</ebay-menu-item>
     <ebay-menu-item>item 2</ebay-menu-item>
     <ebay-menu-item>item 3</ebay-menu-item>

--- a/src/components/ebay-menu/template.marko
+++ b/src/components/ebay-menu/template.marko
@@ -2,7 +2,7 @@
     <ebay-button w-id="button" class=data.buttonClass variant="expand" size=data.size priority=data.priority aria-expanded=String(data.expanded) aria-haspopup="true" aria-label=data.a11yText>
         <span class="expand-btn__cell">
             <!-- Convoluted markup to satisfy both Skin and Marko -->
-            <div if(data.icon) w-preserve-body class="expand-btn__icon">
+            <div if(data.icon) w-preserve-body class="btn__icon">
                 <span if(data.iconTag) w-body=data.iconTag body-only-if(true)/>
             </div>
             <span if(data.text)>${data.text}</span>

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -114,7 +114,7 @@ describe('menu', () => {
     test('renders with icon', context => {
         const input = { icon: 'settings', iconTag: { renderBody: mock.iconRenderBody } };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('div.expand-btn__icon').text()).to.equal('icon');
+        expect($('div.btn__icon').text()).to.equal('icon');
     });
 
     test('renders without toggle icon', context => {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- update menu non-toggle icon class from `expand-btn__icon` -> `btn__icon`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
There isn't an exact pattern that's currently in Skin (there's a button with an icon, but no an expand button with one). But this seems to make sense, because the `expand-btn__icon` class is used to target the toggle for rotation. So now we can avoid that.

The movement issue is not fixed yet, but will be fixed in the next Skin pre-release.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #355 