### PR TITLE
Icon: Fix rerender in Marko 4

### DIFF
--- a/src/components/ebay-icon/index.js
+++ b/src/components/ebay-icon/index.js
@@ -21,7 +21,6 @@ function init() {
         // We then mark this symbol as `defined` so that no other `ebay-icons` render it.
         defined[symbol.id.slice(5)] = true;
         rootSvg.appendChild(symbol);
-        defs.parentNode.removeChild(defs);
     }
 }
 

--- a/src/components/ebay-icon/template.marko
+++ b/src/components/ebay-icon/template.marko
@@ -5,7 +5,7 @@
 <else-if(data.isInline)>
     <svg w-bind class=data.classes style=data.style ${data.htmlAttributes} ${data.a11yAttributes} focusable="false">
         <if(data.renderDefs && data.themes)>
-            <defs w-id="defs">
+            <defs w-id="defs" w-preserve-body>
                 <%
                     var theme;
 


### PR DESCRIPTION
## Description
Currently the defs for the `ebay-icon` is removed manually when the component initializes. This trips up Marko 4 which is expecting it to be there.

This PR allows Marko to remove the `defs` element instead, and marks the contents of the `defs` element as preserved so that Marko ignores it.

## References
Fixes #412 