### PR TITLE
Carousel: Native scrolling with css snap points.

### DIFF
--- a/src/common/test-utils/browser.js
+++ b/src/common/test-utils/browser.js
@@ -29,33 +29,9 @@ function testOriginalEvent(spy) {
  * @param {function} cb A callback to call after the scroll.
  */
 function simulateScroll(el, to, cb) {
-    const { scrollLeft } = el;
-    const distance = to - scrollLeft;
-    const frames = 4;
-    let frame = 0;
-    triggerEvent(el, 'touchstart');
-    requestAnimationFrame(() => {
-        (function animate() {
-            if (++frame > frames) {
-                triggerEvent(el, 'touchend');
-                el.scrollLeft = to;
-                // Allow two frames and a timeout for the on scroll to finish.
-                if (cb) {
-                    requestAnimationFrame(() => {
-                        setTimeout(() => {
-                            requestAnimationFrame(cb);
-                        }, 64);
-                    });
-                }
-
-                return;
-            }
-
-            triggerEvent(el, 'touchmove');
-            el.scrollLeft = (frame / frames) * distance + scrollLeft;
-            requestAnimationFrame(animate);
-        }());
-    });
+    triggerEvent(el, 'scroll', undefined, false);
+    el.scrollTo({ left: to });
+    setTimeout(cb, 600);
 }
 
 function waitFrames(count, cb) {

--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -65,6 +65,7 @@ Event | Data | Description
 
 Notes:
 
+* The carousel will use native scrolling if a sufficient implementation of the css scroll snapping api is available. Otherwise it will fall back to using a transform with manual user navigation via the controls.
 * The `carousel` will manipulate the `tabindex` property of nested focusable elements inside `<ebay-carousel-item>`.
 * The `autoplay` carousel currently does not support native scrolling and will use transforms instead.
 * The `items-per-slide` attribute can be set to a float such as `3.5` to show 3 items, and half of the 4th item. This also automatically enables the `no-dots` attribute.

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -3,7 +3,7 @@ const resizeUtil = require('../../common/event-utils').resizeUtil;
 const emitAndFire = require('../../common/emit-and-fire');
 const processHtmlAttributes = require('../../common/html-attributes');
 const observer = require('../../common/property-observer');
-const onScrollEnd = require('./utils/on-scroll-end');
+const onScroll = require('./utils/on-scroll-debounced');
 const scrollTransition = require('./utils/scroll-transition');
 const template = require('./template.marko');
 
@@ -62,8 +62,8 @@ function getInitialState(input) {
 
 function getTemplateData(state) {
     let { index } = state;
-    const { offsetOverride, autoplayInterval, items, itemsPerSlide, slideWidth, gap } = state;
-    const hasOverride = offsetOverride !== undefined;
+    const { config, autoplayInterval, items, itemsPerSlide, slideWidth, gap } = state;
+    const hasOverride = config.offsetOverride !== undefined;
     const totalItems = items.length;
     const isSingleSlide = items.length <= itemsPerSlide;
     index %= totalItems || 1; // Ensure index is within bounds.
@@ -86,17 +86,20 @@ function getTemplateData(state) {
     }
 
     items.forEach((item, i) => {
+        const isStartOfSlide = itemsPerSlide ? i % itemsPerSlide === 0 : true;
         const { style, transform } = item;
         const marginRight = i !== (items.length - 1) && `${gap}px`;
 
         // Account for users providing a style string or object for each item.
         if (typeof style === 'string') {
-            item.style = `${style};flex-basis:${itemWidth};margin-right:${marginRight}`;
+            item.style = `${style};flex-basis:${itemWidth};margin-right:${marginRight};`;
+            if (isStartOfSlide) item.style += `scroll-snap-align: start;`;
             if (transform) item.style += `transform:${transform}`;
         } else {
             item.style = Object.assign({}, style, {
                 'width': itemWidth,
                 'margin-right': marginRight,
+                'scroll-snap-align': isStartOfSlide && 'start',
                 transform
             });
         }
@@ -111,7 +114,7 @@ function getTemplateData(state) {
     const data = Object.assign({}, state, {
         items,
         slide,
-        offset: hasOverride ? state.offsetOverride : offset,
+        offset: hasOverride ? config.offsetOverride : offset,
         disableTransition: hasOverride,
         totalSlides,
         a11yStatusText,
@@ -138,28 +141,35 @@ function init() {
         observer.observeRoot(this, ['paused']);
     }
 
-    if (!autoplayInterval && getComputedStyle(this.listEl).getPropertyValue('overflow-x') !== 'visible') {
+    if (isNativeScrolling(this.listEl)) {
         config.nativeScrolling = true;
+        this.once('destroy', onScroll(this.listEl, () => {
+            if (!config.scrollTransitioning) {
+                handleScroll.call(this, this.listEl.scrollLeft);
+            }
+        }));
     } else {
-        this.subscribeTo(this.listEl).on('transitionend', this.emitUpdate);
+        this.subscribeTo(this.listEl).on('transitionend', ({ target }) => {
+            if (target === this.listEl) {
+                this.emitUpdate();
+            }
+        });
     }
 }
 
 function onRender() {
     const { containerEl, listEl, state } = this;
-    const { config, items, autoplayInterval, paused, offsetOverride } = state;
-    const hasOverride = offsetOverride !== undefined;
+    const { config, items, autoplayInterval, paused } = state;
 
     // Do nothing for empty carousels.
     if (!items.length) {
         return;
     }
 
-    // When there is an offset override (used for infinite scroll) we reset it
-    // after rendering to restore the expected carousel state.
-    if (hasOverride) {
-        config.preserveItems = true;
-        this.renderFrame = requestAnimationFrame(() => this.setState('offsetOverride', undefined));
+    // Force a rerender to start the offset override animation.
+    if (config.offsetOverride) {
+        config.offsetOverride = undefined;
+        this.renderFrame = requestAnimationFrame(() => this.setStateDirty());
         return;
     }
 
@@ -177,11 +187,17 @@ function onRender() {
         });
 
         if (config.nativeScrolling) {
-            const offset = hasOverride ? offsetOverride : getOffset(state);
-            // Listen for future scroll events and snap to the closest point.
-            this.cancelScrollHandler = onScrollEnd(listEl, handleScrollEnd.bind(this));
-            // Animate to the new scrolling position and emit update events afterward.
-            this.cancelScrollTransition = scrollTransition(listEl, offset, this.emitUpdate);
+            if (config.skipScrolling) {
+                this.emitUpdate();
+                config.skipScrolling = false;
+            } else {
+                const offset = getOffset(state);
+                if (offset !== listEl.scrollLeft) {
+                    // Animate to the new scrolling position and emit update events afterward.
+                    config.scrollTransitioning = true;
+                    this.cancelScrollTransition = scrollTransition(listEl, offset, this.emitUpdate);
+                }
+            }
         }
 
         if (autoplayInterval && !paused) {
@@ -204,6 +220,7 @@ function onRender() {
 
         this.setStateDirty('slideWidth', containerWidth);
         config.preserveItems = true;
+        config.nativeScrolling = isNativeScrolling(listEl);
 
         // Update item positions in the dom.
         forEls(listEl, (itemEl, i) => {
@@ -221,17 +238,16 @@ function onRender() {
 function cleanupAsync() {
     clearTimeout(this.autoplayTimeout);
     cancelAnimationFrame(this.renderFrame);
-    if (this.cancelScrollHandler) {
-        this.cancelScrollHandler();
-    }
+
     if (this.cancelScrollTransition) {
         this.cancelScrollTransition();
+        this.cancelScrollTransition = undefined;
     }
-    this.cancelScrollHandler = this.cancelScrollTransition = undefined;
 }
 
 function emitUpdate() {
-    const { state: { items } } = this;
+    const { state: { config, items } } = this;
+    config.scrollTransitioning = false;
     emitAndFire(this, 'carousel-update', {
         visibleIndexes: items
             .filter(({ fullyVisible }) => fullyVisible)
@@ -294,41 +310,40 @@ function togglePlay(originalEvent) {
  *
  * @param {number} scrollLeft The current scroll position of the carousel.
  */
-function handleScrollEnd(scrollLeft) {
-    if (this.cancelScrollTransition) {
-        this.cancelScrollTransition();
-        this.cancelScrollTransition = undefined;
-    }
-
+function handleScroll(scrollLeft) {
     const { state } = this;
-    const { config, items, slideWidth } = state;
-    const itemsPerSlide = state.itemsPerSlide || 1;
-    const direction = getOffset(state) > scrollLeft ? RIGHT : LEFT;
-    // Used to add additional tolerance based on swipe direction.
-    const targetLeft = scrollLeft - (direction * slideWidth * 0.2);
+    const { config, items, gap } = state;
+    let closest;
 
-    // Find the closest item using a binary search on each carousel slide.
-    const totalItems = items.length;
-    let low = 0;
-    let high = Math.ceil(totalItems / itemsPerSlide) - 1;
+    if (scrollLeft >= getMaxOffset(state) - gap) {
+        closest = items.length - 1;
+    } else {
+        // Find the closest item using a binary search on each carousel slide.
+        const itemsPerSlide = state.itemsPerSlide || 1;
+        const totalItems = items.length;
+        let low = 0;
+        let high = Math.ceil(totalItems / itemsPerSlide) - 1;
 
-    while (high - low > 1) {
-        const mid = Math.floor((low + high) / 2);
-        if (targetLeft > items[mid * itemsPerSlide].left) {
-            low = mid;
-        } else {
-            high = mid;
+        while (high - low > 1) {
+            const mid = Math.floor((low + high) / 2);
+            if (scrollLeft > items[mid * itemsPerSlide].left) {
+                low = mid;
+            } else {
+                high = mid;
+            }
         }
+
+        const deltaLow = Math.abs(scrollLeft - items[low * itemsPerSlide].left);
+        const deltaHigh = Math.abs(scrollLeft - items[high * itemsPerSlide].left);
+        closest = (deltaLow > deltaHigh ? high : low) * itemsPerSlide;
     }
 
-    const deltaLow = Math.abs(targetLeft - items[low * itemsPerSlide].left);
-    const deltaHigh = Math.abs(targetLeft - items[high * itemsPerSlide].left);
-    const closest = (deltaLow > deltaHigh ? high : low) * itemsPerSlide;
-
-    // Always update with the new index to ensure the scroll animations happen.
-    config.preserveItems = true;
-    this.setStateDirty('index', closest);
-    emitAndFire(this, 'carousel-scroll', { index: closest });
+    if (state.index !== closest) {
+        config.skipScrolling = true;
+        config.preserveItems = true;
+        this.setState('index', closest);
+        emitAndFire(this, 'carousel-scroll', { index: closest });
+    }
 }
 
 /**
@@ -351,7 +366,7 @@ function move(delta) {
     if (autoplayInterval) {
         if (delta === RIGHT && nextIndex < index) {
             // Transitions to one slide before the beginning.
-            offsetOverride = -slideWidth;
+            offsetOverride = -slideWidth - gap;
 
             // Move the items in the last slide to be before the first slide.
             for (let i = Math.ceil(itemsPerSlide + peek); i--;) {
@@ -360,7 +375,7 @@ function move(delta) {
             }
         } else if (delta === LEFT && nextIndex > index) {
             // Transitions one slide past the end.
-            offsetOverride = getMaxOffset(state) + slideWidth;
+            offsetOverride = getMaxOffset(state) + slideWidth + gap;
 
             // Moves the items in the first slide to be after the last slide.
             for (let i = Math.ceil(itemsPerSlide + peek); i--;) {
@@ -369,7 +384,7 @@ function move(delta) {
             }
         }
 
-        this.setState('offsetOverride', offsetOverride);
+        config.offsetOverride = offsetOverride;
     }
 
     this.setState('index', nextIndex);
@@ -380,8 +395,6 @@ function move(delta) {
             // If we are in autoplay mode and went outside of the normal offset
             // We make sure to restore all of the items that got moved around.
             items.forEach(item => { item.transform = undefined; });
-            config.preserveItems = true;
-            this.setStateDirty('items');
         }
     });
 
@@ -483,6 +496,16 @@ function forEls(parent, fn) {
         fn(child, i++);
         child = child.nextElementSibling;
     }
+}
+
+/**
+ * Checks if an element is using native scrolling.
+ *
+ * @param {HTMLElement} el the element to check
+ * @return {boolean}
+ */
+function isNativeScrolling(el) {
+    return getComputedStyle(el).overflowX !== 'visible';
 }
 
 module.exports = require('marko-widgets').defineComponent({

--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -1,29 +1,29 @@
+.carousel-control-visible() {
+    opacity: @ebay-carousel-control-enabled-opacity;
+    pointer-events: auto;
+
+    &[aria-disabled="true"] {
+        opacity: @ebay-carousel-control-disabled-opacity;
+    }
+
+    &:active:not([aria-disabled="true"]) {
+        background-color: @ds6-color-g205-gray;
+
+        svg {
+            color: @ds6-color-g201-gray;
+        }
+    }
+}
+
 .carousel {
     &--slides&:not(&--peek) &__control, // show controls on touch since there's no hover.
     &__control:focus { // also show controls on focus for a11y.
-        opacity: @ebay-carousel-control-enabled-opacity;
-        pointer-events: auto;
-
-        &[aria-disabled="true"] {
-            opacity: @ebay-carousel-control-disabled-opacity;
-        }
-
-        &:active:not([aria-disabled="true"]) {
-            background-color: @ds6-color-g205-gray;
-
-            svg {
-                color: @ds6-color-g201-gray;
-            }
-        }
+        .carousel-control-visible();
     }
+}
 
-    &:not(&__autoplay) &__list {
-        overflow-x: auto; // also used in js to determine scroll behavior
-        -webkit-overflow-scrolling: touch;
-        -ms-overflow-style: none;
-
-        &::-webkit-scrollbar {
-            display: none;
-        }
+@supports not (scroll-snap-align: start) { // always show paddles when scroll snapping is not supported.
+    .carousel__control {
+        .carousel-control-visible();
     }
 }

--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -22,7 +22,13 @@
     }
 }
 
-@supports not (scroll-snap-align: start) { // always show paddles when scroll snapping is not supported.
+@supports not (
+    (-webkit-scroll-snap-coordinate: 0 0) or
+    (-ms-scroll-snap-coordinate: 0 0) or
+    (scroll-snap-coordinate: 0 0) or
+    (scroll-snap-align: start)
+) {
+    // always show paddles when scroll snapping is not supported.
     .carousel__control {
         .carousel-control-visible();
     }

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -143,12 +143,20 @@
     }
 }
 
-@supports (scroll-snap-align: start) {
+@supports (
+    (-webkit-scroll-snap-coordinate: 0 0) or
+    (-ms-scroll-snap-coordinate: 0 0) or
+    (scroll-snap-coordinate: 0 0) or
+    (scroll-snap-align: start)
+) {
     .carousel {
         &:not(&__autoplay) &__list {
             scroll-behavior: smooth;
+            -webkit-scroll-snap-type: mandatory;
             -webkit-scroll-snap-type: x mandatory;
+            -ms-scroll-snap-type: mandatory;
             -ms-scroll-snap-type: x mandatory;
+            scroll-snap-type: mandatory;
             scroll-snap-type: x mandatory;
             overflow-x: auto; // also used in js to determine scroll behavior
             -ms-overflow-style: none;
@@ -166,6 +174,13 @@
             &::-webkit-scrollbar-thumb {
                 background-color: transparent;
             }
+        }
+
+        &__snap-point {
+            -webkit-scroll-snap-coordinate: 0 0;
+            -ms-scroll-snap-coordinate: 0 0;
+            scroll-snap-coordinate: 0 0;
+            scroll-snap-align: start;
         }
     }
 }

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -1,5 +1,5 @@
-@ebay-carousel-transition-time: 0.25s;
-@ebay-carousel-transition-function: ease-out;
+@ebay-carousel-transition-time: 0.45s;
+@ebay-carousel-transition-function: ease-in-out;
 @ebay-carousel-control-enabled-opacity: 0.92;
 @ebay-carousel-control-disabled-opacity: 0.3;
 
@@ -8,8 +8,7 @@
 
     &__container {
         white-space: nowrap;
-        overflow-y: hidden;
-        overflow-x: hidden;
+        overflow: hidden;
         padding: 16px 0;
         position: relative;
         width: 100%;
@@ -103,32 +102,69 @@
             display: inline-block;
 
             > button {
-                background-color: @ds6-color-g206-gray;
+                position: relative;
                 border: 0;
-                border-radius: 50%;
                 display: inline-block;
                 margin: 0 6px;
                 padding: 0;
                 height: 8px;
                 width: 8px;
-                overflow: hidden;
+                background-color: transparent;
 
                 // The active dot uses an after to color it in which transitions opacity.
                 // This was done to avoid transitioning the background color of the element
                 // while still allowing us to use exact ds colors.
-                &::after {
-                    transition: opacity @ebay-carousel-transition-time @ebay-carousel-transition-function;
+                &::before, &::after {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
                     content: "";
                     display: block;
                     width: 100%;
                     height: 100%;
-                    opacity: 1;
-                    background-color: @ds6-color-g204-gray;
+                    border-radius: 50%;
                 }
 
                 &.carousel__dot--active::after {
-                    opacity: 0;
+                    opacity: 1;
                 }
+
+                &::before {
+                    background-color: @ds6-color-g204-gray;
+                }
+
+                &::after {
+                    opacity: 0;
+                    transition: opacity @ebay-carousel-transition-time @ebay-carousel-transition-function;
+                    background-color: @ds6-color-g206-gray;
+                }
+            }
+        }
+    }
+}
+
+@supports (scroll-snap-align: start) {
+    .carousel {
+        &:not(&__autoplay) &__list {
+            scroll-behavior: smooth;
+            -webkit-scroll-snap-type: x mandatory;
+            -ms-scroll-snap-type: x mandatory;
+            scroll-snap-type: x mandatory;
+            overflow-x: auto; // also used in js to determine scroll behavior
+            -ms-overflow-style: none;
+            -webkit-overflow-scrolling: touch;
+
+            &::-webkit-scrollbar {
+                display: none;
+                background-color: transparent;
+            }
+
+            &::-webkit-scrollbar-track {
+                background-color: transparent;
+            }
+
+            &::-webkit-scrollbar-thumb {
+                background-color: transparent;
             }
         }
     }

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -143,6 +143,13 @@
     }
 }
 
+/**
+ * In browsers that support a compatible version of the css scroll snap api we use native scrolling.
+ * Otherwise we fall back to using css transforms.
+ *
+ * Not all browsers that have implemented scroll snapping have done so in a way that we can leverage.
+ * Currently the below media query ensures that the browser supports exactly what we need.
+ */
 @supports (
     (-webkit-scroll-snap-coordinate: 0 0) or
     (-ms-scroll-snap-coordinate: 0 0) or

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -57,7 +57,7 @@
             </if>
             <else>
                 <button
-                    class=`carousel__pause`
+                    class="carousel__pause"
                     aria-label=data.a11yPauseText
                     w-onclick="togglePlay">
                     <ebay-icon type="inline" name="pause"/>

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -35,7 +35,14 @@ function getVisibleIndexes(items) {
 }
 
 function getTranslateX(el) {
+    if (isScrollable(el)) {
+        return el.scrollLeft;
+    }
     return parseInt(getComputedStyle(el).transform.match(/^matrix\((?:-?\d+, ?){4}(-?\d+)/)[1], 10) * -1;
+}
+
+function isScrollable(el) {
+    return getComputedStyle(el).overflowX !== 'visible';
 }
 
 describe('given the carousel is in the default state', () => {
@@ -82,7 +89,7 @@ describe('given the carousel starts in the default state with items', () => {
         beforeEach(done => {
             updateSpy = sinon.spy();
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             root.index = 1;
         });
 
@@ -109,7 +116,7 @@ describe('given the carousel starts in the default state with items', () => {
         beforeEach(done => {
             updateSpy = sinon.spy();
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             widget.setProps({ index: '1', items: mock.sixItems });
         });
 
@@ -153,7 +160,7 @@ describe('given the carousel starts in the default state with items', () => {
             updateSpy = sinon.spy();
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             testUtils.triggerEvent(nextButton, 'click');
         });
 
@@ -181,7 +188,7 @@ describe('given the carousel starts in the default state with items', () => {
         beforeEach((done) => {
             updateSpy = sinon.spy();
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             root.index = -1;
         });
 
@@ -228,7 +235,7 @@ describe('given a continuous carousel has next button clicked', () => {
         nextButton = root.querySelector('.carousel__control--next');
         prevButton = root.querySelector('.carousel__control--prev');
         waitForUpdate(widget, () => {
-            widget.subscribeTo(list).once('transitionend', () => {
+            waitForChange(widget, () => {
                 expect(getTranslateX(list)).to.equal(480);
                 done();
             });
@@ -245,7 +252,7 @@ describe('given a continuous carousel has next button clicked', () => {
             updateSpy = sinon.spy();
             widget.on('carousel-previous', prevSpy);
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             testUtils.triggerEvent(prevButton, 'click');
         });
 
@@ -314,14 +321,12 @@ describe('given a continuous carousel with many items', () => {
     const input = { items: mock.twelveItems };
     let widget;
     let root;
-    let list;
     let prevButton;
     let nextButton;
 
     beforeEach(done => {
         widget = renderer.renderSync(input).appendTo(document.body).getWidget();
         root = document.querySelector('.carousel');
-        list = root.querySelector('.carousel__list');
         prevButton = root.querySelector('.carousel__control--prev');
         nextButton = root.querySelector('.carousel__control--next');
         waitForUpdate(widget, done);
@@ -332,15 +337,14 @@ describe('given a continuous carousel with many items', () => {
         let nextSpy;
         let updateSpy;
         beforeEach(done => {
-            const listSub = widget.subscribeTo(list);
             nextSpy = sinon.spy();
             updateSpy = sinon.spy();
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            listSub.once('transitionend', () => {
-                listSub.once('transitionend', () => {
-                    listSub.once('transitionend', done);
+            waitForChange(widget, () => {
+                waitForChange(widget, () => {
+                    waitForChange(widget, done);
                     testUtils.triggerEvent(nextButton, 'click');
                 });
                 testUtils.triggerEvent(nextButton, 'click');
@@ -364,7 +368,6 @@ describe('given a continuous carousel with many items', () => {
         let nextSpy;
         let updateSpy;
         beforeEach(done => {
-            const listSub = widget.subscribeTo(list);
             prevSpy = sinon.spy();
             nextSpy = sinon.spy();
             updateSpy = sinon.spy();
@@ -372,13 +375,13 @@ describe('given a continuous carousel with many items', () => {
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            listSub.once('transitionend', () => {
+            waitForChange(widget, () => {
                 testUtils.triggerEvent(nextButton, 'click');
-                listSub.once('transitionend', () => {
+                waitForChange(widget, () => {
                     testUtils.triggerEvent(nextButton, 'click');
-                    listSub.once('transitionend', () => {
+                    waitForChange(widget, () => {
                         testUtils.triggerEvent(prevButton, 'click');
-                        listSub.once('transitionend', done);
+                        waitForChange(widget, done);
                     });
                 });
             });
@@ -403,16 +406,15 @@ describe('given a continuous carousel with many items', () => {
         let nextSpy;
         let updateSpy;
         beforeEach(done => {
-            const listSub = widget.subscribeTo(list);
             prevSpy = sinon.spy();
             nextSpy = sinon.spy();
             updateSpy = sinon.spy();
             widget.on('carousel-previous', prevSpy);
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-update', updateSpy);
-            listSub.once('transitionend', () => {
-                listSub.once('transitionend', () => {
-                    listSub.once('transitionend', done);
+            waitForChange(widget, () => {
+                waitForChange(widget, () => {
+                    waitForChange(widget, done);
                     testUtils.triggerEvent(prevButton, 'click');
                 });
                 testUtils.triggerEvent(nextButton, 'click');
@@ -459,7 +461,7 @@ describe('given a discrete carousel', () => {
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             testUtils.triggerEvent(nextButton, 'click');
         });
 
@@ -515,7 +517,7 @@ describe('given a discrete carousel has next button clicked', () => {
         nextButton = root.querySelector('.carousel__control--next');
         prevButton = root.querySelector('.carousel__control--prev');
         waitForUpdate(widget, () => {
-            widget.subscribeTo(list).once('transitionend', () => {
+            waitForChange(widget, () => {
                 const { offsetLeft } = list.children[1];
                 expect(getTranslateX(list)).to.equal(offsetLeft);
                 done();
@@ -536,7 +538,7 @@ describe('given a discrete carousel has next button clicked', () => {
             widget.on('carousel-previous', prevSpy);
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             testUtils.triggerEvent(prevButton, 'click');
         });
 
@@ -596,7 +598,7 @@ describe('given a discrete carousel with half width items', () => {
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
         });
 
         it('then it emits the marko next event', () => testControlEvent(nextSpy));
@@ -637,7 +639,7 @@ describe('given a discrete carousel with half width items', () => {
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextSlideDot, 'click');
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
         });
 
         it('then it does not emit the marko next event', () => {
@@ -680,7 +682,7 @@ describe('given a discrete carousel with half width items', () => {
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-update', updateSpy);
             root.index = 4;
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
         });
 
         it('then it does not emit the marko next event', () => {
@@ -738,7 +740,7 @@ describe('given a discrete carousel with three half width items', () => {
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
         });
 
         it('then it emits the marko next event', () => testControlEvent(nextSpy));
@@ -805,7 +807,7 @@ describe('given a discrete carousel with a partial slide', () => {
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-update', updateSpy);
             testUtils.triggerEvent(nextButton, 'click');
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
         });
 
         it('then it emits the marko next event', () => testControlEvent(nextSpy));
@@ -865,7 +867,7 @@ describe('given an autoplay carousel in the default state', () => {
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-update', updateSpy);
             // Wait for both update events.
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
         });
 
         it('then it does not emit next or slide events', () => {
@@ -971,7 +973,7 @@ describe('given an autoplay carousel in the paused state', () => {
             updateSpy = sinon.spy();
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             testUtils.triggerEvent(playButton, 'click');
         });
 
@@ -1009,7 +1011,7 @@ describe('given an autoplay carousel in the paused state', () => {
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-previous', prevSpy);
             widget.on('carousel-update', updateSpy);
-            widget.subscribeTo(list).once('transitionend', done);
+            waitForChange(widget, done);
             testUtils.triggerEvent(prevButton, 'click');
         });
 
@@ -1044,13 +1046,6 @@ describe('given a carousel in the default state with native scrolling', () => {
     let widget;
     let root;
     let list;
-    let style;
-
-    before(() => {
-        style = document.createElement('style');
-        style.innerHTML = '.carousel__list { overflow: scroll; }';
-        document.body.appendChild(style);
-    });
 
     beforeEach(done => {
         widget = renderer.renderSync(input).appendTo(document.body).getWidget();
@@ -1060,7 +1055,6 @@ describe('given a carousel in the default state with native scrolling', () => {
     });
 
     afterEach(() => widget.destroy());
-    after(() => document.body.removeChild(style));
 
     describe('when scrolling an item to the right', () => {
         let nextSpy;
@@ -1074,7 +1068,9 @@ describe('given a carousel in the default state with native scrolling', () => {
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-scroll', scrollSpy);
-            testUtils.simulateScroll(list, list.children[2].offsetLeft);
+            setTimeout(() => {
+                testUtils.simulateScroll(list, list.children[2].offsetLeft);
+            }, 200);
             waitForChange(widget, done);
         });
 
@@ -1113,7 +1109,11 @@ describe('given a carousel in the default state with native scrolling', () => {
             widget.on('carousel-next', nextSpy);
             widget.on('carousel-slide', slideSpy);
             widget.on('carousel-scroll', scrollSpy);
-            testUtils.simulateScroll(list, list.children[1].offsetLeft);
+            setTimeout(() => {
+                const secondChild = list.children[1];
+                const halfwayThroughSecondChild = secondChild.offsetLeft + (secondChild.offsetWidth / 2) + 10;
+                testUtils.simulateScroll(list, halfwayThroughSecondChild);
+            }, 200);
             waitForChange(widget, done);
         });
 

--- a/src/components/ebay-carousel/utils/on-scroll-debounced/index.js
+++ b/src/components/ebay-carousel/utils/on-scroll-debounced/index.js
@@ -1,0 +1,30 @@
+const eventOptions = { passive: true };
+
+module.exports = function onScrollDebounced(el, cb) {
+    let timeout;
+    waitForScroll();
+    return cancel;
+
+    function waitForScroll() {
+        el.addEventListener('scroll', handleScroll, eventOptions);
+    }
+
+    function handleScroll() {
+        cancelWaitForScroll();
+        timeout = setTimeout(finish, 640);
+    }
+
+    function finish() {
+        cb();
+        waitForScroll();
+    }
+
+    function cancelWaitForScroll() {
+        el.removeEventListener('scroll', handleScroll, eventOptions);
+    }
+
+    function cancel() {
+        cancelWaitForScroll();
+        clearTimeout(timeout);
+    }
+};

--- a/src/components/ebay-carousel/utils/on-scroll-debounced/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/on-scroll-debounced/test/test.browser.js
@@ -1,0 +1,48 @@
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const testUtils = require('../../../../../common/test-utils/browser');
+const onScroll = require('../');
+
+describe('scroll-debounced', () => {
+    let scrollEl;
+
+    before(() => {
+        scrollEl = document.createElement('div');
+        scrollEl.style.overflowX = 'scroll';
+        scrollEl.innerHTML = `<div style="width: 200%; border: 25px dashed #000;"></div>`;
+        document.body.appendChild(scrollEl);
+    });
+
+    beforeEach(() => {
+        scrollEl.scrollLeft = 0;
+    });
+
+    after(() => {
+        document.body.removeChild(scrollEl);
+    });
+
+    it('calls a handler at most every 600ms', (done) => {
+        const scrollSpy = sinon.spy();
+        onScroll(scrollEl, scrollSpy);
+        testUtils.simulateScroll(scrollEl, 50, () => {
+            testUtils.simulateScroll(scrollEl, 100, () => {
+                setTimeout(() => {
+                    expect(scrollSpy.calledOnce).to.equal(true);
+                    done();
+                }, 400);
+            });
+        });
+    });
+
+    it('can be canceled', (done) => {
+        const scrollEndSpy = sinon.spy();
+        const cancel = onScroll(scrollEl, scrollEndSpy);
+        testUtils.simulateScroll(scrollEl, 100);
+        setTimeout(() => {
+            expect(scrollEndSpy.notCalled).to.equal(true);
+            done();
+        }, 700);
+
+        cancel();
+    });
+});

--- a/src/components/ebay-carousel/utils/on-scroll-end/index.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/index.js
@@ -1,81 +1,31 @@
 /**
- * Calls a function every time scrolling completes for an element.
- * Returns a function to stop listening for scroll ends events.
- *
- * (Only works in mobile and relies on touch events)
+ * Checks on an interval to see if the element is scrolling.
+ * When the scrolling has finished it then calls the function.
  *
  * @param {HTMLElement} el The element which scrolls.
  * @param {(offset: number)=>{}} fn The function to call after scrolling completes.
  * @return {function} A function to cancel the scroll listener.
  */
 module.exports = function onScrollEnd(el, fn) {
-    let frame;
     let timeout;
-    let stage = 0;
-    el.addEventListener('touchmove', handleTouchMove);
+    let frame;
+    let lastPos;
 
-    return cancel;
-
-    // First we wait for a touch move (means scrolling as started).
-    function handleTouchMove() {
-        stage++;
-        cancelTouchMove();
-        el.addEventListener('touchend', handleTouchEnd);
-    }
-
-    // Then we wait for the touch to end (user has stopped scrolling).
-    function handleTouchEnd() {
-        stage++;
-        cancelTouchEnd();
-        el.addEventListener('touchstart', handleTouchStart);
-        frame = requestAnimationFrame(() => checkScrollEnded(el.scrollLeft));
-    }
-
-    // If the user touches again before the inertial scrolling has stopped then we reset.
-    function handleTouchStart() {
-        cancel();
-        stage--;
-        el.addEventListener('touchend', handleTouchEnd);
-    }
-
-    // Finally after the touch end we poll the scroll state every animation frame
-    // to determine when inertial scrolling has stopped.
-    function checkScrollEnded(lastOffset) {
-        timeout = setTimeout(() => {
-            frame = requestAnimationFrame(() => {
-                const newOffset = el.scrollLeft;
-                if (lastOffset !== newOffset) {
-                    checkScrollEnded(newOffset);
-                } else {
-                    cancelTouchStart();
-                    fn(newOffset);
-                    stage = 0;
-                    el.addEventListener('touchmove', handleTouchMove);
-                }
-            });
-        }, 64);
-    }
-
-    function cancelTouchMove() {
-        el.removeEventListener('touchmove', handleTouchMove);
-    }
-
-    function cancelTouchEnd() {
-        el.removeEventListener('touchend', handleTouchEnd);
-    }
-
-    function cancelTouchStart() {
-        el.removeEventListener('touchstart', handleTouchStart);
-    }
-
-    function cancel() {
-        cancelAnimationFrame(frame);
-        clearTimeout(timeout);
-
-        switch (stage) {
-            case 0: cancelTouchMove(); break;
-            case 1: cancelTouchEnd(); break;
-            default: cancelTouchStart(); break;
+    (function checkMoved() {
+        const { scrollLeft } = el;
+        if (lastPos !== scrollLeft) {
+            lastPos = scrollLeft;
+            timeout = setTimeout(() => {
+                frame = requestAnimationFrame(checkMoved);
+            }, 90);
+            return;
         }
-    }
+
+        fn(lastPos);
+    }());
+
+    return () => {
+        clearTimeout(timeout);
+        cancelAnimationFrame(frame);
+    };
 };

--- a/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/on-scroll-end/test/test.browser.js
@@ -25,12 +25,11 @@ describe('scroll-end', () => {
         const scrollEndSpy = sinon.spy();
         onScrollEnd(scrollEl, scrollEndSpy);
         testUtils.simulateScroll(scrollEl, 50, () => {
-            testUtils.simulateScroll(scrollEl, 100, () => {
-                expect(scrollEndSpy.calledTwice).to.equal(true);
+            setTimeout(() => {
+                expect(scrollEndSpy.calledOnce).to.equal(true);
                 expect(scrollEndSpy.args[0][0]).to.equal(50);
-                expect(scrollEndSpy.args[1][0]).to.equal(100);
                 done();
-            });
+            }, 250);
         });
     });
 
@@ -39,9 +38,11 @@ describe('scroll-end', () => {
         onScrollEnd(scrollEl, scrollEndSpy);
         setTimeout(() => {
             testUtils.simulateScroll(scrollEl, 100, () => {
-                expect(scrollEndSpy.calledOnce).to.equal(true);
-                expect(scrollEndSpy.args[0][0]).to.equal(100);
-                done();
+                setTimeout(() => {
+                    expect(scrollEndSpy.calledOnce).to.equal(true);
+                    expect(scrollEndSpy.args[0][0]).to.equal(100);
+                    done();
+                }, 250);
             });
         }, 0);
         testUtils.simulateScroll(scrollEl, 50);

--- a/src/components/ebay-carousel/utils/scroll-transition/index.js
+++ b/src/components/ebay-carousel/utils/scroll-transition/index.js
@@ -1,3 +1,6 @@
+const onScrollEnd = require('../on-scroll-end');
+const supportsScrollBehavior = typeof window !== 'undefined' && 'scrollBehavior' in document.body.style;
+
 /**
  * Utility to animate scroll position of an element using an `ease-out` curve over 250ms.
  * Cancels the animation if the user touches back down.
@@ -8,11 +11,16 @@
  * @return {function} A function that cancels the transition.
  */
 module.exports = function scrollTransition(el, to, fn) {
-    const duration = 250;
+    if (supportsScrollBehavior) {
+        el.scrollTo({ left: to });
+        return onScrollEnd(el, fn);
+    }
+
     let lastPosition, cancelInterruptTransition;
     let frame = requestAnimationFrame(startTime => {
         const { scrollLeft } = el;
         const distance = to - scrollLeft;
+        const duration = 450;
         (function animate(curTime) {
             const delta = curTime - startTime;
             if (delta > duration) {

--- a/src/components/ebay-carousel/utils/scroll-transition/test/test.browser.js
+++ b/src/components/ebay-carousel/utils/scroll-transition/test/test.browser.js
@@ -1,6 +1,5 @@
 const sinon = require('sinon');
 const expect = require('chai').expect;
-const testUtils = require('../../../../../common/test-utils/browser');
 const scrollTransition = require('../');
 
 describe('scroll-transition', () => {
@@ -28,39 +27,15 @@ describe('scroll-transition', () => {
         });
     });
 
-    it('cancels the transition on additional touches', (done) => {
+    it('does not call finish function if scroll is canceled', (done) => {
         const spy = sinon.spy();
+        const cancel = scrollTransition(scrollEl, 100, spy);
         setTimeout(() => {
-            testUtils.triggerEvent(scrollEl, 'touchstart');
+            cancel();
             setTimeout(() => {
-                expect(scrollEl.scrollLeft).to.not.equal(0);
-                expect(scrollEl.scrollLeft).to.not.equal(100);
                 expect(spy.callCount).to.equal(0);
                 done();
             }, 300);
         }, 50);
-
-        scrollTransition(scrollEl, 100, spy);
-    });
-
-    it('continues a canceled transition if the touch event does not move', (done) => {
-        const spy = sinon.spy();
-        setTimeout(() => {
-            testUtils.triggerEvent(scrollEl, 'touchstart');
-            setTimeout(() => {
-                expect(scrollEl.scrollLeft).to.not.equal(0);
-                expect(scrollEl.scrollLeft).to.not.equal(100);
-                expect(spy.callCount).to.equal(0);
-                testUtils.triggerEvent(scrollEl, 'touchend');
-
-                setTimeout(() => {
-                    expect(scrollEl.scrollLeft).to.equal(100);
-                    expect(spy.callCount).to.equal(1);
-                    done();
-                }, 300);
-            }, 300);
-        }, 50);
-
-        scrollTransition(scrollEl, 100, spy);
     });
 });


### PR DESCRIPTION
## Description
This PR switches the carousel to prefer using native scrolling with [css snap points](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap_Points) where available.
If the browser does not support one of the variants of css snap points then it falls back to using transforms without native scrolling.

This also has support for native scrolling (with snap points) using trackpads on desktop.

## Context
The reason I decided to make the fallback just the simple transform based implementation is:
a) It seems that most mobile browsers support the css snap points (or some version of it) 🎉.
b) This allows for the exist events to stay as is and work in all cases they used to work.
c) Should ensure a working experience for basically all devices.

## References
implements #476 
fixes #466 
fixes #465 
fixes #463 

## Notes
Because it is impossible to speed up these native scroll animations the tests now take a chunk longer to run.

## Screenshots
![native-scrolling-carousel](https://user-images.githubusercontent.com/4985201/48293106-5d52b800-e432-11e8-831b-c575b95c8521.gif)
