### PR TITLE
Icon: map DS4 arrow-down to DS6 chevron-down-bold

### DIFF
--- a/scripts/import-svg/index.js
+++ b/scripts/import-svg/index.js
@@ -38,6 +38,13 @@ for (const theme of THEMES) {
     }
 }
 
+// map DS4 icons that should use the markup of a DS6 icon
+const map4To6 = { 'arrow-down': 'chevron-down-bold' };
+Object.keys(map4To6).forEach(ds4Name => {
+    const ds6Name = map4To6[ds4Name];
+    icons.get(ds6Name).ds4 = icons.get(ds4Name).ds4.replace(ds4Name, ds6Name);
+});
+
 for (const [name, themes] of icons) {
     const iconFolder = path.join(outputDir, name);
     const browserJSON = path.join(iconFolder, 'browser.json');

--- a/src/components/ebay-icon/symbols/chevron-down-bold/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-down-bold/browser.json
@@ -1,10 +1,5 @@
 {
-  "dependencies": [
-    {
-      "path": "./missing.js",
-      "if-not-flag": "skin-ds6"
-    }
-  ],
+  "dependencies": [],
   "requireRemap": [
     {
       "from": "./ds6.marko",

--- a/src/components/ebay-icon/symbols/chevron-down-bold/ds4.marko
+++ b/src/components/ebay-icon/symbols/chevron-down-bold/ds4.marko
@@ -1,26 +1,3 @@
-<symbol id="icon-chevron-down-bold">
-    <g fill="#111820" fill-rule="nonzero">
-    <g transform="translate(5.5 4.5)">
-        <circle cx="2.3" cy="6.1" r="1"/>
-        <path d="M1.8 4.7c0-.6 0-1.1.3-1.4.4-.4.9-.5 1.1-.6.3-.2.6-.5.6-.8 0-.3-.2-.8-1.3-.8-1 0-1.4.6-1.4 1.2H.3c0-1.3.8-2 2.2-2C4.6.4 4.7 1.7 4.7 2c0 .4-.2.8-.7 1.1-.5.4-.9.4-1.1.7-.2.2-.2.5-.2 1h-.9z"/>
-    </g>
-    <g transform="translate(1 1)">
-        <circle cx="7" cy=".7" r="1"/>
-        <circle cx="10.2" cy=".7" r="1"/>
-        <circle cx="13.3" cy=".7" r="1"/>
-        <circle cx=".7" cy=".7" r="1"/>
-        <circle cx="3.8" cy=".7" r="1" transform="rotate(90 3.8 .7)"/>
-        <circle cx="7" cy="13.3" r="1" transform="rotate(180 7 13.3)"/>
-        <circle cx="3.8" cy="13.3" r="1" transform="rotate(180 3.8 13.3)"/>
-        <circle cx=".7" cy="13.3" r="1" transform="rotate(180 .7 13.3)"/>
-        <circle cx="13.3" cy="13.3" r="1" transform="rotate(180 13.4 13.3)"/>
-        <circle cx="10.2" cy="13.3" r="1" transform="rotate(-90 10.2 13.3)"/>
-        <circle cx="13.3" cy="7" r="1" transform="rotate(90 13.3 7)"/>
-        <circle cx="13.3" cy="10.2" r="1" transform="rotate(90 13.3 10.2)"/>
-        <circle cx="13.3" cy="3.8" r="1" transform="rotate(180 13.3 3.8)"/>
-        <circle cx=".7" cy="7" r="1" transform="rotate(-90 .7 7)"/>
-        <circle cx=".7" cy="3.8" r="1" transform="rotate(-90 .7 3.8)"/>
-        <circle cx=".7" cy="10.2" r="1"/>
-    </g>
-    </g>
-</symbol>
+<symbol id="icon-chevron-down-bold" viewBox="0 0 24 13">
+        <path d="M11.604 12.921L0 0h23.215l-5.807 6.462z"></path>
+    </symbol>

--- a/src/components/ebay-icon/symbols/chevron-down-bold/missing.js
+++ b/src/components/ebay-icon/symbols/chevron-down-bold/missing.js
@@ -1,1 +1,0 @@
-if (typeof window !== 'undefined') console.error('ds4 icon not found: chevron-down-bold');

--- a/src/components/ebay-icon/symbols/pause/browser.json
+++ b/src/components/ebay-icon/symbols/pause/browser.json
@@ -1,4 +1,5 @@
 {
+  "dependencies": [],
   "requireRemap": [
     {
       "from": "./ds6.marko",

--- a/src/components/ebay-icon/symbols/pause/ds4.marko
+++ b/src/components/ebay-icon/symbols/pause/ds4.marko
@@ -1,1 +1,3 @@
-<symbol id="icon-pause" viewBox="0 0 16 16"><g fill="currentColor" fill-rule="evenodd"><path d="M0 0h6v16H0zM10 0h6v16h-6z"></path></g></symbol>
+<symbol id="icon-pause" viewBox="0 0 16 16">
+        <path d="M0 0h6v16H0zM10 0h6v16h-6z"></path>
+    </symbol>

--- a/src/components/ebay-icon/symbols/pause/ds6.marko
+++ b/src/components/ebay-icon/symbols/pause/ds6.marko
@@ -1,1 +1,3 @@
-<symbol id="icon-pause" viewBox="0 0 16 16"><g fill="currentColor" fill-rule="evenodd"><path d="M0 0h6v16H0zM10 0h6v16h-6z"></path></g></symbol>
+<symbol id="icon-pause" viewBox="0 0 16 16">
+        <path d="M0 0h6v16H0zM10 0h6v16h-6z"></path>
+    </symbol>

--- a/src/components/ebay-icon/symbols/play/browser.json
+++ b/src/components/ebay-icon/symbols/play/browser.json
@@ -1,4 +1,5 @@
 {
+  "dependencies": [],
   "requireRemap": [
     {
       "from": "./ds6.marko",

--- a/src/components/ebay-icon/symbols/play/ds4.marko
+++ b/src/components/ebay-icon/symbols/play/ds4.marko
@@ -1,1 +1,3 @@
-<symbol id="icon-play" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="M16 8L0 16V0z"></path></symbol>
+<symbol id="icon-play" viewBox="0 0 16 16">
+        <path d="M16 8L0 16V0z"></path>
+    </symbol>

--- a/src/components/ebay-icon/symbols/play/ds6.marko
+++ b/src/components/ebay-icon/symbols/play/ds6.marko
@@ -1,1 +1,3 @@
-<symbol id="icon-play" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="M16 8L0 16V0z"></path></symbol>
+<symbol id="icon-play" viewBox="0 0 16 16">
+        <path d="M16 8L0 16V0z"></path>
+    </symbol>


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- modify `import-svg` script to allow icon mapping between DS4/DS6
- re-run `import-svg`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
The Menu component tries to use `chevron-down-bold` for the toggle icon, which doesn't exist in DS4. The DS4 Menu is supposed to use `arrow-down`. Now, when users try to use `chevron-down-bold` in DS4, they'll get the `arrow-down` markup.

Running `import-svg` includes a few other changes that weren't imported before.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #378 

## Screenshots
<!-- Upload screenshots if appropriate. -->

<img width="746" alt="screen shot 2018-08-28 at 9 53 47 am" src="https://user-images.githubusercontent.com/3595986/44738427-b654b600-aaa9-11e8-9259-468b9acfcc97.png">
<img width="734" alt="screen shot 2018-08-28 at 9 53 43 am" src="https://user-images.githubusercontent.com/3595986/44738428-b6ed4c80-aaa9-11e8-934d-d653f952cdbd.png">
