### PR TITLE
Build: exclude compiled marko files from lintspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "yarn lint:less && yarn lint:js && yarn lint:whitespace",
     "lint:less": "stylelint '**/**.less'",
     "lint:js": "eslint .",
-    "lint:whitespace": "lintspaces *.md src/**/*.md src/**/*.marko src/**/*.js src/**/*.less --newline --maxnewlines 1 --trailingspaces --spaces 4",
+    "lint:whitespace": "lintspaces *.md src/**/*.md src/**/*.marko 'src/**/!(*.marko).js' src/**/*.less --newline --maxnewlines 1 --trailingspaces --spaces 4",
     "build": "yarn lint && yarn build:v3 && yarn build:v4 && yarn clean && yarn installMarkoV3",
     "build:ci": "yarn lint && yarn test && mocha integration && yarn build:v4",
     "build:v3": "yarn installMarkoV3 && yarn clean:integration && yarn test && mocha integration",


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- exclude `*.marko.js` files from `lint:whitespace`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Will help avoid issues like:
```sh
File: ebayui-core/src/components/ebay-icon/template.marko.js
Line: 70 Unexpected trailing spaces found. [warning]
Line: 79 Unexpected trailing spaces found. [warning]
```