### PR TITLE
Breadcrumbs: Button mode

### DIFF
--- a/src/components/ebay-breadcrumb/README.md
+++ b/src/components/ebay-breadcrumb/README.md
@@ -15,7 +15,6 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `a11y-heading-text` | String | No | heading for breadcrumb which will be clipped
 `a11y-heading-tag` | String | No | heading tag for breadcrumb (default: `"h2"`)
-`hijax` | Boolean | No | Prevent link navigation; for use with ajax
 
 ## ebay-breadcrumb Events
 
@@ -27,4 +26,8 @@ Event | Description | Data
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`href` | String | No | anchor href
+`href` | String | No | anchor href; omitting the href will switch to a button
+
+Notes:
+
+* If you want to have client side or ajax based navigation then you should omit the `href` attribute on each item. This will cause each item to be `<button>` instead of an `<a>`. Alternatively you can manually `preventDefault` the provided `originalEvent` on the `breadcrumb-select` event.

--- a/src/components/ebay-breadcrumb/index.js
+++ b/src/components/ebay-breadcrumb/index.js
@@ -1,31 +1,25 @@
 const markoWidgets = require('marko-widgets');
 const emitAndFire = require('../../common/emit-and-fire');
 const processHtmlAttributes = require('../../common/html-attributes');
