### PR TITLE
w-preserve-body-if in carousel component has to be true or false

### DIFF
--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -31,7 +31,7 @@
                     style=item.style
                     w-body=item.renderBody
                     aria-hidden=(!item.fullyVisible && 'true')
-                    w-preserve-body-if(config.preserveItems)/>
+                    w-preserve-body-if(!!config.preserveItems)/>
             </for>
         </ul>
 


### PR DESCRIPTION
## Description
Changed `w-preserve-body-if` to false rather than undefined
Fixes https://github.com/eBay/ebayui-core/issues/410

## Context
Currently it was passed as undefined for state changes, but the Marko "if" check tested for an absolute false, not just falsy.

I'm not sure if this is going to cause any other issues with carousel rerendering. So it would be good if @DylanPiercey could review.

Also, I couldn't figure out a clean way to add a test, since I couldn't identify a parent component where I could change the state.

## Screenshots
![screen shot 2018-09-14 at 5 29 20 pm](https://user-images.githubusercontent.com/1562843/45580277-3f0e7880-b844-11e8-910c-9fda504a83ea.png)

