### PR TITLE
389 combobox fixes

### DIFF
--- a/src/common/element-scroll/index.js
+++ b/src/common/element-scroll/index.js
@@ -1,0 +1,24 @@
+module.exports = { scroll, nodeListToArray };
+
+/**
+ * Scrolls the parent element until the child element is in view
+ */
+function scroll(el) {
+    if (!el) {
+        return;
+    }
+
+    const parentEl = el && el.parentElement;
+    const offsetBottom = el.offsetTop + el.offsetHeight;
+    const scrollBottom = parentEl.scrollTop + parentEl.offsetHeight;
+
+    if (el.offsetTop < parentEl.scrollTop) {
+        parentEl.scrollTop = el.offsetTop;
+    } else if (offsetBottom > scrollBottom) {
+        parentEl.scrollTop = offsetBottom - parentEl.offsetHeight;
+    }
+}
+
+function nodeListToArray(nodeList) {
+    return Array.prototype.slice.call(nodeList);
+}

--- a/src/common/element-scroll/index.js
+++ b/src/common/element-scroll/index.js
@@ -1,5 +1,3 @@
-module.exports = { scroll, nodeListToArray };
-
 /**
  * Scrolls the parent element until the child element is in view
  */
@@ -19,6 +17,4 @@ function scroll(el) {
     }
 }
 
-function nodeListToArray(nodeList) {
-    return Array.prototype.slice.call(nodeList);
-}
+module.exports = { scroll };

