### PR TITLE
Icon: exclude generated symbols from coverage

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -7,7 +7,8 @@
     "**/mock",
     "demo",
     "**/*.marko.js",
-    "src/common/test-utils"
+    "src/common/test-utils",
+    "src/components/ebay-icon/symbols"
   ],
   "sourceMap": true,
   "instrument": true,


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- excludes `symbols/` from coverage

## Context
<!--- Why did you make these changes, and why in this particular way? -->
These files are generated and don't really need coverage.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Follow up to #358 
