### PR TITLE
Hotfix for dialog close icon missing;

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   ],
   "devDependencies": {
     "@ebay/browserslist-config": "^1.0.0",
-    "@ebay/skin": "^6.0.0",
+    "@ebay/skin": "^6.0.1",
     "@lasso/marko-taglib": "^1.0.9",
     "async": "^2.6.0",
     "babel-cli": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,9 +93,9 @@
   version "1.0.0"
   resolved "https://registry.npmjs.org/@ebay/browserslist-config/-/browserslist-config-1.0.0.tgz#06328378600156458dacb0278767ff8490f2074c"
 
-"@ebay/skin@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-6.0.0.tgz#7aee8b8b4b34cf79b7c243418e750ea9b127479b"
+"@ebay/skin@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-6.0.1.tgz#aa44bc2094782872cf3cfb8ee3ae70cfbd0f2864"
 
 "@lasso/marko-taglib@^1.0.10", "@lasso/marko-taglib@^1.0.9":
   version "1.0.10"


### PR DESCRIPTION
## Description
- new version of skin for missing dialog close icon

## References
https://github.com/eBay/skin/pull/385

## Screenshots
**Before**
![image 13](https://user-images.githubusercontent.com/105656/45327584-546a6680-b515-11e8-86be-d65a2532a7f7.png)

**After**
![image](https://user-images.githubusercontent.com/105656/45328355-e889fd00-b518-11e8-80f0-4c2a338a2d01.png)
