### PR TITLE
Dialog: fix scroll restoration with multiple quick renders.

### DIFF
--- a/src/common/body-scroll/index.js
+++ b/src/common/body-scroll/index.js
@@ -18,30 +18,32 @@ module.exports = { prevent, restore };
  * scrolling.
  */
 function prevent() {
-    const { body } = document;
-    const { pageXOffset, pageYOffset } = window;
-    const { width, height, marginTop, marginLeft } = getComputedStyle(body);
-    let styleText = 'position:fixed;overflow:hidden;';
-    previousPosition = [pageXOffset, pageYOffset];
-    previousStyles = body.getAttribute('style');
-    styleText += `height:${height};`;
-    styleText += `width:${width};`;
+    if (!isPrevented) {
+        const { body } = document;
+        const { pageXOffset, pageYOffset } = window;
+        const { width, height, marginTop, marginLeft } = getComputedStyle(body);
+        let styleText = 'position:fixed;overflow:hidden;';
+        previousPosition = [pageXOffset, pageYOffset];
+        previousStyles = body.getAttribute('style');
+        styleText += `height:${height};`;
+        styleText += `width:${width};`;
 
-    if (pageYOffset) {
-        styleText += `margin-top:${-1 * (pageYOffset - parseInt(marginTop, 10))}px;`;
+        if (pageYOffset) {
+            styleText += `margin-top:${-1 * (pageYOffset - parseInt(marginTop, 10))}px;`;
+        }
+
+        if (pageXOffset) {
+            styleText += `margin-left:${-1 * (pageXOffset - parseInt(marginLeft, 10))}px`;
+        }
+
+        if (previousStyles) {
+            styleText = `${previousStyles};${styleText}`;
+        }
+
+        body.setAttribute('style', styleText);
+        resizeUtil.addEventListener('', recalculate);
+        isPrevented = true;
     }
-
-    if (pageXOffset) {
-        styleText += `margin-left:${-1 * (pageXOffset - parseInt(marginLeft, 10))}px`;
-    }
-
-    if (previousStyles) {
-        styleText = `${previousStyles};${styleText}`;
-    }
-
-    body.setAttribute('style', styleText);
-    resizeUtil.addEventListener('', recalculate);
-    isPrevented = true;
 }
 
 /**

--- a/src/common/body-scroll/test/test.browser.js
+++ b/src/common/body-scroll/test/test.browser.js
@@ -62,4 +62,19 @@ describe('body-scroll', () => {
 
         body.removeAttribute('style');
     });
+
+    test('restores the correct styles when prevented multiple times', () => {
+        expect(body.getAttribute('style')).to.equal(null);
+        bodyScroll.prevent();
+        bodyScroll.prevent();
+        bodyScroll.prevent();
+        expect(body.getAttribute('style'))
+            .to.contain('overflow:hidden')
+            .and.to.contain('position:fixed')
+            .and.to.not.contain('margin-top')
+            .and.to.not.contain('margin-left');
+
+        bodyScroll.restore();
+        expect(body.getAttribute('style')).to.equal(null);
+    });
 });


### PR DESCRIPTION
## Description
Currently if you render multiple dialogs open at the same time (probably shouldn't do that) or you render the same dialog open really quickly (we're talking during the update of the dialog) it will cause the previous body styles to be in the scroll lock state. The effect is that the user won't be able to scroll any more.

## Context
The fix is simple which is to just check that we have not already prevent scrolling before we store the `previousStyles` or lock the scrolling.

## References
fixes #480 
