### PR TITLE
Common Transformer: fix wrong parent node

### DIFF
--- a/src/common/transformer/index.js
+++ b/src/common/transformer/index.js
@@ -11,7 +11,7 @@ function transform(el, context) {
         el.tagName.replace(/^(ebay-[^-]+)-/, '$1:'),
         el.getAttributes()
     );
-    replacement.body = el.body;
+    replacement.body = replacement.makeContainer(el.body.items);
     el.replaceWith(replacement);
 }
 


### PR DESCRIPTION
## Description
After digging into #419 In a sample app I realized that the issue was actually another transformer bug. In this case the `contents` of the transformed tag had the wrong parent container reference which caused some things to get inserted in the wrong place.

## References
fixes #419 