-const eventUtils = require('../../common/event-utils');
 const template = require('./template.marko');
 
 function getTemplateData(state, input) {
     const inputItems = input.items || [];
-    const hijax = input.hijax || false;
     const items = inputItems.map((item, index) => {
         let ariaCurrent = null;
-        let role;
-        const href = item.href || null;
+        const { href } = item;
         const current = (inputItems.length - 1 === index);
         let shouldHandleClick = true;
         if (current && !href) {
             ariaCurrent = 'location';
             shouldHandleClick = false;
         }
-        if (hijax && href) {
-            role = 'button';
-        }
+
         return {
             htmlAttributes: processHtmlAttributes(item),
             class: item.class,
             style: item.style,
             renderBody: item.renderBody,
-            role,
             href,
             ariaCurrent,
             shouldHandleClick
@@ -36,24 +30,17 @@ function getTemplateData(state, input) {
         classes: ['breadcrumb', input.class],
         style: input.style,
         items,
-        hijax,
         a11yHeadingText: input.a11yHeadingText || '',
         a11yHeadingTag: input.a11yHeadingTag || 'h2'
     };
 }
 
-function getInitialState({ hijax }) {
-    return { hijax };
-}
-
 function handleClick(originalEvent) {
-    eventUtils.preventDefaultIfHijax(originalEvent, this.state.hijax);
     emitAndFire(this, 'breadcrumb-select', { originalEvent, el: originalEvent.target });
 }
 
 module.exports = markoWidgets.defineComponent({
     template,
     getTemplateData,
-    getInitialState,
     handleClick
 });

--- a/src/components/ebay-breadcrumb/mock/index.js
+++ b/src/components/ebay-breadcrumb/mock/index.js
@@ -1,20 +1,17 @@
-const getItem = (text, href) => {
-    const item = {
-        href: 'https://www.ebay.com/',
-        navSrc: '{"actionKind":"NAVSRC","operationId":"2489527"}',
-        _sp: 'p2489527.m4340.l9751.c1'
-    };
-    const clonedItem = JSON.parse(JSON.stringify(item));
-    clonedItem.renderBody = (stream) => stream.write(text);
-    clonedItem.href = href;
-    return clonedItem;
-};
-const basicItems = [getItem('eBay', 'https://www.ebay.com'),
-    getItem('Auto Parts and Vehicles', 'https://www.ebay.com/b/Auto-Parts-and-Vehicles/6000/bn_1865334'),
+const getItem = (text, href = '#') => ({
+    href,
+    navSrc: '{"actionKind":"NAVSRC","operationId":"2489527"}',
+    _sp: 'p2489527.m4340.l9751.c1',
+    renderBody(stream) {
+        stream.write(text);
+    }
+});
+const basicItems = [getItem('eBay'),
+    getItem('Auto Parts and Vehicles'),
     getItem('Motors Parts & Accessories', null)];
 
 const firstItemMissingHref = [getItem('eBay', null),
-    getItem('Auto Parts and Vehicles', 'https://www.ebay.com/b/Auto-Parts-and-Vehicles/6000/bn_1865334'),
+    getItem('Auto Parts and Vehicles'),
     getItem('Motors Parts & Accessories', null)];
 
 module.exports = {
@@ -22,9 +19,8 @@ module.exports = {
         a11yHeadingText: 'Page navigation',
         items: basicItems
     },
-    hijax: {
-        hijax: true,
-        items: basicItems
+    buttons: {
+        items: basicItems.map(item => Object.assign({}, item, { href: undefined }))
     },
     firstItemMissingHref: {
         a11yHeadingText: 'Page navigation',

--- a/src/components/ebay-breadcrumb/template.marko
+++ b/src/components/ebay-breadcrumb/template.marko
@@ -2,12 +2,11 @@
     <${data.a11yHeadingTag} id="breadcrumb-heading" class="clipped">${data.a11yHeadingText}</>
     <ul>
         <li for(item in data.items)>
-            <a
+            <${item.href ? 'a' : 'button'}
                 class=item.class
                 style=item.style
                 href=item.href
                 aria-current=item.ariaCurrent
-                role=item.role
                 w-body=item.renderBody
                 w-onclick=(item.shouldHandleClick && "handleClick")
                 ${item.htmlAttributes}/>

--- a/src/components/ebay-breadcrumb/test/test.browser.js
+++ b/src/components/ebay-breadcrumb/test/test.browser.js
@@ -12,7 +12,7 @@ describe('given a basic breadcrumb', () => {
     beforeEach(() => {
         widget = renderer.renderSync(mock.basicItems).appendTo(document.body).getWidget();
         firstItem = document.querySelector('nav li a');
-        lastItem = document.querySelector('nav li a:not([href])');
+        lastItem = document.querySelector('nav li button');
     });
     afterEach(() => widget.destroy());
 
@@ -32,7 +32,7 @@ describe('given a basic breadcrumb', () => {
         });
     });
 
-    describe('when a <a> with no href is clicked', () => {
+    describe('when a <button> is clicked', () => {
         let spy;
         beforeEach((done) => {
             spy = sinon.spy();

--- a/src/components/ebay-breadcrumb/test/test.server.js
+++ b/src/components/ebay-breadcrumb/test/test.server.js
@@ -12,10 +12,10 @@ describe('breadcrumb', () => {
         expect($('nav li').length).to.equal(mock.basicItems.items.length);
     });
 
-    test('should set item roles for hijax version', context => {
-        const input = mock.hijax;
+    test('should use buttons when hrefs are missing', context => {
+        const input = mock.buttons;
         const $ = testUtils.getCheerio(context.render(input));
-        expect($('li a[role="button"]').length).to.equal(input.items.length - 1);
+        expect($('li button').length).to.equal(input.items.length);
     });
 
     test('renders <a> without href for missing input href on non-last item', context => {
@@ -25,11 +25,11 @@ describe('breadcrumb', () => {
         expect(li.length).to.equal(mock.firstItemMissingHref.items.length);
     });
 
-    test('renders a tag with no href attribute when href is null on last item', context => {
+    test('renders a button when href is null on last item', context => {
         const $ = testUtils.getCheerio(context.render(mock.basicItems));
         const li = $('nav li');
         expect(li.length).to.equal(mock.basicItems.items.length);
-        const currentElement = $('a', li[li.length - 1]);
+        const currentElement = $('button', li[li.length - 1]);
         expect(currentElement.attr('aria-current')).to.equal('location');
     });
 
@@ -44,6 +44,6 @@ describe('breadcrumb', () => {
 });
 
 describe('breadcrumb-item', () => {
-    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'li a', 'items'));
-    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'li a', 'items'));
+    test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'li > *', 'items'));
+    test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'li > *', 'items'));
 });


### PR DESCRIPTION
## Description
This change coincides with https://github.com/eBay/skin/pull/349 which now allows the breadcrumb styles to contain buttons for items.

If the `href` attribute is omitted on any item it now becomes a button.

This also replaces the `hijax` functionality.

## References
Fixes #371 

Note:
Currently to view this PR you will have to manually link the skin branch mentioned above.