### PR TITLE
Carousel: Switch from flex-basis to width

### DIFF
--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -82,8 +82,6 @@ function getTemplateData(state) {
         a11yStatusText = state.a11yStatusText
             .replace('{currentSlide}', slide + 1)
             .replace('{totalSlides}', totalSlides);
-    } else {
-        itemWidth = 'auto';
     }
 
     items.forEach((item, i) => {
@@ -96,7 +94,7 @@ function getTemplateData(state) {
             if (transform) item.style += `transform:${transform}`;
         } else {
             item.style = Object.assign({}, style, {
-                'flex-basis': itemWidth,
+                'width': itemWidth,
                 'margin-right': marginRight,
                 transform
             });

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -27,7 +27,6 @@
 
         > li {
             display: inline-block;
-            flex-grow: 0;
             flex-shrink: 0;
             list-style: none;
         }


### PR DESCRIPTION
## Description
This PR swaps out `flex-basis` usage for `width`. This allows for items within the carousel to size themselves relative to the width of the carousel item, which is currently not possible with flex-basis.

## References
Fixes #431 
