### PR TITLE
Add fixed height and truncated options to btn;

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -33,7 +33,9 @@
         "@size": "size",
         "@no-text": "boolean",
         "@fluid": "boolean",
-        "@variant": "string"
+        "@variant": "string",
+        "@fixed": "boolean",
+        "@truncate": "boolean"
     },
     "<ebay-carousel>": {
         "renderer": "./src/components/ebay-carousel/index.js",

--- a/marko.json
+++ b/marko.json
@@ -34,7 +34,7 @@
         "@no-text": "boolean",
         "@fluid": "boolean",
         "@variant": "string",
-        "@fixed": "boolean",
+        "@fixed-height": "boolean",
         "@truncate": "boolean"
     },
     "<ebay-carousel>": {

--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -16,8 +16,10 @@ Name | Type | Stateful | Description
 `href` | String | No | for link that looks like a button
 `fluid` | Boolean | No |
 `disabled` | Boolean | Yes |
-`partially-disabled` | Boolean | No
+`partially-disabled` | Boolean | No |
 `variant` | String | No | optional, to alter Skin classes: "expand" / "cta"
+`fixed-height` | Boolean | No | fixes the height based on `size`; defaults to `medium` when no size is specified
+`truncate` | Boolean | No | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows
 
 ## ebay-button Events
 

--- a/src/components/ebay-button/examples/11-fixed-height/template.marko
+++ b/src/components/ebay-button/examples/11-fixed-height/template.marko
@@ -1,1 +1,1 @@
-<ebay-button fixed>Fixed height</ebay-button>
+<ebay-button fixed-height>Fixed height</ebay-button>

--- a/src/components/ebay-button/examples/11-fixed-height/template.marko
+++ b/src/components/ebay-button/examples/11-fixed-height/template.marko
@@ -1,0 +1,1 @@
+<ebay-button fixed>Fixed height</ebay-button>

--- a/src/components/ebay-button/examples/12-truncated/template.marko
+++ b/src/components/ebay-button/examples/12-truncated/template.marko
@@ -1,0 +1,3 @@
+<div style="max-width: 200px">
+    <ebay-button truncate>Truncated button with a whole lot of text</ebay-button>
+</div>

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -11,9 +11,14 @@ function getInitialState(input) {
     const size = input.size;
     const noText = input.noText;
     const fluid = input.fluid;
+    const fixed = input.fixed;
+    const truncate = input.truncate;
     let variant = input.variant;
     let tag;
     let mainClass = 'btn';
+    let sizeClass = '';
+    let fixedClass = '';
+    let truncatedClass = '';
 
     if (href) {
         variant = 'fake';
@@ -24,6 +29,7 @@ function getInitialState(input) {
 
     const isExpandVariant = variant === 'expand';
     const isCtaVariant = variant === 'cta';
+
     if (href || isExpandVariant || isCtaVariant) {
         mainClass = `${variant}-${mainClass}`;
     }
@@ -34,8 +40,24 @@ function getInitialState(input) {
         classes.push(`${mainClass}--${priority}`);
     }
 
-    if (size === 'small' || size === 'large') {
-        classes.push(`${mainClass}--${size}`);
+    if (size === 'small' || size === 'medium' || size === 'large') {
+        sizeClass = `${mainClass}--${size}`;
+    } else if (!size && (fixed || truncate)) {
+        sizeClass = `${mainClass}--medium`;
+    }
+
+    if (fixed) {
+        fixedClass = `${sizeClass}-fixed-height`;
+        classes.push(fixedClass);
+    }
+
+    if (truncate) {
+        truncatedClass = `${sizeClass}-truncated`;
+        classes.push(truncatedClass);
+    }
+
+    if (!fixed && !truncate) {
+        classes.push(sizeClass);
     }
 
     if (isExpandVariant && noText) {

--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -11,13 +11,13 @@ function getInitialState(input) {
     const size = input.size;
     const noText = input.noText;
     const fluid = input.fluid;
-    const fixed = input.fixed;
+    const fixedHeight = input.fixedHeight;
     const truncate = input.truncate;
     let variant = input.variant;
     let tag;
     let mainClass = 'btn';
     let sizeClass = '';
-    let fixedClass = '';
+    let fixedHeightClass = '';
     let truncatedClass = '';
 
     if (href) {
@@ -42,13 +42,13 @@ function getInitialState(input) {
 
     if (size === 'small' || size === 'medium' || size === 'large') {
         sizeClass = `${mainClass}--${size}`;
-    } else if (!size && (fixed || truncate)) {
+    } else if (!size && (fixedHeight || truncate)) {
         sizeClass = `${mainClass}--medium`;
     }
 
-    if (fixed) {
-        fixedClass = `${sizeClass}-fixed-height`;
-        classes.push(fixedClass);
+    if (fixedHeight) {
+        fixedHeightClass = `${sizeClass}-fixed-height`;
+        classes.push(fixedHeightClass);
     }
 
     if (truncate) {
@@ -56,7 +56,7 @@ function getInitialState(input) {
         classes.push(truncatedClass);
     }
 
-    if (!fixed && !truncate) {
+    if (!fixedHeight && !truncate) {
         classes.push(sizeClass);
     }
 


### PR DESCRIPTION
## Description
- added `fixed` boolean attribute (UPDATE: now changed to `fixed-height`)
- added `truncate` boolean attribute

## Context
Recent changes in Skin to how overflow and wrapping work with the button have then created two new modifiers: one for fixed heigh (sized heights) and truncation.

## References
Completes #462 

This will go into 2.0.0 branch (when we create it).