### PR TITLE
Pagination: improve hidden overflow logic

### DIFF
--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -65,6 +65,7 @@ function getTemplateData(state) {
 
 function init() {
     this.pageContainerEl = this.el.querySelector('.pagination__items');
+    this.pageContainerEl.style.flexWrap = 'nowrap';
     this.pageEls = this.pageContainerEl.children;
     this.containerEl = this.el;
     this.previousPageEl = this.el.querySelector('.pagination__previous');
@@ -91,44 +92,40 @@ function refresh() {
     for (let i = 0; i < this.state.items.length; i++) {
         if (this.state.items[i].current) {
             current = i;
-        } else {
-            // remove all hidden attribues to get accurate widths
-            this.pageEls[i].removeAttribute('hidden');
         }
+        this.pageEls[i].removeAttribute('hidden');
     }
+
     const totalPages = this.pageEls.length;
-    const pageNumWidth = this.pageEls[current].offsetWidth + constants.margin;
-    const containerWidth = this.containerEl.offsetWidth - pageNumWidth * 2;
-    const numPagesAllowed = Math.floor((containerWidth) / (pageNumWidth));
-    const adjustedNumPages = Math.min(constants.maxPagesAllowed - 1,
-        Math.max(numPagesAllowed, constants.minPagesRequired));
+    const pageNumWidth = this.pageEls[0].children[0].offsetWidth + constants.margin;
+    const numPagesAllowed = (((this.pageContainerEl.offsetWidth) / pageNumWidth));
+    const adjustedNumPages = Math.floor(Math.min(constants.maxPagesAllowed,
+        Math.max(numPagesAllowed, constants.minPagesRequired)));
 
     let start = 0;
     let end = adjustedNumPages;
-    const rangeLeft = Math.floor(adjustedNumPages * 0.5);
+    let rangeLeft = Math.floor(adjustedNumPages * 0.5);
     const rangeRight = Math.floor(adjustedNumPages * 0.5);
+
+    if (rangeLeft + rangeRight + 1 > adjustedNumPages) {
+        rangeLeft -= 1;
+    }
 
     start = current - rangeLeft;
     end = current + rangeRight;
-    if (end > totalPages) {
-        start -= (end - totalPages);
-    }
 
     if (totalPages < constants.maxPagesAllowed) {
         end = totalPages;
     }
 
-    if (totalPages - current < rangeRight) {
-        start -= (rangeRight - (totalPages - current));
+    if (current + rangeRight >= totalPages) {
+        end = totalPages;
+        start = end - adjustedNumPages;
     }
 
-    if (start < 0) {
-        end -= start;
+    if (start <= 0) {
+        end = adjustedNumPages - 1;
         start = 0;
-    }
-
-    if (end - start < constants.minPagesRequired && end === totalPages && start > 0) {
-        start = end - constants.minPagesRequired;
     }
 
     for (let i = 0; i < totalPages; i++) {

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -352,9 +352,9 @@ describe('given the pagination has the second item selected', () => {
         it('then it shows items 0 through 5', () => testItemVisibility(root, 0, 5));
     });
 
-    describe('when the component is 550px wide', () => {
+    describe('when the component is 540px wide', () => {
         beforeEach((done) => {
-            widget.el.style.width = '550px';
+            widget.el.style.width = '540px';
             testUtils.triggerEvent(window, 'resize');
             setTimeout(done, 20);
         });
@@ -396,9 +396,9 @@ describe('given the pagination has the fifth item selected', () => {
         it('then it shows items 2 through 7', () => testItemVisibility(root, 2, 7));
     });
 
-    describe('when the component is 550px wide', () => {
+    describe('when the component is 540px wide', () => {
         beforeEach((done) => {
-            widget.el.style.width = '550px';
+            widget.el.style.width = '540px';
             testUtils.triggerEvent(window, 'resize');
             setTimeout(done, 20);
         });
@@ -440,9 +440,9 @@ describe('given the pagination has the eighth item selected', () => {
         it('then it shows items 4 through 9', () => testItemVisibility(root, 4, 9));
     });
 
-    describe('when the component is 550px wide', () => {
+    describe('when the component is 540px wide', () => {
         beforeEach((done) => {
-            widget.el.style.width = '550px';
+            widget.el.style.width = '540px';
             testUtils.triggerEvent(window, 'resize');
             setTimeout(done, 20);
         });

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -396,6 +396,17 @@ describe('given the pagination has the fifth item selected', () => {
         it('then it shows items 2 through 7', () => testItemVisibility(root, 2, 7));
     });
 
+    describe('when the component is 440px wide', () => {
+        beforeEach((done) => {
+            widget.el.style.width = '440px';
+            testUtils.triggerEvent(window, 'resize');
+            setTimeout(done, 20);
+        });
+        afterEach(() => widget.destroy());
+
+        it('then it shows items 2 through 8', () => testItemVisibility(root, 2, 8));
+    });
+
     describe('when the component is 540px wide', () => {
         beforeEach((done) => {
             widget.el.style.width = '540px';


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
when using pagination--fluid and selecting a page number near the totalPage number the displayed number of pages would be missing a few items.

This update fixes the problem yet is dependent upon https://github.com/eBay/skin/pull/350 getting merged in and released to ebay/skin

## Context
to fix a bug introduced by my last update that I missed.

## References
fix for https://github.com/eBay/ebayui-core/issues/374
