### PR TITLE
Carousel: Fix styles when minified with yui-compressor

### DIFF
--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -150,10 +150,11 @@
  * Not all browsers that have implemented scroll snapping have done so in a way that we can leverage.
  * Currently the below media query ensures that the browser supports exactly what we need.
  */
+/* autoprefixer: off */
 @supports (
-    (-webkit-scroll-snap-coordinate: 0 0) or
-    (-ms-scroll-snap-coordinate: 0 0) or
-    (scroll-snap-coordinate: 0 0) or
+    (-webkit-scroll-snap-coordinate: 0 0) or/*!*/
+    (-ms-scroll-snap-coordinate: 0 0) or/*!*/
+    (scroll-snap-coordinate: 0 0) or/*!*/
     (scroll-snap-align: start)
 ) {
     .carousel {
@@ -191,3 +192,4 @@
         }
     }
 }
+/* autoprefixer: on */


### PR DESCRIPTION
## Description
Currently the resource server improperly minifies the css for the carousel because it uses `yui-compressor` under the hood. This change adds spacer comments to ensure that the `@supports` rule can still be parsed properly after minification.

## References
Fixes #504
