### PR TITLE
Ensure marko treats nested transformed tags as components.

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -1,7 +1,6 @@
 {
     "<ebay-breadcrumb>": {
         "renderer": "./src/components/ebay-breadcrumb/index.js",
-        "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
@@ -17,7 +16,9 @@
             "@href": "string"
         }
     },
-    "<ebay-breadcrumb-item>": {},
+    "<ebay-breadcrumb-item>": {
+      "transformer": "./src/common/transformer/index.js"
+    },
     "<ebay-button>": {
         "renderer": "./src/components/ebay-button/index.js",
         "@*": "expression",
@@ -36,7 +37,6 @@
     },
     "<ebay-carousel>": {
         "renderer": "./src/components/ebay-carousel/index.js",
-        "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
@@ -64,7 +64,9 @@
             "@style": "string"
         }
     },
-    "<ebay-carousel-item>": {},
+    "<ebay-carousel-item>": {
+      "transformer": "./src/common/transformer/index.js"
+    },
     "<ebay-checkbox>": {
         "renderer": "./src/components/ebay-checkbox/index.js",
         "@*": "expression",
@@ -75,7 +77,6 @@
     },
     "<ebay-combobox>": {
         "renderer": "./src/components/ebay-combobox/index.js",
-        "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
@@ -94,7 +95,9 @@
             "@selected": "boolean"
         }
     },
-    "<ebay-combobox-option>": {},
+    "<ebay-combobox-option>": {
+      "transformer": "./src/common/transformer/index.js"
+    },
     "<ebay-dialog>": {
         "renderer": "./src/components/ebay-dialog/index.js",
         "@*": "expression",
@@ -149,7 +152,9 @@
             "@current": "boolean"
         }
     },
-    "<ebay-menu-item>": {},
+    "<ebay-menu-item>": {
+      "transformer": "./src/common/transformer/index.js"
+    },
     "<ebay-notice>": {
         "renderer": "./src/components/ebay-notice/index.js",
         "@*": "expression",
@@ -166,7 +171,6 @@
     },
     "<ebay-pagination>": {
         "renderer": "./src/components/ebay-pagination/index.js",
-        "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
@@ -187,7 +191,9 @@
             "@role": "string"
         }
     },
-    "<ebay-pagination-item>": {},
+    "<ebay-pagination-item>": {
+      "transformer": "./src/common/transformer/index.js"
+    },
     "<ebay-radio>": {
         "renderer": "./src/components/ebay-radio/index.js",
         "@*": "expression",
@@ -198,7 +204,6 @@
     },
     "<ebay-select>": {
         "renderer": "./src/components/ebay-select/index.js",
-        "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
@@ -216,7 +221,9 @@
             "@selected": "boolean"
         }
     },
-    "<ebay-select-option>": {},
+    "<ebay-select-option>": {
+      "transformer": "./src/common/transformer/index.js"
+    },
     "<ebay-switch>": {
         "renderer": "./src/components/ebay-switch/index.js",
         "@*": "expression",
@@ -227,7 +234,6 @@
     },
     "<ebay-tab>": {
         "renderer": "./src/components/ebay-tab/index.js",
-        "transformer": "./src/common/transformer/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
         "@class": "string",
@@ -248,8 +254,12 @@
             "@style": "string"
         }
     },
-    "<ebay-tab-heading>": {},
-    "<ebay-tab-panel>": {},
+    "<ebay-tab-heading>": {
+      "transformer": "./src/common/transformer/index.js"
+    },
+    "<ebay-tab-panel>": {
+      "transformer": "./src/common/transformer/index.js"
+    },
     "<ebay-textbox>": {
         "renderer": "./src/components/ebay-textbox/index.js",
         "@*": "expression",
@@ -260,4 +270,5 @@
         "@fluid": "boolean",
         "@multiline": "boolean"
     }
-}
+  }
+  

--- a/src/common/transformer/index.js
+++ b/src/common/transformer/index.js
@@ -7,26 +7,12 @@
  * @param {Object} context
  */
 function transform(el, context) {
-    const parentTag = el.tagName;
-
-    // walk the tree
-    const walker = context.createWalker({
-        enter(node) {
-            const childTag = node.tagName;
-            // find the matching tag based on the child tag name of
-            // the children matching the given tagName
-            if (node.type === 'HtmlElement' && node.tagName.indexOf(`${parentTag}-`) === 0) {
-                const outputTag = `${parentTag}:${childTag.slice(parentTag.length + 1)}`;
-                const nestedTag = context.createNodeForEl(outputTag, node.getAttributes());
-                nestedTag.body = node.body;
-                node.replaceWith(nestedTag);
-
-                walker.skip();
-            }
-        }
-    });
-
-    walker.walk(el);
+    const replacement = context.createNodeForEl(
+        el.tagName.replace(/^(ebay-[^-]+)-/, '$1:'),
+        el.getAttributes()
+    );
+    replacement.body = el.body;
+    el.replaceWith(replacement);
 }
 
 module.exports = transform;

--- a/src/common/transformer/test/test.server.js
+++ b/src/common/transformer/test/test.server.js
@@ -4,15 +4,8 @@ const testUtils = require('../../test-utils/server');
 
 function getTagString(rootTag, nestedTag) {
     return {
-        'before': `<${rootTag}><${rootTag}-${nestedTag}/></${rootTag}>`,
-        'after': `<${rootTag}><${rootTag}:${nestedTag}/></${rootTag}>`
-    };
-}
-
-function getNestedTagString(rootTag, nestedTag) {
-    return {
-        'before': `<${rootTag}><if(true)><${rootTag}-${nestedTag}/></if></${rootTag}>`,
-        'after': `<${rootTag}><if(true)><${rootTag}:${nestedTag}/></if></${rootTag}>`
+        'before': `<${rootTag}-${nestedTag}/>`,
+        'after': `<${rootTag}:${nestedTag}/>`
     };
 }
 
@@ -25,23 +18,6 @@ describe('when the ebay-combobox-option tag is transformed', () => {
         const nestedTag = 'option';
         const templatePath = `../../../components/${rootTag}/template.marko`;
         tagString = getTagString(rootTag, nestedTag);
-        outputTemplate = testUtils.getTransformedTemplate(transformer, tagString.before, templatePath);
-    });
-
-    test('transforms the body contents of a listbox', () => {
-        expect(outputTemplate).to.deep.equal(tagString.after);
-    });
-});
-
-describe('when the ebay-combobox-option tag is nested and is transformed', () => {
-    let tagString;
-    let outputTemplate;
-
-    beforeEach(() => {
-        const rootTag = 'ebay-combobox';
-        const nestedTag = 'option';
-        const templatePath = `../../../components/${rootTag}/template.marko`;
-        tagString = getNestedTagString(rootTag, nestedTag);
         outputTemplate = testUtils.getTransformedTemplate(transformer, tagString.before, templatePath);
     });
 

--- a/src/components/ebay-menu/transformer.js
+++ b/src/components/ebay-menu/transformer.js
@@ -1,8 +1,5 @@
-const commonTransformer = require('../../common/transformer');
-
 // Transforms an `icon` attribute into an `<ebay-menu:icon>` tag
 function transform(el, context) {
-    commonTransformer(el, context);
     const builder = context.builder;
     const iconAttribute = el.getAttribute('icon');
     const iconName = iconAttribute && iconAttribute.value.value;


### PR DESCRIPTION
## Description
This change adds a `renderer` for each of the nested elements in the `marko.json` which forces them to be treated at a component. Previously they were treated as elements and subtle differences between the compilation of the two was causing these not to be keyed properly in Marko 4 when inside of a for loop.