### PR TITLE
Fix data-ebayui transform in marko v4

### DIFF
--- a/src/common/transformers/ebayui-attribute/index.js
+++ b/src/common/transformers/ebayui-attribute/index.js
@@ -12,35 +12,11 @@ const COMPONENT_FILES = fs
  * @param {Object} context
  */
 function transform(el, context) {
-    // Ensure this transform is only ran once per file.
-    const alreadyTransformed = context._ebayUIAttributeTransformed;
-    context._ebayUIAttributeTransformed = true;
-
-    if (alreadyTransformed) {
-        return;
-    }
-
     // Only runs on top level ebay ui templates (skips demos).
     const isEbayUIComponentFile = COMPONENT_FILES.indexOf(context.filename) !== -1;
-    if (!isEbayUIComponentFile) {
-        return;
-    }
 
-    // Find all elements with `w-bind` and add the data-ebayui attribute.
-    let wasTransformed = false;
-    const walker = context.createWalker({
-        enter(node) {
-            if (node.type === 'HtmlElement' && node.hasAttribute('w-bind')) {
-                wasTransformed = true;
-                node.setAttributeValue('data-ebayui', context.builder.literal(true));
-            }
-        }
-    });
-
-    walker.walk(context.root);
-
-    if (!wasTransformed) {
-        throw new Error(`w-bind is required to add the data-ebayui attribute, none found in "${context.filename}".`);
+    if (isEbayUIComponentFile && el.hasAttribute('w-bind')) {
+        el.setAttributeValue('data-ebayui', context.builder.literal(true));
     }
 }
 


### PR DESCRIPTION
## Description
Simplifies the transform used in for adding the `data-ebayui` and allows it to work in Marko 3 & 4.

## References
Improves on #457 
