### PR TITLE
Switch: fix typo in docs

### DIFF
--- a/src/components/ebay-switch/README.md
+++ b/src/components/ebay-switch/README.md
@@ -14,7 +14,7 @@ Name | Type | Stateful | Description
 
 Note: For this component, `class`/`style` are applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 
-## ebay-radio Events
+## ebay-switch Events
 
 Event | Data | Description
 --- | --- | ---


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- change `radio` to `switch` in `switch` docs

