### PR TITLE
Select: remove update() call and add unit test

### DIFF
--- a/src/components/ebay-select/index.js
+++ b/src/components/ebay-select/index.js
@@ -120,7 +120,6 @@ function setSelectedOption(optionValue) {
         } else {
             option.selected = false;
         }
-        this.update();
         return option;
     });
 

--- a/src/components/ebay-select/test/test.browser.js
+++ b/src/components/ebay-select/test/test.browser.js
@@ -72,4 +72,29 @@ describe('given the select is in the default state', () => {
             expect(selectElement.selectedIndex).to.equal(expectedIndex);
         });
     });
+
+    describe('when the index is set multiple times through the selectedIndex attribute', () => {
+        const initialExpectedIndex = 1;
+        const finalExpectedIndex = 0;
+        const finalExpectedValue = '1';
+        let spy;
+
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('select-change', spy);
+            root.selectedIndex = initialExpectedIndex;
+            root.selectedIndex = finalExpectedIndex;
+        });
+
+        test('then it emits the select-change event with the correct data', () => {
+            const eventData = spy.getCall(1).args[0];
+            expect(spy.calledTwice).to.equal(true);
+            expect(eventData.index).to.equal(finalExpectedIndex);
+            expect(eventData.selected).to.deep.equal([finalExpectedValue]);
+            expect(root.value).to.equal(finalExpectedValue);
+            expect(root.selectedIndex).to.equal(finalExpectedIndex);
+            expect(selectElement.value).to.equal(finalExpectedValue);
+            expect(selectElement.selectedIndex).to.equal(finalExpectedIndex);
+        });
+    });
 });


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
Remove the call to `update()`, since `.map` returns a new options array. 

## References
Fixes #460 