### PR TITLE
Carousel: Wrong threshold moving left.

### DIFF
--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -303,7 +303,7 @@ function handleScrollEnd(scrollLeft, velocity) {
     const { state } = this;
     const { config, items, slideWidth } = state;
     const itemsPerSlide = state.itemsPerSlide || 1;
-    const direction = velocity < 0 ? RIGHT : LEFT;
+    const direction = getOffset(state) > scrollLeft ? RIGHT : LEFT;
     // Used to add additional tolerance based on swipe direction.
     const targetLeft = scrollLeft - (direction * slideWidth * Math.max(0.2, Math.abs(velocity) / 2));
 


### PR DESCRIPTION
## Description
In the current version of the carousel there is a bug where it cannot properly tell the direction that the scroll is moving when on chrome which causes thresholds to be off.

The fix here is pretty simple to use the current scroll position to determine which direction we are going instead of velocity (which is always zero on chrome).

## References
fixes #468 