### PR TITLE
Marketplace config missing from NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "dist/",
     "marko.json",
     "yarn.lock",
-    "*.browser.json"
+    "*.browser.json",
+    "marketplace.json"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Description
Currently the `marketplace.json` is not part of our npm file whitelist which means that the ui-marketplace is not picking it up.