### PR TITLE
Carousel: hide paddles on mobile when peek enabled

### DIFF
--- a/src/components/ebay-carousel/examples/11-items-per-slide-partial-item/template.marko
+++ b/src/components/ebay-carousel/examples/11-items-per-slide-partial-item/template.marko
@@ -9,7 +9,7 @@
         text-align: center;
     }
 </style>
-<ebay-carousel items-per-slide="3.25">
+<ebay-carousel items-per-slide="1.5">
     <ebay-carousel-item class="demo11-card">Card 1</ebay-carousel-item>
     <ebay-carousel-item class="demo11-card">Card 2</ebay-carousel-item>
     <ebay-carousel-item class="demo11-card">Card 3</ebay-carousel-item>

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -44,6 +44,7 @@ function getInitialState(input) {
         state.classes.push('carousel--slides');
 
         if (state.peek) {
+            state.classes.push('carousel--peek');
             state.noDots = true;
         }
 

--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -1,5 +1,5 @@
 .carousel {
-    &--slides &__control, // show controls on touch since there's no hover.
+    &--slides&:not(&--peek) &__control, // show controls on touch since there's no hover.
     &__control:focus { // also show controls on focus for a11y.
         opacity: @ebay-carousel-control-enabled-opacity;
         pointer-events: auto;


### PR DESCRIPTION
## Description
This hides the paddles from carousels on mobile when `peek` is enabled as described in #440.

## References
* fixes #440

### Notes
In #440 we were talking about making both paddles visible once a they are focused. This is going to require a larger PR since we can't use something like [`focus-within`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within) and so will require JS.

Since the existing continuous carousel also hides the paddles and works by only showing the one that is focused I feel like there should be a separate PR/issue if we would like to address that as well.

I also updated one of the examples to make it have more of a peek on mobile.