### PR TITLE
Textbox: add basic native events

### DIFF
--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -15,3 +15,12 @@ Name | Type | Stateful | Description
 `fluid` | Boolean | No |
 `multiline` | Boolean | No | renders a multi-line texbox if true
 `invalid` | Boolean | No | indicates a field-level error with red border if true
+
+## ebay-textbox Events
+
+Event | Data | Description
+--- | --- | ---
+`textbox-change` | `{ originalEvent, value }` |
+`textbox-input` | `{ originalEvent, value }` |
+`textbox-focus` | `{ originalEvent, value }` |
+`textbox-blur` | `{ originalEvent, value }` |

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -1,4 +1,5 @@
 const markoWidgets = require('marko-widgets');
+const emitAndFire = require('../../common/emit-and-fire');
 const processHtmlAttributes = require('../../common/html-attributes');
 const template = require('./template.marko');
 
@@ -22,8 +23,22 @@ function getTemplateData(state) {
     return state;
 }
 
+function handleEvent(originalEvent, eventName) {
+    emitAndFire(this, `textbox-${eventName}`, { originalEvent, value: originalEvent.target.value });
+}
+
+const handleChange = function(originalEvent) { this.handleEvent(originalEvent, 'change'); };
+const handleInput = function(originalEvent) { this.handleEvent(originalEvent, 'input'); };
+const handleFocus = function(originalEvent) { this.handleEvent(originalEvent, 'focus'); };
+const handleBlur = function(originalEvent) { this.handleEvent(originalEvent, 'blur'); };
+
 module.exports = markoWidgets.defineComponent({
     template,
     getInitialState,
-    getTemplateData
+    getTemplateData,
+    handleEvent,
+    handleChange,
+    handleInput,
+    handleFocus,
+    handleBlur
 });

--- a/src/components/ebay-textbox/template.marko
+++ b/src/components/ebay-textbox/template.marko
@@ -3,5 +3,9 @@
     class=data.classes
     type="text"
     aria-invalid=data.invalid
-     ${data.htmlAttributes} />
+    w-onchange="handleChange"
+    w-oninput="handleInput"
+    w-onfocus="handleFocus"
+    w-onblur="handleBlur"
+    ${data.htmlAttributes} />
 </>

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -1,0 +1,35 @@
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const testUtils = require('../../../common/test-utils/browser');
+const renderer = require('../');
+
+let widget;
+
+describe('given an input textbox', () => {
+    let root;
+    let input;
+    beforeEach(() => {
+        widget = renderer.renderSync({ '*': { value: 'val' } }).appendTo(document.body).getWidget();
+        root = document.querySelector('.textbox');
+        input = root.querySelector('input');
+    });
+    afterEach(() => widget.destroy());
+
+    ['change', 'input', 'focus', 'blur'].forEach(eventName => {
+        describe(`when native event is fired: ${eventName}`, () => {
+            let spy;
+            beforeEach(() => {
+                spy = sinon.spy();
+                widget.on(`textbox-${eventName}`, spy);
+                testUtils.triggerEvent(input, eventName);
+            });
+
+            test('then it emits the event', () => {
+                expect(spy.calledOnce).to.equal(true);
+                const eventData = spy.getCall(0).args[0];
+                expect(eventData.value).to.equal('val');
+                testUtils.testOriginalEvent(spy);
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- add `change` `input` `focus` `blur`
- update docs and tests

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This is not the full list of native DOM events that could potentially need forwarding, but this should hold us over until we decide if we want to handle _all_ events.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fix #427 