### PR TITLE
Carousel: Native scrolling snap fixes

### DIFF
--- a/src/common/test-utils/browser.js
+++ b/src/common/test-utils/browser.js
@@ -39,9 +39,13 @@ function simulateScroll(el, to, cb) {
             if (++frame > frames) {
                 triggerEvent(el, 'touchend');
                 el.scrollLeft = to;
-                // Allow two frames for the on scroll to finish.
+                // Allow two frames and a timeout for the on scroll to finish.
                 if (cb) {
-                    waitFrames(2, cb);
+                    requestAnimationFrame(() => {
+                        setTimeout(() => {
+                            requestAnimationFrame(cb);
+                        }, 64);
+                    });
                 }
 
                 return;

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -329,7 +329,6 @@ function handleScrollEnd(scrollLeft) {
     // Always update with the new index to ensure the scroll animations happen.
     config.preserveItems = true;
     this.setStateDirty('index', closest);
-    this.once('update', this.emitUpdate);
     emitAndFire(this, 'carousel-scroll', { index: closest });
 }
 

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -135,7 +135,9 @@ function init() {
         onRender.call(this);
     });
     observer.observeRoot(this, ['index']);
-    if (autoplayInterval) observer.observeRoot(this, ['paused']);
+    if (autoplayInterval) {
+        observer.observeRoot(this, ['paused']);
+    }
 
     if (!autoplayInterval && getComputedStyle(this.listEl).getPropertyValue('overflow-x') !== 'visible') {
         config.nativeScrolling = true;
@@ -150,7 +152,9 @@ function onRender() {
     const hasOverride = offsetOverride !== undefined;
 
     // Do nothing for empty carousels.
-    if (!items.length) return;
+    if (!items.length) {
+        return;
+    }
 
     // When there is an offset override (used for infinite scroll) we reset it
     // after rendering to restore the expected carousel state.
@@ -184,7 +188,9 @@ function onRender() {
         if (autoplayInterval && !paused) {
             const moveRight = this.move.bind(this, RIGHT);
             this.autoplayTimeout = setTimeout(() => {
-                if (this.isMoving) return this.once('carousel-update', moveRight);
+                if (this.isMoving) {
+                    return this.once('carousel-update', moveRight);
+                }
                 moveRight();
             }, autoplayInterval);
         }
@@ -216,8 +222,12 @@ function onRender() {
 function cleanupAsync() {
     clearTimeout(this.autoplayTimeout);
     cancelAnimationFrame(this.renderFrame);
-    if (this.cancelScrollHandler) this.cancelScrollHandler();
-    if (this.cancelScrollTransition) this.cancelScrollTransition();
+    if (this.cancelScrollHandler) {
+        this.cancelScrollHandler();
+    }
+    if (this.cancelScrollTransition) {
+        this.cancelScrollTransition();
+    }
     this.cancelScrollHandler = this.cancelScrollTransition = undefined;
 }
 
@@ -237,7 +247,9 @@ function emitUpdate() {
  * @param {HTMLElement} target
  */
 function handleMove(originalEvent, target) {
-    if (this.isMoving) return;
+    if (this.isMoving) {
+        return;
+    }
     const { state } = this;
     const direction = parseInt(target.getAttribute('data-direction'), 10);
     const nextIndex = this.move(direction);
@@ -253,7 +265,9 @@ function handleMove(originalEvent, target) {
  * @param {HTMLElement} target
  */
 function handleDotClick(originalEvent, target) {
-    if (this.isMoving) return;
+    if (this.isMoving) {
+        return;
+    }
     const { state: { config, itemsPerSlide } } = this;
     const slide = parseInt(target.getAttribute('data-slide'), 10);
     config.preserveItems = true;
@@ -270,7 +284,9 @@ function togglePlay(originalEvent) {
     const { state: { config, paused } } = this;
     config.preserveItems = true;
     this.setState('paused', !paused);
-    if (paused && !this.isMoving) this.move(RIGHT);
+    if (paused && !this.isMoving) {
+        this.move(RIGHT);
+    }
     emitAndFire(this, `carousel-${paused ? 'play' : 'pause'}`, { originalEvent });
 }
 
@@ -299,8 +315,11 @@ function handleScrollEnd(scrollLeft) {
 
     while (high - low > 1) {
         const mid = Math.floor((low + high) / 2);
-        if (targetLeft > items[mid * itemsPerSlide].left) low = mid;
-        else high = mid;
+        if (targetLeft > items[mid * itemsPerSlide].left) {
+            low = mid;
+        } else {
+            high = mid;
+        }
     }
 
     const deltaLow = Math.abs(targetLeft - items[low * itemsPerSlide].left);
@@ -380,7 +399,9 @@ function move(delta) {
  */
 function getOffset(state) {
     const { items, index } = state;
-    if (!items.length) return 0;
+    if (!items.length) {
+        return 0;
+    }
     return Math.min(items[index].left, getMaxOffset(state)) || 0;
 }
 
@@ -391,7 +412,9 @@ function getOffset(state) {
  * @return {number}
  */
 function getMaxOffset({ items, slideWidth }) {
-    if (!items.length) return 0;
+    if (!items.length) {
+        return 0;
+    }
     return Math.max(items[items.length - 1].right - slideWidth, 0) || 0;
 }
 
@@ -404,7 +427,9 @@ function getMaxOffset({ items, slideWidth }) {
  * @return {number}
  */
 function getSlide({ index, itemsPerSlide }, i = index) {
-    if (!itemsPerSlide) return;
+    if (!itemsPerSlide) {
+        return;
+    }
     return Math.ceil(i / itemsPerSlide);
 }
 
@@ -420,20 +445,30 @@ function getNextIndex({ index, items, slideWidth, itemsPerSlide }, delta) {
     let item;
 
     // If going backward from 0, we go to the end.
-    if (delta === LEFT && i === 0) return items.length - 1;
+    if (delta === LEFT && i === 0) {
+        return items.length - 1;
+    }
 
     // Find the index of the next item that is not fully in view.
-    do item = items[i += delta]; while (item && item.fullyVisible);
+    do {
+        item = items[i += delta];
+    } while (item && item.fullyVisible);
 
     // If going right, then we just want the next item not fully in view.
-    if (delta === RIGHT) return i % items.length;
+    if (delta === RIGHT) {
+        return i % items.length;
+    }
 
     // If items per slide is set we must show the same items on the same slide.
-    if (itemsPerSlide) return i;
+    if (itemsPerSlide) {
+        return i;
+    }
 
     // If going left without items per slide, go as far left as possible while keeping this item fully in view.
     const targetOffset = item.right - slideWidth;
-    do item = items[--i]; while (item && item.left >= targetOffset);
+    do {
+        item = items[--i];
+    } while (item && item.left >= targetOffset);
     return i + 1;
 }
 

--- a/src/components/ebay-carousel/utils/on-scroll-end/index.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/index.js
@@ -10,6 +10,7 @@
  */
 module.exports = function onScrollEnd(el, fn) {
     let frame;
+    let timeout;
     let stage = 0;
     el.addEventListener('touchmove', handleTouchMove);
 
@@ -40,17 +41,19 @@ module.exports = function onScrollEnd(el, fn) {
     // Finally after the touch end we poll the scroll state every animation frame
     // to determine when inertial scrolling has stopped.
     function checkScrollEnded(lastOffset) {
-        frame = requestAnimationFrame(() => {
-            const newOffset = el.scrollLeft;
-            if (lastOffset !== newOffset) {
-                checkScrollEnded(newOffset);
-            } else {
-                cancelTouchStart();
-                fn(newOffset);
-                stage = 0;
-                el.addEventListener('touchmove', handleTouchMove);
-            }
-        });
+        timeout = setTimeout(() => {
+            frame = requestAnimationFrame(() => {
+                const newOffset = el.scrollLeft;
+                if (lastOffset !== newOffset) {
+                    checkScrollEnded(newOffset);
+                } else {
+                    cancelTouchStart();
+                    fn(newOffset);
+                    stage = 0;
+                    el.addEventListener('touchmove', handleTouchMove);
+                }
+            });
+        }, 64);
     }
 
     function cancelTouchMove() {
@@ -67,6 +70,7 @@ module.exports = function onScrollEnd(el, fn) {
 
     function cancel() {
         cancelAnimationFrame(frame);
+        clearTimeout(timeout);
 
         switch (stage) {
             case 0: cancelTouchMove(); break;

--- a/src/components/ebay-carousel/utils/scroll-transition/index.js
+++ b/src/components/ebay-carousel/utils/scroll-transition/index.js
@@ -21,7 +21,7 @@ module.exports = function scrollTransition(el, to, fn) {
                 return fn();
             }
 
-            el.scrollLeft = easeOut(delta / duration) * distance + scrollLeft;
+            el.scrollLeft = easeInOut(delta / duration) * distance + scrollLeft;
             frame = requestAnimationFrame(animate);
         }(startTime));
     });
@@ -32,8 +32,9 @@ module.exports = function scrollTransition(el, to, fn) {
     return cancel;
 
     function cancel() {
+        cancelAnimationFrame(frame);
+
         if (lastPosition === undefined) {
-            cancelAnimationFrame(frame);
             cancelTouchStart();
         } else {
             if (cancelInterruptTransition) cancelInterruptTransition();
@@ -72,7 +73,6 @@ module.exports = function scrollTransition(el, to, fn) {
  * @param {number} val - A number between 0 and 1.
  * @return {number}
  */
-function easeOut(v) {
-    const t = v - 1;
-    return t * t * t + 1;
+function easeInOut(v) {
+    return v < 0.5 ? 2 * v * v : -1 + (4 - 2 * v) * v;
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where the carousel would snap to the incorrect place when items-per-slide was set in mobile. The new implementation a properly checks for the closest slide instead of just the closest item.

The also fixes an issue we were seeing in Chrome where the scroll position was not being updated quick enough and was causing false positives in our `onScrollEnd` handler. To fix this I added an additional artificial timeout for the scroll position polling.

## References
* fixes #432 
* fixes #439 
