### PR TITLE
Carousel: Sizing & Native scroll animation

### DIFF
--- a/src/common/test-utils/browser.js
+++ b/src/common/test-utils/browser.js
@@ -39,9 +39,13 @@ function simulateScroll(el, to, cb) {
             if (++frame > frames) {
                 triggerEvent(el, 'touchend');
                 el.scrollLeft = to;
-                // Allow two frames for the on scroll to finish.
+                // Allow two frames and a timeout for the on scroll to finish.
                 if (cb) {
-                    waitFrames(2, cb);
+                    requestAnimationFrame(() => {
+                        setTimeout(() => {
+                            requestAnimationFrame(cb);
+                        }, 64);
+                    });
                 }
 
                 return;

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -88,7 +88,7 @@ function getTemplateData(state) {
 
     items.forEach((item, i) => {
         const { style, transform } = item;
-        const marginRight = i !== items.length - 1 && `${gap}px`;
+        const marginRight = i !== (items.length - 1) && `${gap}px`;
 
         // Account for users providing a style string or object for each item.
         if (typeof style === 'string') {

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -82,8 +82,6 @@ function getTemplateData(state) {
         a11yStatusText = state.a11yStatusText
             .replace('{currentSlide}', slide + 1)
             .replace('{totalSlides}', totalSlides);
-    } else {
-        itemWidth = 'auto';
     }
 
     items.forEach((item, i) => {

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -88,7 +88,7 @@ function getTemplateData(state) {
 
     items.forEach((item, i) => {
         const { style, transform } = item;
-        const marginRight = i !== items.length && `${gap}px`;
+        const marginRight = i !== items.length - 1 && `${gap}px`;
 
         // Account for users providing a style string or object for each item.
         if (typeof style === 'string') {
@@ -96,7 +96,7 @@ function getTemplateData(state) {
             if (transform) item.style += `transform:${transform}`;
         } else {
             item.style = Object.assign({}, style, {
-                'flex-basis': itemWidth,
+                'width': itemWidth,
                 'margin-right': marginRight,
                 transform
             });

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -27,7 +27,6 @@
 
         > li {
             display: inline-block;
-            flex-grow: 0;
             flex-shrink: 0;
             list-style: none;
         }

--- a/src/components/ebay-carousel/utils/on-scroll-end/index.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/index.js
@@ -10,6 +10,7 @@
  */
 module.exports = function onScrollEnd(el, fn) {
     let frame;
+    let timeout;
     let stage = 0;
     el.addEventListener('touchmove', handleTouchMove);
 
@@ -40,17 +41,19 @@ module.exports = function onScrollEnd(el, fn) {
     // Finally after the touch end we poll the scroll state every animation frame
     // to determine when inertial scrolling has stopped.
     function checkScrollEnded(lastOffset) {
-        frame = requestAnimationFrame(() => {
-            const newOffset = el.scrollLeft;
-            if (lastOffset !== newOffset) {
-                checkScrollEnded(newOffset);
-            } else {
-                cancelTouchStart();
-                fn(newOffset);
-                stage = 0;
-                el.addEventListener('touchmove', handleTouchMove);
-            }
-        });
+        timeout = setTimeout(() => {
+            frame = requestAnimationFrame(() => {
+                const newOffset = el.scrollLeft;
+                if (lastOffset !== newOffset) {
+                    checkScrollEnded(newOffset);
+                } else {
+                    cancelTouchStart();
+                    fn(newOffset);
+                    stage = 0;
+                    el.addEventListener('touchmove', handleTouchMove);
+                }
+            });
+        }, 64);
     }
 
     function cancelTouchMove() {
@@ -67,6 +70,7 @@ module.exports = function onScrollEnd(el, fn) {
 
     function cancel() {
         cancelAnimationFrame(frame);
+        clearTimeout(timeout);
 
         switch (stage) {
             case 0: cancelTouchMove(); break;


### PR DESCRIPTION
## Description
If desired I can separate these out into two PR's.

1. switched to using `width` instead of `flex-basis` to size `carousel-items`. This resolves #431 with no apparent change in appearance.

2. added an additional timeout to the `onScrollEnd` handler. Chrome doesn't seem to be working properly with the previous 1 animation frame polling, not sure if this is something that has changed recently but causes the scroll animation to start too early.

# Details

For the timeout change I just noticed while fixing #431 that this was happening. This could be what is causing #432 and I will confirm with @scttdavs.

## References
fixes #431