### PR TITLE
Fixing the LESS variables because of Skin bundle changes;

### DIFF
--- a/src/components/ebay-carousel/browser.json
+++ b/src/components/ebay-carousel/browser.json
@@ -12,6 +12,18 @@
                 "@ebay/skin/icon"
             ]
         },
+        {
+            "if-not-flag": "skin-ds6",
+            "dependencies": [
+                "./variables-ds4.less"
+            ]
+        },
+        {
+            "if-flag": "skin-ds6",
+            "dependencies": [
+                "./variables-ds6.less"
+            ]
+        },
         "./style.less",
         {
             "if-flag": "touch",

--- a/src/components/ebay-carousel/style-no-touch.less
+++ b/src/components/ebay-carousel/style-no-touch.less
@@ -11,14 +11,14 @@
         }
 
         &:hover:not([aria-disabled="true"]) {
-            background-color: @ds6-color-g204-gray;
+            background-color: @carousel-dots-hover-background-color;
         }
 
         &:hover:active:not([aria-disabled="true"]) {
-            background-color: @ds6-color-g205-gray;
+            background-color: @carousel-dots-hover-active-background-color;
 
             svg {
-                color: @ds6-color-g201-gray;
+                color: @carousel-dots-hover-active-svg-color;
             }
         }
     }

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -37,12 +37,12 @@
         opacity: 0;
         pointer-events: none;
         font-size: 18px;
-        background-color: @ds6-color-g201-gray;
+        background-color: @carousel-control-background-color;
         padding: 0; // override browser default
         height: 72px;
         width: 28px;
         z-index: 1;
-        border: 1px solid @ds6-color-g206-gray;
+        border: 1px solid @carousel-control-border-color;
         position: absolute;
         top: 50%;
         transform: translateY(-50%);
@@ -56,7 +56,7 @@
         }
 
         svg {
-            color: @ds6-color-g206-gray;
+            color: @carousel-control-svg-color;
         }
 
         .icon--chevron-right {
@@ -82,7 +82,7 @@
         width: 40px;
         border-radius: 50%;
         text-align: center;
-        color: @ds6-color-g201-gray;
+        color: @carousel-play-pause-color;
         box-sizing: border-box;
 
         svg {
@@ -103,7 +103,7 @@
             display: inline-block;
 
             > button {
-                background-color: @ds6-color-g206-gray;
+                background-color: @carousel-dots-background-color;
                 border: 0;
                 border-radius: 50%;
                 display: inline-block;
@@ -123,7 +123,7 @@
                     width: 100%;
                     height: 100%;
                     opacity: 1;
-                    background-color: @ds6-color-g204-gray;
+                    background-color: @carousel-dots-after-background-color;
                 }
 
                 &.carousel__dot--active::after {

--- a/src/components/ebay-carousel/variables-ds4.less
+++ b/src/components/ebay-carousel/variables-ds4.less
@@ -1,0 +1,14 @@
+// .carousel__control
+@carousel-control-background-color: @ds4-color-core-white;
+@carousel-control-border-color: @ds4-color-core-gray-jet;
+@carousel-control-svg-color: @ds4-color-core-gray-jet;
+
+// .carousel__play, .carousel__pause
+@carousel-play-pause-color: @ds4-color-core-white;
+
+// .carousel__dots
+@carousel-dots-background-color: @ds4-color-core-gray-jet;
+@carousel-dots-after-background-color: @ds4-color-core-gray-silver;
+@carousel-dots-hover-background-color: @ds4-color-core-gray-silver;
+@carousel-dots-hover-active-background-color: @ds4-color-core-gray-dim;
+@carousel-dots-hover-active-svg-color: @ds4-color-core-white;

--- a/src/components/ebay-carousel/variables-ds6.less
+++ b/src/components/ebay-carousel/variables-ds6.less
@@ -1,0 +1,14 @@
+// .carousel__control
+@carousel-control-background-color: @ds6-color-g201-gray;
+@carousel-control-border-color: @ds6-color-g206-gray;
+@carousel-control-svg-color: @ds6-color-g206-gray;
+
+// .carousel__play, .carousel__pause
+@carousel-play-pause-color: @ds6-color-g201-gray;
+
+// .carousel__dots
+@carousel-dots-background-color: @ds6-color-g206-gray;
+@carousel-dots-after-background-color: @ds6-color-g204-gray;
+@carousel-dots-hover-background-color: @ds6-color-g204-gray;
+@carousel-dots-hover-active-background-color: @ds6-color-g205-gray;
+@carousel-dots-hover-active-svg-color: @ds6-color-g201-gray;


### PR DESCRIPTION
**Note:** This should not be merged until Skin v7 is updated and available for the 2.0.0 branch to use. 

## Description
- adds split variable files per Design System
- creates new, generic variables in order to provide capability for switching design systems

## Context
In Skin v7 there was an update which changed the way variables are delivered, essentially splitting out the DS4 and DS6 variables based on the `skin-ds6` Lasso flag. This had detrimental results for the carousel, as it was relying solely on the DS6 Less variables. When you switched the demo page (which is part of this project) to DS4 you would receive an error. Even though the carousel is intended for use only on DS6 pages, we need to support the demo app rendering, and therefore, the DS4 variables.

## References
Fixes #470 
