### PR TITLE
8 pill component

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -32,7 +32,8 @@
         "@size": "size",
         "@no-text": "boolean",
         "@fluid": "boolean",
-        "@variant": "string"
+        "@variant": "string",
+        "@pill": "boolean"
     },
     "<ebay-carousel>": {
         "renderer": "./src/components/ebay-carousel/index.js",

--- a/src/common/truncate/index.js
+++ b/src/common/truncate/index.js
@@ -1,0 +1,57 @@
+/**
+ * Will truncate text at the specified number of lines.
+ * Aborts if the container contains more than just simple text.
+ *
+ * @param {HTMLElement} el: The root element.
+ * @param {Number} lines: Number of lines to display before truncation. Default: 2
+ */
+
+module.exports = ({ el, lines = 2 }) => {
+    if (el.children.length) {
+        return;
+    }
+
+    // get element text
+    const text = el.textContent;
+
+    // remember original max height
+    const computedStyle = getComputedStyle(el);
+    const maxHeight = computedStyle.getPropertyValue('max-height');
+    el.style.maxHeight = 'none';
+
+    // get height
+    const origHeight = el.clientHeight;
+    const targetHeight = getTargetHeight(el, computedStyle, lines);
+
+    if (origHeight <= targetHeight) {
+        el.textContent = text;
+        el.style.maxHeight = maxHeight;
+        return;
+    }
+
+    let start = 1,
+        length = 0,
+        end = text.length;
+
+    while (start < end) { // Binary search for max length
+        length = Math.ceil((start + end) / 2);
+
+        el.textContent = `${text.slice(0, length) }...`;
+
+        if (el.clientHeight <= targetHeight) {
+            start = length;
+        } else {
+            end = length - 1;
+        }
+    }
+    el.innerHTML = `<span class="clipped">${text}</span><span aria-hidden="true">${text.slice(0, start) }...</span>`;
+    el.style.maxHeight = maxHeight;
+};
+
+function getTargetHeight(el, computedStyle, lines) {
+    el.textContent = 'j';
+    const lineHeight = Math.ceil(parseFloat(computedStyle.lineHeight), 10);
+    const rowHeight = Math.ceil(el.clientHeight);
+    const gapHeight = lineHeight > rowHeight ? (lineHeight - rowHeight) : 0;
+    return gapHeight * (lines - 1) + rowHeight * lines;
+}

--- a/src/common/truncate/test/test.browser.js
+++ b/src/common/truncate/test/test.browser.js
@@ -1,0 +1,45 @@
+const expect = require('chai').expect;
+const truncate = require('../');
+const testText = 'this is very long text that needs to be truncated';
+
+describe('truncate', () => {
+    let styleSheet;
+    let truncateEl;
+
+    beforeEach(() => {
+        truncateEl = document.createElement('div');
+        truncateEl.id = 'truncate-test';
+
+        styleSheet = document.createElement('style');
+        styleSheet.innerHTML = `
+            #truncate-test {
+                max-height: 24px;
+                width: 50px;
+            }
+        `;
+
+        document.head.appendChild(styleSheet);
+        document.body.appendChild(truncateEl);
+    });
+
+    afterEach(() => {
+        document.head.removeChild(styleSheet);
+        document.body.removeChild(truncateEl);
+    });
+
+    it('truncates long text', () => {
+        truncateEl.innerHTML = testText;
+        truncate({ el: truncateEl });
+        const childNodes = truncateEl.childNodes;
+        expect(childNodes.length).to.equal(2);
+        expect(childNodes[1].textContent.length).to.be.below(testText.length);
+        expect(childNodes[0].textContent).to.equal(testText);
+    });
+
+    it('does not truncate complex content', () => {
+        const testHtml = `<b>${testText}</b>`;
+        truncateEl.innerHTML = testHtml;
+        truncate({ el: truncateEl });
+        expect(truncateEl.innerHTML = testHtml);
+    });
+});

--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -6,6 +6,14 @@
 <ebay-button>text</ebay-button>
 ```
 
+```marko
+<ebay-button pill>
+    <span class="btn__cell">
+        <span>Pill text</span>
+    </span>
+</ebay-button>
+```
+
 ## ebay-button Attributes
 
 Name | Type | Stateful | Description

--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -18,6 +18,7 @@ Name | Type | Stateful | Description
 `disabled` | Boolean | Yes |
 `partially-disabled` | Boolean | No
 `variant` | String | No | optional, to alter Skin classes: "expand" / "cta"
+`pill` | Boolean | No | for buttons/links that look like a pill (DS6 only)
 
 ## ebay-button Events
 

--- a/src/components/ebay-button/examples/11-expand/template.marko
+++ b/src/components/ebay-button/examples/11-expand/template.marko
@@ -1,0 +1,6 @@
+<ebay-button variant="expand" priority="primary">
+    <span class="expand-btn__cell">
+        <span>Expand</span>
+        <ebay-icon type="inline" name="chevron-down-bold" class="expand-btn__icon" no-skin-classes/>
+    </span>
+</ebay-button>

--- a/src/components/ebay-button/examples/12-pill-(DS6-only)/template.marko
+++ b/src/components/ebay-button/examples/12-pill-(DS6-only)/template.marko
@@ -1,0 +1,3 @@
+<ebay-button href="#" priority="secondary" pill>Single line</ebay-button>
+<ebay-button href="#" priority="secondary" pill>Lots of text that should be truncated at 2 lines</ebay-button>
+<ebay-button priority="primary" pill>Lots of text that should be truncated at 2 lines</ebay-button>

--- a/src/components/ebay-button/examples/12-pill-(DS6-only)/template.marko
+++ b/src/components/ebay-button/examples/12-pill-(DS6-only)/template.marko
@@ -1,3 +1,15 @@
-<ebay-button href="#" priority="secondary" pill>Single line</ebay-button>
-<ebay-button href="#" priority="secondary" pill>Lots of text that should be truncated at 2 lines</ebay-button>
-<ebay-button priority="primary" pill>Lots of text that should be truncated at 2 lines</ebay-button>
+<ebay-button href="#" priority="secondary" pill>
+    <span class="fake-btn__cell">
+        <span>Single line</span>
+    </span>
+</ebay-button>
+<ebay-button href="#" priority="secondary" pill>
+    <span class="fake-btn__cell">
+        <span>Lots of text that should be truncated at 2 lines</span>
+    </span>
+</ebay-button>
+<ebay-button priority="primary" pill>
+    <span class="btn__cell">
+        <span>Lots of text that should be truncated at 2 lines</span>
+    </span>
+</ebay-button>

--- a/src/components/ebay-button/examples/12-pill-(DS6-only)/template.marko
+++ b/src/components/ebay-button/examples/12-pill-(DS6-only)/template.marko
@@ -3,11 +3,13 @@
         <span>Single line</span>
     </span>
 </ebay-button>
+
 <ebay-button href="#" priority="secondary" pill>
     <span class="fake-btn__cell">
         <span>Lots of text that should be truncated at 2 lines</span>
     </span>
 </ebay-button>
+
 <ebay-button priority="primary" pill>
     <span class="btn__cell">
         <span>Lots of text that should be truncated at 2 lines</span>

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -7,7 +7,8 @@ const template = require('./template.marko');
 
 function getInitialState(input) {
     return {
-        disabled: Boolean(input.disabled)
+        disabled: Boolean(input.disabled),
+        pill: input.pill
     };
 }
 
@@ -68,15 +69,14 @@ function getTemplateData(state, input) {
     model.disabled = state.disabled;
     model.partiallyDisabled = input.partiallyDisabled ? 'true' : null; // for aria-disabled
     model.pillCellClass = pillCellClass;
-    model.renderBody = input.renderBody;
     return model;
 }
 
 function onRender() {
-    this.pill = this.getEl('pill');
-    if (this.pill) {
+    const children = this.el.children;
+    if (this.state.pill && children.length && children[0].children.length) {
         truncate({
-            el: this.pill
+            el: children[0].children[0]
         });
     }
 }

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -22,7 +22,6 @@ function getTemplateData(state, input) {
     const model = {};
     let tag;
     let mainClass = 'btn';
-    let pillCellClass;
 
     if (href) {
         variant = 'fake';
@@ -58,7 +57,6 @@ function getTemplateData(state, input) {
 
     if (input.pill) {
         classes.push(`${mainClass}--pill`);
-        pillCellClass = `${mainClass}__cell`;
     }
 
     model.htmlAttributes = processHtmlAttributes(input);
@@ -68,7 +66,6 @@ function getTemplateData(state, input) {
     model.type = input.type || 'button';
     model.disabled = state.disabled;
     model.partiallyDisabled = input.partiallyDisabled ? 'true' : null; // for aria-disabled
-    model.pillCellClass = pillCellClass;
     return model;
 }
 

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -2,6 +2,7 @@ const markoWidgets = require('marko-widgets');
 const emitAndFire = require('../../common/emit-and-fire');
 const eventUtils = require('../../common/event-utils');
 const processHtmlAttributes = require('../../common/html-attributes');
+const truncate = require('../../common/truncate');
 const template = require('./template.marko');
 
 function getInitialState(input) {
@@ -20,6 +21,7 @@ function getTemplateData(state, input) {
     const model = {};
     let tag;
     let mainClass = 'btn';
+    let pillCellClass;
 
     if (href) {
         variant = 'fake';
@@ -53,6 +55,11 @@ function getTemplateData(state, input) {
         classes.push(`${mainClass}--fluid`);
     }
 
+    if (input.pill) {
+        classes.push(`${mainClass}--pill`);
+        pillCellClass = `${mainClass}__cell`;
+    }
+
     model.htmlAttributes = processHtmlAttributes(input);
     model.classes = classes;
     model.style = input.style;
@@ -60,8 +67,18 @@ function getTemplateData(state, input) {
     model.type = input.type || 'button';
     model.disabled = state.disabled;
     model.partiallyDisabled = input.partiallyDisabled ? 'true' : null; // for aria-disabled
-
+    model.pillCellClass = pillCellClass;
+    model.renderBody = input.renderBody;
     return model;
+}
+
+function onRender() {
+    this.pill = this.getEl('pill');
+    if (this.pill) {
+        truncate({
+            el: this.pill
+        });
+    }
 }
 
 function handleClick(originalEvent) {
@@ -91,5 +108,6 @@ module.exports = markoWidgets.defineComponent({
     getInitialState,
     getTemplateData,
     handleClick,
-    handleKeydown
+    handleKeydown,
+    onRender
 });

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -1,6 +1,5 @@
 <${data.tag}
     w-bind
-    w-body
     w-onclick="handleClick"
     w-onkeydown="handleKeydown"
     type=data.type
@@ -10,4 +9,9 @@
     disabled=data.disabled
     aria-disabled=data.partiallyDisabled
     ${data.htmlAttributes}>
+    <span body-only-if(!data.pillCellClass) class=data.pillCellClass>
+        <span body-only-if(!data.pillCellClass) w-id="pill">
+            <invoke data.renderBody(out) if(data.renderBody) />
+        </span>
+    </span>
 </>

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -1,5 +1,6 @@
 <${data.tag}
     w-bind
+    w-body
     w-onclick="handleClick"
     w-onkeydown="handleKeydown"
     type=data.type
@@ -9,9 +10,4 @@
     disabled=data.disabled
     aria-disabled=data.partiallyDisabled
     ${data.htmlAttributes}>
-    <span body-only-if(!data.pillCellClass) class=data.pillCellClass>
-        <span body-only-if(!data.pillCellClass) w-id="pill">
-            <invoke data.renderBody(out) if(data.renderBody) />
-        </span>
-    </span>
 </>

--- a/src/components/ebay-button/test/test.browser.js
+++ b/src/components/ebay-button/test/test.browser.js
@@ -95,3 +95,22 @@ describe('given button is disabled', () => {
         });
     });
 });
+
+describe('given pill button', () => {
+    let root;
+    const content = 'Lots of text that should be truncated at 2 lines';
+    beforeEach(() => {
+        root = renderAndGetRoot({
+            pill: true,
+            style: 'width: 80px',
+            renderBody: out => out.write(`<span class="btn__cell"><span>${content}</span></span>`)
+        });
+    });
+    afterEach(() => widget.destroy());
+
+    describe('when should be truncated', () => {
+        test('then it is truncated', () => {
+            expect(root.querySelector('*[aria-hidden]').textContent.slice(-3)).to.equal('...');
+        });
+    });
+});

--- a/src/components/ebay-button/test/test.browser.js
+++ b/src/components/ebay-button/test/test.browser.js
@@ -99,11 +99,13 @@ describe('given button is disabled', () => {
 describe('given pill button', () => {
     let root;
     const content = 'Lots of text that should be truncated at 2 lines';
+    const styles = 'style="max-height:36px;white-space: normal"'; // remove this once pill comes from skin
+    const bodyHtml = `<span class="btn__cell"><span ${styles}>${content}</span></span>`;
     beforeEach(() => {
         root = renderAndGetRoot({
             pill: true,
-            style: 'width: 80px',
-            renderBody: out => out.write(`<span class="btn__cell"><span>${content}</span></span>`)
+            style: 'width:80px',
+            renderBody: out => out.write(bodyHtml)
         });
     });
     afterEach(() => widget.destroy());

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -87,5 +87,11 @@ test('renders cta variant', context => {
     expect($('.cta-btn').length).to.equal(1);
 });
 
+test('renders pill version', context => {
+    const input = { pill: true, renderBody: out => out.write('<span class="btn__cell"><span>test</span></span>') };
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($('.btn--pill').length).to.equal(1);
+});
+
 test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, 'button.btn'));
 test('handles custom class and style', context => testUtils.testClassAndStyle(context, 'button.btn'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,31 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.51"
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/core@^7.0.0-rc.1":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.0.0.tgz#0cb0c0fd2e78a0a2bec97698f549ae9ce0b99515"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.0.0"
+    "@babel/helpers" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/template" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    convert-source-map "^1.1.0"
+    debug "^3.1.0"
+    json5 "^0.5.0"
+    lodash "^4.17.10"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz#6c7575ffde761d07485e04baedc0392c6d9e30f6"
@@ -15,6 +40,16 @@
     "@babel/types" "7.0.0-beta.51"
     jsesc "^2.5.1"
     lodash "^4.17.5"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz#1efd58bffa951dc846449e58ce3a1d7f02d393aa"
+  dependencies:
+    "@babel/types" "^7.0.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
@@ -26,17 +61,45 @@
     "@babel/template" "7.0.0-beta.51"
     "@babel/types" "7.0.0-beta.51"
 
+"@babel/helper-function-name@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz#a68cc8d04420ccc663dd258f9cc41b8261efa2d4"
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.0.0"
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-get-function-arity@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz#3281b2d045af95c172ce91b20825d85ea4676411"
   dependencies:
     "@babel/types" "7.0.0-beta.51"
 
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-split-export-declaration@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz#8a6c3f66c4d265352fc077484f9f6e80a51ab978"
   dependencies:
     "@babel/types" "7.0.0-beta.51"
+
+"@babel/helper-split-export-declaration@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helpers@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0.tgz#7213388341eeb07417f44710fd7e1d00acfa6ac0"
+  dependencies:
+    "@babel/template" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
 
 "@babel/highlight@7.0.0-beta.51":
   version "7.0.0-beta.51"
@@ -46,9 +109,21 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
 "@babel/parser@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz#27cec2df409df60af58270ed8f6aa55409ea86f6"
+
+"@babel/parser@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz#697655183394facffb063437ddf52c0277698775"
 
 "@babel/runtime@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -66,6 +141,14 @@
     "@babel/types" "7.0.0-beta.51"
     lodash "^4.17.5"
 
+"@babel/template@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz#c2bc9870405959c89a9c814376a2ecb247838c80"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/types" "^7.0.0"
+
 "@babel/traverse@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz#981daf2cec347a6231d3aa1d9e1803b03aaaa4a8"
@@ -81,12 +164,34 @@
     invariant "^2.2.0"
     lodash "^4.17.5"
 
+"@babel/traverse@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0.tgz#b1fe9b6567fdf3ab542cfad6f3b31f854d799a61"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.0.0"
+    "@babel/helper-function-name" "^7.0.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
 "@babel/types@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz#d802b7b543b5836c778aa691797abf00f3d97ea9"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.5"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
 "@ebay/browserslist-config@^1.0.0":
@@ -97,10 +202,20 @@
   version "6.0.0"
   resolved "https://registry.npmjs.org/@ebay/skin/-/skin-6.0.0.tgz#7aee8b8b4b34cf79b7c243418e750ea9b127479b"
 
-"@lasso/marko-taglib@^1.0.10", "@lasso/marko-taglib@^1.0.9":
+"@lasso/marko-taglib@^1.0.10":
   version "1.0.10"
   resolved "https://registry.npmjs.org/@lasso/marko-taglib/-/marko-taglib-1.0.10.tgz#cc8f61353a88430d2f34f66441f5cf757aa69944"
   dependencies:
+    lasso-resolve-from "^1.2.0"
+    raptor-async "^1.1.3"
+    raptor-logging "^1.1.3"
+    raptor-util "^1.1.2"
+
+"@lasso/marko-taglib@^1.0.9":
+  version "1.0.12"
+  resolved "https://registry.npmjs.org/@lasso/marko-taglib/-/marko-taglib-1.0.12.tgz#4c2a51e9018dbc53a5eb810fc972b3c3f12534a4"
+  dependencies:
+    async "^0.9.2"
     lasso-resolve-from "^1.2.0"
     raptor-async "^1.1.3"
     raptor-logging "^1.1.3"
@@ -124,9 +239,9 @@
     ora "^2.1.0"
     unzip "^0.1.11"
 
-"@marko/test@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/@marko/test/-/test-4.0.1.tgz#3c2bf4ce7c2d8bb1a1afe775a95f8d9f26f399ea"
+"@marko/test@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/@marko/test/-/test-4.0.4.tgz#20a4a5407f3cd1918179e3bd04f4acbea0ff704d"
   dependencies:
     "@lasso/marko-taglib" "^1.0.10"
     async "^2.6.1"
@@ -174,7 +289,7 @@
   version "0.7.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@sinonjs/commons@^1.0.1":
+"@sinonjs/commons@^1.0.2":
   version "1.0.2"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
   dependencies:
@@ -574,7 +689,7 @@ async@1.x, async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^0.9.0:
+async@^0.9.0, async@^0.9.2:
   version "0.9.2"
   resolved "https://registry.npmjs.org/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
@@ -2097,6 +2212,12 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
+convert-source-map@^1.1.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  dependencies:
+    safe-buffer "~5.1.1"
+
 convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
@@ -3425,7 +3546,7 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
-formidable@^1.1.1:
+formidable@^1.2.0:
   version "1.2.1"
   resolved "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
 
@@ -4701,7 +4822,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-"js-tokens@^3.0.0 || ^4.0.0":
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
@@ -4762,7 +4883,7 @@ json-stringify-safe@5.0.x, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json5@^0.5.1:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
@@ -4797,9 +4918,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-just-extend@^1.1.27:
-  version "1.1.27"
-  resolved "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+just-extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz#cee004031eaabf6406da03a7b84e4fe9d78ef288"
 
 karma-chai@^0.1.0:
   version "0.1.0"
@@ -5072,11 +5193,12 @@ lasso@^3.2.0:
     util "^0.11.0"
 
 lasso@^3.2.1:
-  version "3.2.3"
-  resolved "https://registry.npmjs.org/lasso/-/lasso-3.2.3.tgz#417b5149f28fecbd9d1e37638dcb49c63db6b9a1"
+  version "3.2.6"
+  resolved "https://registry.npmjs.org/lasso/-/lasso-3.2.6.tgz#da4bb9074bb5ca7bdd1305ec415776a55bdb60b1"
   dependencies:
     app-root-dir "^1.0.2"
     assert "^1.4.1"
+    babel-code-frame "^6.26.0"
     browser-refresh-client "^1.1.4"
     buffer "^5.1.0"
     clean-css "^4.1.11"
@@ -5318,9 +5440,13 @@ lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
-lolex@^2.3.2, lolex@^2.7.1:
+lolex@^2.3.2:
   version "2.7.1"
   resolved "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz#e40a8c4d1f14b536aa03e42a537c7adbaf0c20be"
+
+lolex@^2.7.2:
+  version "2.7.4"
+  resolved "https://registry.npmjs.org/lolex/-/lolex-2.7.4.tgz#6514de2c3291e9d6f09d49ddce4a95f7d4d5a93f"
 
 longest-streak@^2.0.1:
   version "2.0.2"
@@ -5477,12 +5603,12 @@ markdown-table@^1.1.0:
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
 marko-cli@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-4.0.1.tgz#d261c97a7035da1b1a2c5ad513daa7384ae5bd17"
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-4.0.4.tgz#30b9e0cf005eee86131430c699b3c12fdb28fe56"
   dependencies:
     "@marko/compile" "^3.2.0"
     "@marko/create" "^3.1.6"
-    "@marko/test" "^4.0.1"
+    "@marko/test" "^4.0.4"
     app-root-dir "^1.0.2"
     argly "^1.2.0"
     babel-runtime "^6.26.0"
@@ -5493,8 +5619,8 @@ marko-cli@^4.0.1:
     update-notifier "^2.5.0"
 
 marko-prettyprint@^1.4.1:
-  version "1.4.2"
-  resolved "https://registry.npmjs.org/marko-prettyprint/-/marko-prettyprint-1.4.2.tgz#1d87d6ba0c9668670a93b01605c13d789dec359f"
+  version "1.4.3"
+  resolved "https://registry.npmjs.org/marko-prettyprint/-/marko-prettyprint-1.4.3.tgz#892f0e1d3bbebe3d1914327b6f06c2091696e90a"
   dependencies:
     argly "^1.2.0"
     cssbeautify "^0.3.1"
@@ -5691,7 +5817,7 @@ merge2@^1.2.1:
   version "1.2.2"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz#03212e3da8d86c4d8523cebd6318193414f94e34"
 
-methods@^1.1.1, methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -5957,12 +6083,12 @@ next-tick@1:
   version "1.0.0"
   resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
-nise@^1.4.2:
-  version "1.4.3"
-  resolved "https://registry.npmjs.org/nise/-/nise-1.4.3.tgz#d1996e8d15256ceff1a0a1596e0c72bff370e37c"
+nise@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.npmjs.org/nise/-/nise-1.4.4.tgz#b8d9dd35334c99e514b75e46fcc38e358caecdd0"
   dependencies:
     "@sinonjs/formatio" "^2.0.0"
-    just-extend "^1.1.27"
+    just-extend "^3.0.0"
     lolex "^2.3.2"
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
@@ -6616,6 +6742,10 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
+pify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/pify/-/pify-4.0.0.tgz#db04c982b632fd0df9090d14aaf1c8413cadb695"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -6640,11 +6770,19 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-postcss-html@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/postcss-html/-/postcss-html-0.31.0.tgz#ea6ae2e95df60a03032e9ab5aba72143d8ca0325"
+postcss-html@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.npmjs.org/postcss-html/-/postcss-html-0.33.0.tgz#8ab6067d7a8a234e1937920b38760e3be1dca070"
   dependencies:
     htmlparser2 "^3.9.2"
+
+postcss-jsx@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.33.0.tgz#433f8aadd6f3b0ee403a62b441bca8db9c87471c"
+  dependencies:
+    "@babel/core" "^7.0.0-rc.1"
+  optionalDependencies:
+    postcss-styled ">=0.33.0"
 
 postcss-less@^2.0.0:
   version "2.0.0"
@@ -6652,9 +6790,9 @@ postcss-less@^2.0.0:
   dependencies:
     postcss "^5.2.16"
 
-postcss-markdown@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.31.0.tgz#e4c699ad34b14a29ad5d47132bb1b3100b60ef75"
+postcss-markdown@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.npmjs.org/postcss-markdown/-/postcss-markdown-0.33.0.tgz#2d0462742ee108c9d6020780184b499630b8b33a"
   dependencies:
     remark "^9.0.0"
     unist-util-find-all-after "^1.0.2"
@@ -6703,13 +6841,13 @@ postcss-selector-parser@^3.1.0:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-styled@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.31.0.tgz#ab532a2b3c469dfcca306a7623c4d4a98bb077d5"
+postcss-styled@>=0.33.0, postcss-styled@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.33.0.tgz#69be377584105a582fda7e4f76888e5b97eed737"
 
-postcss-syntax@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.31.0.tgz#13d955c705d339595d10a19efa4a1bee82dfb78f"
+postcss-syntax@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.33.0.tgz#59c0c678d2f9ecefa84c6ce9ef46fc805c54ab3a"
 
 postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
@@ -6732,7 +6870,7 @@ postcss@^5.2.16:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.14, postcss@^6.0.8:
+postcss@^6.0.8:
   version "6.0.23"
   resolved "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   dependencies:
@@ -7499,7 +7637,7 @@ resolve@1.1.7, resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.4, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.4, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -7765,17 +7903,17 @@ sinon@^1.17.6:
     util ">=0.10.3 <1"
 
 sinon@^6.1.3:
-  version "6.1.5"
-  resolved "https://registry.npmjs.org/sinon/-/sinon-6.1.5.tgz#41451502d43cd5ffb9d051fbf507952400e81d09"
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/sinon/-/sinon-6.2.0.tgz#ec95af3a88aeb451f0275f14213e6e9f066879e2"
   dependencies:
-    "@sinonjs/commons" "^1.0.1"
+    "@sinonjs/commons" "^1.0.2"
     "@sinonjs/formatio" "^2.0.0"
     "@sinonjs/samsam" "^2.0.0"
     diff "^3.5.0"
     lodash.get "^4.4.2"
-    lolex "^2.7.1"
-    nise "^1.4.2"
-    supports-color "^5.4.0"
+    lolex "^2.7.2"
+    nise "^1.4.4"
+    supports-color "^5.5.0"
     type-detect "^4.0.8"
 
 slack-node@~0.2.0:
@@ -8245,8 +8383,8 @@ style-search@^0.1.0:
   resolved "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
 
 stylelint@^9.3.0:
-  version "9.4.0"
-  resolved "https://registry.npmjs.org/stylelint/-/stylelint-9.4.0.tgz#2f2b82ae9db53a06735ae0724f41b134fdb84a10"
+  version "9.5.0"
+  resolved "https://registry.npmjs.org/stylelint/-/stylelint-9.5.0.tgz#f7afb45342abc4acf28a8da8a48373e9f79c1fb4"
   dependencies:
     autoprefixer "^9.0.0"
     balanced-match "^1.0.0"
@@ -8269,11 +8407,12 @@ stylelint@^9.3.0:
     meow "^5.0.0"
     micromatch "^2.3.11"
     normalize-selector "^0.2.0"
-    pify "^3.0.0"
+    pify "^4.0.0"
     postcss "^7.0.0"
-    postcss-html "^0.31.0"
+    postcss-html "^0.33.0"
+    postcss-jsx "^0.33.0"
     postcss-less "^2.0.0"
-    postcss-markdown "^0.31.0"
+    postcss-markdown "^0.33.0"
     postcss-media-query-parser "^0.2.3"
     postcss-reporter "^5.0.0"
     postcss-resolve-nested-selector "^0.1.1"
@@ -8281,15 +8420,15 @@ stylelint@^9.3.0:
     postcss-sass "^0.3.0"
     postcss-scss "^2.0.0"
     postcss-selector-parser "^3.1.0"
-    postcss-styled "^0.31.0"
-    postcss-syntax "^0.31.0"
+    postcss-styled "^0.33.0"
+    postcss-syntax "^0.33.0"
     postcss-value-parser "^3.3.0"
     resolve-from "^4.0.0"
     signal-exit "^3.0.2"
     specificity "^0.4.0"
     string-width "^2.1.0"
     style-search "^0.1.0"
-    sugarss "^1.0.0"
+    sugarss "^2.0.0"
     svg-tags "^1.0.0"
     table "^4.0.1"
 
@@ -8299,33 +8438,33 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-sugarss@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz#be826d9003e0f247735f92365dc3fd7f1bae9e44"
+sugarss@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz#ddd76e0124b297d40bf3cca31c8b22ecb43bc61d"
   dependencies:
-    postcss "^6.0.14"
+    postcss "^7.0.2"
 
-superagent@3.8.2:
-  version "3.8.2"
-  resolved "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
+superagent@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
   dependencies:
     component-emitter "^1.2.0"
     cookiejar "^2.1.0"
     debug "^3.1.0"
     extend "^3.0.0"
     form-data "^2.3.1"
-    formidable "^1.1.1"
+    formidable "^1.2.0"
     methods "^1.1.1"
     mime "^1.4.1"
     qs "^6.5.1"
-    readable-stream "^2.0.5"
+    readable-stream "^2.3.5"
 
 supertest@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/supertest/-/supertest-3.1.0.tgz#f9ebaf488e60f2176021ec580bdd23ad269e7bc6"
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/supertest/-/supertest-3.2.0.tgz#9addd40096135f4fb8f032dd7c3fe3789604aa7a"
   dependencies:
-    methods "~1.1.2"
-    superagent "3.8.2"
+    methods "^1.1.2"
+    superagent "^3.8.3"
 
 supports-color@5.4.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
@@ -8342,6 +8481,12 @@ supports-color@^3.1.0, supports-color@^3.1.2, supports-color@^3.2.3:
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+supports-color@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  dependencies:
+    has-flag "^3.0.0"
 
 supports-color@~5.0.0:
   version "5.0.1"


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
Add pill support for button component.
Add truncate utility. 
Add expand example that was missing.

## Context
I tried to add the pill support in a way that the user didn't have to add the inner content.  I wanted them to create it like:
```
<ebay-button href="#" priority="secondary" pill>Single line</ebay-button>
```

Instead I ended up with:
```
<ebay-button href="#" priority="secondary" pill>
    <span class="fake-btn__cell">
        <span>Single line</span>
    </span>
</ebay-button>
```

I did this because I ran into a problem when button content was dynamically updated. The text content didn't get updated. I can give more details if needed.

This seems to be the current expectations though.  The expand button requires the user to create it as:
```
<ebay-button variant="expand" priority="primary">
    <span class="expand-btn__cell">
        <span>Expand</span>
        <ebay-icon type="inline" name="chevron-down-bold" class="expand-btn__icon" no-skin-classes/>
    </span>
</ebay-button>
```

I think we should eventually see if we can simplify these cases for the users.

### A11y
The truncated button results in the following HTML structure:
```
<span class="fake-btn__cell">
    <span>
        <span class="clipped">Lots of text that should be truncated at 2 lines</span>
        <span aria-hidden="true">Lots of text that should be trunca...</span>
    </span>
</span>
```


## References
https://github.com/eBay/skin/pull/379

## Screenshots
![screen shot 2018-09-20 at 1 50 52 pm](https://user-images.githubusercontent.com/1562843/45846561-f1c75680-bcdc-11e8-9e15-fbbe0c51fa3d.png)

