### PR TITLE
Carousel: Improve native scrolling animation on IOS.

### DIFF
--- a/src/common/test-utils/browser.js
+++ b/src/common/test-utils/browser.js
@@ -6,9 +6,10 @@ const expect = require('chai').expect;
  * @param {String} type
  * @param {Number} keyCode
  */
-function triggerEvent(el, type, keyCode) {
+function triggerEvent(el, type, keyCode, cancelable) {
+    const isCancelable = cancelable === undefined ? true : cancelable;
     const event = document.createEvent('Event');
-    event.initEvent(type, true, true, null);
+    event.initEvent(type, true, isCancelable, null);
     event.keyCode = keyCode;
     el.dispatchEvent(event);
 }
@@ -33,11 +34,11 @@ function simulateScroll(el, to, cb) {
     const distance = to - scrollLeft;
     const frames = 4;
     let frame = 0;
-    triggerEvent(el, 'touchstart');
+    triggerEvent(el, 'touchstart', undefined, false);
     requestAnimationFrame(() => {
         (function animate() {
             if (++frame > frames) {
-                triggerEvent(el, 'touchend');
+                triggerEvent(el, 'touchend', undefined, false);
                 el.scrollLeft = to;
                 // Allow two frames and a timeout for the on scroll to finish.
                 if (cb) {
@@ -51,7 +52,7 @@ function simulateScroll(el, to, cb) {
                 return;
             }
 
-            triggerEvent(el, 'touchmove');
+            triggerEvent(el, 'touchmove', undefined, false);
             el.scrollLeft = (frame / frames) * distance + scrollLeft;
             requestAnimationFrame(animate);
         }());

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -295,7 +295,7 @@ function togglePlay(originalEvent) {
  *
  * @param {number} scrollLeft The current scroll position of the carousel.
  */
-function handleScrollEnd(scrollLeft) {
+function handleScrollEnd(scrollLeft, velocity) {
     if (this.cancelScrollTransition) {
         this.cancelScrollTransition();
         this.cancelScrollTransition = undefined;
@@ -304,9 +304,9 @@ function handleScrollEnd(scrollLeft) {
     const { state } = this;
     const { config, items, slideWidth } = state;
     const itemsPerSlide = state.itemsPerSlide || 1;
-    const direction = getOffset(state) > scrollLeft ? RIGHT : LEFT;
+    const direction = velocity < 0 ? RIGHT : LEFT;
     // Used to add additional tolerance based on swipe direction.
-    const targetLeft = scrollLeft - (direction * slideWidth * 0.2);
+    const targetLeft = scrollLeft - (direction * slideWidth * Math.max(0.2, Math.abs(velocity) / 2));
 
     // Find the closest item using a binary search on each carousel slide.
     const totalItems = items.length;

--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -19,7 +19,6 @@
 
     &:not(&__autoplay) &__list {
         overflow-x: auto; // also used in js to determine scroll behavior
-        -webkit-overflow-scrolling: touch;
         -ms-overflow-style: none;
 
         &::-webkit-scrollbar {

--- a/src/components/ebay-carousel/utils/on-scroll-end/index.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/index.js
@@ -11,31 +11,47 @@
 module.exports = function onScrollEnd(el, fn) {
     let frame;
     let timeout;
+    let lastTime;
+    let lastLeft;
     let stage = 0;
     el.addEventListener('touchmove', handleTouchMove);
 
     return cancel;
 
     // First we wait for a touch move (means scrolling as started).
-    function handleTouchMove() {
-        stage++;
-        cancelTouchMove();
-        el.addEventListener('touchend', handleTouchEnd);
+    function handleTouchMove(e) {
+        if (stage !== 1) {
+            el.addEventListener('touchend', handleTouchEnd);
+        }
+
+        stage = 1;
+        lastTime = e.timeStamp;
+        lastLeft = el.scrollLeft;
     }
 
     // Then we wait for the touch to end (user has stopped scrolling).
-    function handleTouchEnd() {
-        stage++;
+    function handleTouchEnd(e) {
+        stage = 2;
         cancelTouchEnd();
+
+        if (e.cancelable) {
+            const time = e.timeStamp - lastTime;
+            const distance = el.scrollLeft - lastLeft;
+            const velocity = distance / time;
+            stage = 0;
+            // If it's cancelable then this browser does not inertial scroll by default and we can animate immediately.
+            return fn(el.scrollLeft, velocity);
+        }
+
         el.addEventListener('touchstart', handleTouchStart);
         frame = requestAnimationFrame(() => checkScrollEnded(el.scrollLeft));
     }
 
     // If the user touches again before the inertial scrolling has stopped then we reset.
-    function handleTouchStart() {
-        cancel();
-        stage--;
-        el.addEventListener('touchend', handleTouchEnd);
+    function handleTouchStart(e) {
+        stage = 0;
+        cancelPolling();
+        handleTouchMove(e);
     }
 
     // Finally after the touch end we poll the scroll state every animation frame
@@ -48,9 +64,8 @@ module.exports = function onScrollEnd(el, fn) {
                     checkScrollEnded(newOffset);
                 } else {
                     cancelTouchStart();
-                    fn(newOffset);
+                    fn(newOffset, 0);
                     stage = 0;
-                    el.addEventListener('touchmove', handleTouchMove);
                 }
             });
         }, 64);
@@ -68,14 +83,24 @@ module.exports = function onScrollEnd(el, fn) {
         el.removeEventListener('touchstart', handleTouchStart);
     }
 
-    function cancel() {
+    function cancelPolling() {
         cancelAnimationFrame(frame);
         clearTimeout(timeout);
+    }
+
+    function cancel() {
+        cancelTouchMove();
 
         switch (stage) {
-            case 0: cancelTouchMove(); break;
-            case 1: cancelTouchEnd(); break;
-            default: cancelTouchStart(); break;
+            case 1:
+                cancelTouchEnd();
+                break;
+            case 2:
+                cancelPolling();
+                cancelTouchStart();
+                break;
+            default:
+                break;
         }
     }
 };

--- a/src/components/ebay-carousel/utils/scroll-transition/index.js
+++ b/src/components/ebay-carousel/utils/scroll-transition/index.js
@@ -8,11 +8,16 @@
  * @return {function} A function that cancels the transition.
  */
 module.exports = function scrollTransition(el, to, fn) {
-    const duration = 250;
+    const { scrollLeft } = el;
+    const distance = to - scrollLeft;
+
+    if (distance === 0) {
+        return fn();
+    }
+
+    const duration = Math.pow(Math.abs(distance) * 16, 0.75);
     let lastPosition, cancelInterruptTransition;
     let frame = requestAnimationFrame(startTime => {
-        const { scrollLeft } = el;
-        const distance = to - scrollLeft;
         (function animate(curTime) {
             const delta = curTime - startTime;
             if (delta > duration) {
@@ -21,7 +26,7 @@ module.exports = function scrollTransition(el, to, fn) {
                 return fn();
             }
 
-            el.scrollLeft = easeInOut(delta / duration) * distance + scrollLeft;
+            el.scrollLeft = easeOut(delta / duration) * distance + scrollLeft;
             frame = requestAnimationFrame(animate);
         }(startTime));
     });
@@ -73,6 +78,7 @@ module.exports = function scrollTransition(el, to, fn) {
  * @param {number} val - A number between 0 and 1.
  * @return {number}
  */
-function easeInOut(v) {
-    return v < 0.5 ? 2 * v * v : -1 + (4 - 2 * v) * v;
+function easeOut(v) {
+    const t = v - 1;
+    return t * t * t + 1;
 }


### PR DESCRIPTION
## Description
This changes the IOS animation such that the transition happens immediately after the `touched` event. It calculates the scroll velocity and moves the user to an appropriate slide.

In chrome (where event.cancelable for touch events is false) we maintain the existing behavior.

## References
fixes #454 

## Screenshots
![carousel-updated-animation-ios](https://user-images.githubusercontent.com/4985201/47520665-9fcaa100-d845-11e8-8f21-6cd2d4740d57.gif)
