### PR TITLE
property-observer: add tests for observeInner

### DIFF
--- a/src/common/property-observer/test/test.browser.js
+++ b/src/common/property-observer/test/test.browser.js
@@ -2,17 +2,46 @@ const sinon = require('sinon');
 const expect = require('chai').expect;
 const observer = require('../');
 
-const mockWidget = {
-    el: {},
-    state: {},
-    setState: sinon.spy()
-};
+function createMock() {
+    return {
+        mockWidget: {
+            el: {},
+            state: {},
+            setState: sinon.spy(),
+            setStateDirty: sinon.spy()
+        },
+        mockCallback: sinon.spy()
+    };
+}
 
-const mockCallback = sinon.spy();
+describe('observeRoot()', () => {
+    test('listens for a property change, then calls a callback', () => {
+        const { mockWidget, mockCallback } = createMock();
+        observer.observeRoot(mockWidget, ['name'], mockCallback);
+        mockWidget.el.name = 'test';
+        expect(mockWidget.el.name).to.equal(mockWidget.state.name);
+        expect(mockWidget.setState.calledOnce).to.equal(true);
+        expect(mockCallback.calledOnce).to.equal(true);
+    });
+});
 
-test('the root element observer listens for a property change, then calls a callback', () => {
-    observer.observeRoot(mockWidget, ['name'], mockCallback);
-    mockWidget.el.name = 'test';
-    expect(mockWidget.setState.calledOnce).to.equal(true);
-    expect(mockCallback.calledOnce).to.equal(true);
+describe('observeInner()', () => {
+    test('listens for a property change and calls setStateDirty() when specified', () => {
+        const { mockWidget, mockCallback } = createMock();
+        observer.observeInner(mockWidget, mockWidget.el, 'name', 'path', true, mockCallback);
+        mockWidget.el.name = 'test';
+        expect(mockWidget.el.name).to.equal(mockWidget.state.path.name);
+        expect(mockWidget.setState.called).to.equal(false);
+        expect(mockWidget.setStateDirty.calledOnce).to.equal(true);
+        expect(mockCallback.calledOnce).to.equal(true);
+    });
+    test('listens for a property change and does not call setStateDirty() when specified', () => {
+        const { mockWidget, mockCallback } = createMock();
+        observer.observeInner(mockWidget, mockWidget.el, 'name', 'path', false, mockCallback);
+        mockWidget.el.name = 'test';
+        expect(mockWidget.el.name).to.equal(mockWidget.state.path.name);
+        expect(mockWidget.setState.called).to.equal(false);
+        expect(mockWidget.setStateDirty.called).to.equal(false);
+        expect(mockCallback.calledOnce).to.equal(true);
+    });
 });


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
- add tests for `observeInner()`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This method previous had some coverage from getting called in other tests, but did not have any tests of its own.

## Screenshots
<!-- Upload screenshots if appropriate. -->
Before:
<img width="602" alt="screen shot 2018-10-17 at 11 05 12 am" src="https://user-images.githubusercontent.com/3595986/47107435-29eb8780-d1fe-11e8-929c-b59007825744.png">

After:
<img width="607" alt="screen shot 2018-10-17 at 11 05 04 am" src="https://user-images.githubusercontent.com/3595986/47107434-29eb8780-d1fe-11e8-991f-3c62e82bc698.png">