--- a/src/common/element-scroll/test/test.browser.js
+++ b/src/common/element-scroll/test/test.browser.js
@@ -9,8 +9,8 @@ describe('element-scroll', () => {
         contentDiv.innerHTML += innerDiv;
     }
 
-    const innerEl1 = elementScroll.nodeListToArray(contentDiv.querySelectorAll('.item5'))[0];
-    const innerEl2 = elementScroll.nodeListToArray(contentDiv.querySelectorAll('.item2'))[0];
+    const innerEl1 = contentDiv.querySelectorAll('.item5')[0];
+    const innerEl2 = contentDiv.querySelectorAll('.item2')[0];
 
     before(() => {
         document.body.appendChild(contentDiv);
@@ -23,14 +23,12 @@ describe('element-scroll', () => {
 
     test('scrolls the parent so the child element below the view is visible', () => {
         elementScroll.scroll(innerEl1);
-        expect(
-            contentDiv.scrollTop === ((innerEl1.offsetTop + innerEl1.offsetHeight) - contentDiv.offsetHeight)
-        ).to.equal(true);
+        expect(contentDiv.scrollTop).to.equal((innerEl1.offsetTop + innerEl1.offsetHeight) - contentDiv.offsetHeight);
     });
 
     test('scrolls the parent so the child element above the view is visible', () => {
         contentDiv.scrollTop = innerEl1.offsetTop;
         elementScroll.scroll(innerEl2);
-        expect(contentDiv.scrollTop === innerEl2.offsetTop).to.equal(true);
+        expect(contentDiv.scrollTop).to.equal(innerEl2.offsetTop);
     });
 });

--- a/src/common/element-scroll/test/test.browser.js
+++ b/src/common/element-scroll/test/test.browser.js
@@ -9,8 +9,8 @@ describe('element-scroll', () => {
         contentDiv.innerHTML += innerDiv;
     }
 
-    const innerEl1 = contentDiv.querySelectorAll('.item5')[0];
-    const innerEl2 = contentDiv.querySelectorAll('.item2')[0];
+    const fifthItemEl = contentDiv.querySelectorAll('.item5')[0];
+    const secondItemEl = contentDiv.querySelectorAll('.item2')[0];
 
     before(() => {
         document.body.appendChild(contentDiv);
@@ -22,13 +22,14 @@ describe('element-scroll', () => {
     });
 
     test('scrolls the parent so the child element below the view is visible', () => {
-        elementScroll.scroll(innerEl1);
-        expect(contentDiv.scrollTop).to.equal((innerEl1.offsetTop + innerEl1.offsetHeight) - contentDiv.offsetHeight);
+        elementScroll.scroll(fifthItemEl);
+        expect(contentDiv.scrollTop)
+            .to.equal((fifthItemEl.offsetTop + fifthItemEl.offsetHeight) - contentDiv.offsetHeight);
     });
 
     test('scrolls the parent so the child element above the view is visible', () => {
-        contentDiv.scrollTop = innerEl1.offsetTop;
-        elementScroll.scroll(innerEl2);
-        expect(contentDiv.scrollTop).to.equal(innerEl2.offsetTop);
+        contentDiv.scrollTop = fifthItemEl.offsetTop;
+        elementScroll.scroll(secondItemEl);
+        expect(contentDiv.scrollTop).to.equal(secondItemEl.offsetTop);
     });
 });

--- a/src/common/element-scroll/test/test.browser.js
+++ b/src/common/element-scroll/test/test.browser.js
@@ -1,0 +1,36 @@
+const expect = require('chai').expect;
+const elementScroll = require('../');
+
+describe('element-scroll', () => {
+    const contentDiv = document.createElement('div');
+
+    for (let index = 0; index < 10; index += 1) {
+        const innerDiv = `<div class="item${index}" style="height: 50px">content</div>`;
+        contentDiv.innerHTML += innerDiv;
+    }
+
+    const innerEl1 = elementScroll.nodeListToArray(contentDiv.querySelectorAll('.item5'))[0];
+    const innerEl2 = elementScroll.nodeListToArray(contentDiv.querySelectorAll('.item2'))[0];
+
+    before(() => {
+        document.body.appendChild(contentDiv);
+        contentDiv.setAttribute('style', 'max-height:100px; overflow-y: auto;');
+    });
+
+    after(() => {
+        document.body.removeChild(contentDiv);
+    });
+
+    test('scrolls the parent so the child element below the view is visible', () => {
+        elementScroll.scroll(innerEl1);
+        expect(
+            contentDiv.scrollTop === ((innerEl1.offsetTop + innerEl1.offsetHeight) - contentDiv.offsetHeight)
+        ).to.equal(true);
+    });
+
+    test('scrolls the parent so the child element above the view is visible', () => {
+        contentDiv.scrollTop = innerEl1.offsetTop;
+        elementScroll.scroll(innerEl2);
+        expect(contentDiv.scrollTop === innerEl2.offsetTop).to.equal(true);
+    });
+});

--- a/src/components/ebay-combobox/examples/05-disabled/template.marko
+++ b/src/components/ebay-combobox/examples/05-disabled/template.marko
@@ -1,7 +1,5 @@
-<span style="display: inline-block; max-width: 200px;">
-    <ebay-combobox disabled name="formFieldName">
-        <ebay-combobox-option value="1" text="Option 1"/>
-        <ebay-combobox-option value="2" text="Option 2"/>
-        <ebay-combobox-option value="3" text="Option 3"/>
-    </ebay-combobox>
-</span>
+<ebay-combobox disabled name="formFieldName">
+    <ebay-combobox-option value="1" text="Option 1"/>
+    <ebay-combobox-option value="2" text="Option 2"/>
+    <ebay-combobox-option value="3" text="Option 3"/>
+</ebay-combobox>

--- a/src/components/ebay-combobox/examples/05-disabled/template.marko
+++ b/src/components/ebay-combobox/examples/05-disabled/template.marko
@@ -1,5 +1,7 @@
-<ebay-combobox disabled name="formFieldName">
-    <ebay-combobox-option value="1" text="Option 1"/>
-    <ebay-combobox-option value="2" text="Option 2"/>
-    <ebay-combobox-option value="3" text="Option 3"/>
-</ebay-combobox>
+<span style="display: inline-block; max-width: 200px;">
+    <ebay-combobox disabled name="formFieldName">
+        <ebay-combobox-option value="1" text="Option 1"/>
+        <ebay-combobox-option value="2" text="Option 2"/>
+        <ebay-combobox-option value="3" text="Option 3"/>
+    </ebay-combobox>
+</span>

--- a/src/components/ebay-combobox/examples/07-scrollable/template.marko
+++ b/src/components/ebay-combobox/examples/07-scrollable/template.marko
@@ -1,0 +1,5 @@
+<ebay-combobox name="formFieldName">
+    <for(i from 1 to 100)>
+        <ebay-combobox-option value=i text=`Option ${i}` selected=(i === 25)/>
+    </for>
+</ebay-combobox>

--- a/src/components/ebay-combobox/examples/07-scrollable/template.marko
+++ b/src/components/ebay-combobox/examples/07-scrollable/template.marko
@@ -1,5 +1,3 @@
 <ebay-combobox name="formFieldName">
-    <for(i from 1 to 100)>
-        <ebay-combobox-option value=i text=`Option ${i}` selected=(i === 25)/>
-    </for>
+    <ebay-combobox-option for(i from 1 to 100) value=i text="Option ${i}" selected=(i === 25)/>
 </ebay-combobox>

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -1,6 +1,7 @@
 const markoWidgets = require('marko-widgets');
 const Expander = require('makeup-expander');
 const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
+const elementScroll = require('../../common/element-scroll');
 const emitAndFire = require('../../common/emit-and-fire');
 const eventUtils = require('../../common/event-utils');
 const processHtmlAttributes = require('../../common/html-attributes');
@@ -12,6 +13,7 @@ const comboboxExpanderClass = 'combobox__control';
 const comboboxHostSelector = `.${comboboxExpanderClass} > input`;
 const comboboxBtnClass = 'combobox__control';
 const comboboxOptionSelector = '.combobox__option[role=option]';
+const comboboxSelectedOptionSelector = '.combobox__option[role=option][aria-selected=true]';
 
 function getInitialState(input) {
     const options = (input.options || []).map(option => ({
@@ -101,6 +103,8 @@ function init() {
 }
 
 function handleExpand() {
+    const selectedOptionEl = elementScroll.nodeListToArray(this.el.querySelectorAll(comboboxSelectedOptionSelector))[0];
+    elementScroll.scroll(selectedOptionEl);
     emitAndFire(this, 'combobox-expand');
 }
 
@@ -191,8 +195,9 @@ function traverseOptions(options, currentIndex, distance) {
  */
 function processAfterStateChange(el) {
     const optionValue = el.dataset.optionValue;
-    const optionIndex = Array.prototype.slice.call(el.parentNode.children).indexOf(el);
+    const optionIndex = elementScroll.nodeListToArray(el.parentNode.children).indexOf(el);
     this.setSelectedOption(optionValue);
+    elementScroll.scroll(el);
     emitAndFire(this, 'combobox-change', {
         index: optionIndex,
         selected: [optionValue],

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -103,7 +103,7 @@ function init() {
 }
 
 function handleExpand() {
-    const selectedOptionEl = elementScroll.nodeListToArray(this.el.querySelectorAll(comboboxSelectedOptionSelector))[0];
+    const selectedOptionEl = this.el.querySelectorAll(comboboxSelectedOptionSelector)[0];
     elementScroll.scroll(selectedOptionEl);
     emitAndFire(this, 'combobox-expand');
 }
@@ -195,7 +195,7 @@ function traverseOptions(options, currentIndex, distance) {
  */
 function processAfterStateChange(el) {
     const optionValue = el.dataset.optionValue;
-    const optionIndex = elementScroll.nodeListToArray(el.parentNode.children).indexOf(el);
+    const optionIndex = Array.prototype.slice.call(el.parentNode.children).indexOf(el);
     this.setSelectedOption(optionValue);
     elementScroll.scroll(el);
     emitAndFire(this, 'combobox-change', {

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -103,8 +103,7 @@ function init() {
 }
 
 function handleExpand() {
-    const selectedOptionEl = this.el.querySelectorAll(comboboxSelectedOptionSelector)[0];
-    elementScroll.scroll(selectedOptionEl);
+    elementScroll.scroll(this.el.querySelector(comboboxSelectedOptionSelector));
     emitAndFire(this, 'combobox-expand');
 }
 

--- a/src/components/ebay-menu/examples/14-scrollable/template.marko
+++ b/src/components/ebay-menu/examples/14-scrollable/template.marko
@@ -1,0 +1,7 @@
+<var i=0/>
+<ebay-menu text="eBay Menu" type="radio">
+    <ebay-menu-item for(idx from 1 to 100) checked=(idx === 24)>
+        <% i++ %>
+        item ${i}
+    </ebay-menu-item>
+</ebay-menu>

--- a/src/components/ebay-menu/examples/14-scrollable/template.marko
+++ b/src/components/ebay-menu/examples/14-scrollable/template.marko
@@ -1,7 +1,15 @@
 <var i=0/>
-<ebay-menu text="eBay Menu" type="radio">
+<ebay-menu text="eBay Radio Menu" type="radio">
     <ebay-menu-item for(idx from 1 to 100) checked=(idx === 24)>
         <% i++ %>
         item ${i}
+    </ebay-menu-item>
+</ebay-menu>
+
+<var j=0/>
+<ebay-menu text="eBay Checkbox Menu" type="checkbox" style="margin-left: 8px;">
+    <ebay-menu-item for(idx from 1 to 100) checked=(idx === 24 || idx === 49)>
+        <% j++ %>
+        item ${j}
     </ebay-menu-item>
 </ebay-menu>

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -13,7 +13,7 @@ const mainButtonClass = 'expand-btn';
 const buttonSelector = `.${mainButtonClass}`;
 const contentClass = 'expander__content';
 const contentSelector = `.${contentClass}`;
-const checkedItemSelector = '.menu__item[role=menuitemradio][aria-checked=true]';
+const checkedItemSelector = '.menu__item[role^=menuitem][aria-checked=true]';
 
 function getInitialState(input) {
     const type = input.type;
@@ -294,7 +294,7 @@ function handleButtonEscape() {
 }
 
 function handleExpand() {
-    const selectedOptionEl = elementScroll.nodeListToArray(this.el.querySelectorAll(checkedItemSelector))[0];
+    const selectedOptionEl = this.el.querySelectorAll(checkedItemSelector)[0];
     elementScroll.scroll(selectedOptionEl);
     this.setState('expanded', true);
     emitAndFire(this, 'menu-expand');

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -215,7 +215,9 @@ function processAfterStateChange(itemIndexes) {
         });
     }
 
-    elementScroll.scroll(itemEl);
+    if (this.state.isRadio || this.state.isCheckbox) {
+        elementScroll.scroll(itemEl);
+    }
 
     if (this.state.isCheckbox && itemIndexes.length > 1) {
         // only calling via API can have multiple item indexes
@@ -294,8 +296,7 @@ function handleButtonEscape() {
 }
 
 function handleExpand() {
-    const selectedOptionEl = this.el.querySelectorAll(checkedItemSelector)[0];
-    elementScroll.scroll(selectedOptionEl);
+    elementScroll.scroll(this.el.querySelector(checkedItemSelector));
     this.setState('expanded', true);
     emitAndFire(this, 'menu-expand');
     scrollKeyPreventer.add(this.contentEl);

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -2,6 +2,7 @@ const markoWidgets = require('marko-widgets');
 const Expander = require('makeup-expander');
 const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 const rovingTabindex = require('makeup-roving-tabindex');
+const elementScroll = require('../../common/element-scroll');
 const emitAndFire = require('../../common/emit-and-fire');
 const eventUtils = require('../../common/event-utils');
 const processHtmlAttributes = require('../../common/html-attributes');
@@ -12,6 +13,7 @@ const mainButtonClass = 'expand-btn';
 const buttonSelector = `.${mainButtonClass}`;
 const contentClass = 'expander__content';
 const contentSelector = `.${contentClass}`;
+const checkedItemSelector = '.menu__item[role=menuitemradio][aria-checked=true]';
 
 function getInitialState(input) {
     const type = input.type;
@@ -213,6 +215,8 @@ function processAfterStateChange(itemIndexes) {
         });
     }
 
+    elementScroll.scroll(itemEl);
+
     if (this.state.isCheckbox && itemIndexes.length > 1) {
         // only calling via API can have multiple item indexes
         this.setState('checked', this.getCheckedList());
@@ -290,6 +294,8 @@ function handleButtonEscape() {
 }
 
 function handleExpand() {
+    const selectedOptionEl = elementScroll.nodeListToArray(this.el.querySelectorAll(checkedItemSelector))[0];
+    elementScroll.scroll(selectedOptionEl);
     this.setState('expanded', true);
     emitAndFire(this, 'menu-expand');
     scrollKeyPreventer.add(this.contentEl);


### PR DESCRIPTION
## Description
- add a scroll utility for element scrolling

## Context
When opening a menu or combobox, or navigating using the keyboard within those components, the element chosen should move the element into view.

## References
Fixes #369.
