### PR TITLE
Button: add no-text option for expand variant

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -30,6 +30,7 @@
         "@href": "string",
         "@priority": "string",
         "@size": "size",
+        "@no-text": "boolean",
         "@fluid": "boolean",
         "@variant": "string"
     },

--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -12,6 +12,7 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `priority` | String | No | "primary" / "secondary" (default) / "none"
 `size` | String | No | "small" or "large" (default: medium)
+`no-text | Boolean | No | used to adjust padding for "expand" variant without text
 `href` | String | No | for link that looks like a button
 `fluid` | Boolean | No |
 `disabled` | Boolean | Yes |

--- a/src/components/ebay-button/examples/10-small-expand-no-text/template.marko
+++ b/src/components/ebay-button/examples/10-small-expand-no-text/template.marko
@@ -1,0 +1,3 @@
+<ebay-button size="small" variant="expand" no-text>
+    <ebay-icon type="inline" name="chevron-down-bold" class="expand-btn__icon" no-skin-classes/>
+</ebay-button>

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -14,6 +14,7 @@ function getTemplateData(state, input) {
     const href = input.href;
     const priority = input.priority || 'secondary';
     const size = input.size;
+    const noText = input.noText;
     const fluid = input.fluid;
     let variant = input.variant;
     const model = {};
@@ -28,7 +29,9 @@ function getTemplateData(state, input) {
         tag = 'button';
     }
 
-    if (href || variant === 'expand' || variant === 'cta') {
+    const isExpandVariant = variant === 'expand';
+    const isCtaVariant = variant === 'cta';
+    if (href || isExpandVariant || isCtaVariant) {
         mainClass = `${variant}-${mainClass}`;
     }
 
@@ -40,6 +43,10 @@ function getTemplateData(state, input) {
 
     if (size === 'small' || size === 'large') {
         classes.push(`${mainClass}--${size}`);
+    }
+
+    if (isExpandVariant && noText) {
+        classes.push(`${mainClass}--no-text`);
     }
 
     if (fluid) {

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -75,6 +75,12 @@ test('renders expand variant', context => {
     expect($('.expand-btn').length).to.equal(1);
 });
 
+test('renders expand variant with no text', context => {
+    const input = { variant: 'expand', noText: true };
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($('.expand-btn.expand-btn--no-text').length).to.equal(1);
+});
+
 test('renders cta variant', context => {
     const input = { variant: 'cta' };
     const $ = testUtils.getCheerio(context.render(input));

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -133,6 +133,7 @@ function getTemplateData(state) {
         expanded: state.expanded,
         size: state.size,
         priority: state.priority,
+        noText: !state.text && !state.icon,
         buttonClass: state.borderless && 'expand-btn--borderless',
         itemsClass,
         role: !state.isFake ? 'menu' : null,

--- a/src/components/ebay-menu/template.marko
+++ b/src/components/ebay-menu/template.marko
@@ -5,6 +5,7 @@
         variant="expand"
         size=data.size
         priority=data.priority
+        no-text=data.noText
         aria-expanded=String(data.expanded)
         aria-haspopup="true"
         aria-label=data.a11yText

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -108,12 +108,14 @@ describe('menu', () => {
         const input = { text: '' };
         const $ = testUtils.getCheerio(context.render(input));
         expect($(textSelector).length).to.equal(0);
+        expect($('.expand-btn.expand-btn--no-text').length).to.equal(1);
         expect($('svg.expand-btn__icon').length).to.equal(1);
     });
 
     test('renders with icon', context => {
         const input = { icon: 'settings', iconTag: { renderBody: mock.iconRenderBody } };
         const $ = testUtils.getCheerio(context.render(input));
+        expect($('.expand-btn:not(.expand-btn--no-text)').length).to.equal(1);
         expect($('div.btn__icon').text()).to.equal('icon');
     });
 


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- adds `no-text` attribute to `<ebay-button>`
- adds logic for sending `no-text` to <ebay-button>` from `<ebay-menu>`
- updates docs and tests

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This PR is fairly awkward. The Button component takes care of the `expand` variant, but that variant really only makes sense in the context of the Menu. Although it should only be used through the Menu like this, I did update the docs and add an example to show this use case.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #382 
