### PR TITLE
emit-and-fire: add tests for no CustomEvent support

### DIFF
--- a/src/common/emit-and-fire/test/test.browser.js
+++ b/src/common/emit-and-fire/test/test.browser.js
@@ -2,15 +2,33 @@ const sinon = require('sinon');
 const expect = require('chai').expect;
 const emitAndFire = require('../');
 
-const mockWidget = {
-    emit: sinon.spy(),
-    el: {
-        dispatchEvent: sinon.spy()
-    }
-};
-
-test('emits marko event and fires dom event', () => {
+const originalCustomEvent = window.CustomEvent;
+function testEventCalls() {
+    const mockWidget = {
+        emit: sinon.spy(),
+        el: {
+            dispatchEvent: sinon.spy()
+        }
+    };
     emitAndFire(mockWidget, 'name');
     expect(mockWidget.emit.calledOnce).to.equal(true);
     expect(mockWidget.el.dispatchEvent.calledOnce).to.equal(true);
+}
+
+afterEach(() => {
+    window.CustomEvent = originalCustomEvent;
+});
+
+test('emits marko event and fires dom event', () => {
+    testEventCalls();
+});
+
+test('creates event if CustomEvent is not in window', () => {
+    window.CustomEvent = undefined;
+    testEventCalls();
+});
+
+test('creates event if CustomEvent is not a function', () => {
+    window.CustomEvent = {};
+    testEventCalls();
 });


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
Adds new tests for:
- when `CustomEvent` is missing (old browsers)
- when `CustomEvent` is not a function (IE11)

## Screenshots
<!-- Upload screenshots if appropriate. -->
Before:
<img width="646" alt="screen shot 2018-10-17 at 10 24 45 am" src="https://user-images.githubusercontent.com/3595986/47105018-b21a5e80-d1f7-11e8-92ca-42ce0308d89c.png">

After:
<img width="639" alt="screen shot 2018-10-17 at 10 24 51 am" src="https://user-images.githubusercontent.com/3595986/47105020-b21a5e80-d1f7-11e8-89c9-b0696bddf99b.png">

