### PR TITLE
Icon: Fix examples in Marko 4 (demo page)

### DIFF
--- a/src/components/ebay-icon/examples/02-inline/template.marko
+++ b/src/components/ebay-icon/examples/02-inline/template.marko
@@ -1,3 +1,8 @@
+/**
+ * Note: Due to limitations in Marko v4, this tag must be within a parent component.
+ * Below we have added an empty class to force this to be the case.
+ */
+class {}
 <ebay-icon type="inline" name="add"/>
 <!-- Note that arrow-left and arrow-right do not appear in markup, but arrow-move does appear. -->
 <ebay-icon type="inline" name="arrow-move" if(data.someFalsyProperty)/>

--- a/src/components/ebay-icon/examples/03-inline-custom-color/template.marko
+++ b/src/components/ebay-icon/examples/03-inline-custom-color/template.marko
@@ -1,3 +1,8 @@
+/**
+ * Note: Due to limitations in Marko v4, this tag must be within a parent component.
+ * Below we have added an empty class to force this to be the case.
+ */
+class {}
 <style>.demo3 { color: blue; }</style>
 <ebay-icon type="inline" name="clear"/>
 <ebay-icon type="inline" name="clear" class="demo3"/>

--- a/src/components/ebay-icon/examples/04-inline-non-decorative/template.marko
+++ b/src/components/ebay-icon/examples/04-inline-non-decorative/template.marko
@@ -1,1 +1,6 @@
+/**
+ * Note: Due to limitations in Marko v4, this tag must be within a parent component.
+ * Below we have added an empty class to force this to be the case.
+ */
+class {}
 <ebay-icon type="inline" name="watch" a11y-text="Item is on watch list"/>


### PR DESCRIPTION
## Description
This ensures that the `ebay-icon` is rendered within a component which is currently required for Marko 4 (similar to in [this pr](https://github.com/eBay/ebayui-core/pull/273)) by adding a `class {}` to examples.

## Context
This does not solve #412, but I discovered it while trying to figure out what's going on there.