### PR TITLE
Textbox: add floating label support (#503)

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -299,7 +299,8 @@
         "@multiline": "boolean",
         "@icon": "string",
         "@icon-position": "string",
-        "@iconTag <icon>": {}
+        "@iconTag <icon>": {},
+        "@floating-label": "string"
     }
   }
   

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "makeup-expander": "~0.5.0",
+    "makeup-floating-label": "~0.0.2",
     "makeup-focusables": "~0.0.3",
     "makeup-key-emitter": "~0.0.3",
     "makeup-keyboard-trap": "~0.1.0",

--- a/src/components/ebay-textbox/browser.json
+++ b/src/components/ebay-textbox/browser.json
@@ -3,6 +3,7 @@
     {
       "if-not-flag": "ebayui-no-skin",
       "dependencies": [
+        "@ebay/skin/label",
         "@ebay/skin/textbox"
       ]
     },

--- a/src/components/ebay-textbox/examples/14-floating-label/template.marko
+++ b/src/components/ebay-textbox/examples/14-floating-label/template.marko
@@ -1,0 +1,1 @@
+<ebay-textbox floating-label="Email address" />

--- a/src/components/ebay-textbox/examples/15-floating-label-with-value/template.marko
+++ b/src/components/ebay-textbox/examples/15-floating-label-with-value/template.marko
@@ -1,0 +1,1 @@
+<ebay-textbox floating-label="Email address" value="test" />

--- a/src/components/ebay-textbox/examples/16-floating-label-with-placeholder/template.marko
+++ b/src/components/ebay-textbox/examples/16-floating-label-with-placeholder/template.marko
@@ -1,0 +1,1 @@
+<ebay-textbox floating-label="Email address" placeholder="placeholder text" />

--- a/src/components/ebay-textbox/examples/17-floating-label-disabled/template.marko
+++ b/src/components/ebay-textbox/examples/17-floating-label-disabled/template.marko
@@ -1,0 +1,1 @@
+<ebay-textbox floating-label="Email address" disabled />

--- a/src/components/ebay-textbox/examples/18-floating-label-invalid/template.marko
+++ b/src/components/ebay-textbox/examples/18-floating-label-invalid/template.marko
@@ -1,0 +1,1 @@
+<ebay-textbox floating-label="Email address" invalid />

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -1,4 +1,5 @@
 const markoWidgets = require('marko-widgets');
+const FloatingLabel = require('makeup-floating-label');
 const emitAndFire = require('../../common/emit-and-fire');
 const processHtmlAttributes = require('../../common/html-attributes');
 const template = require('./template.marko');
@@ -8,16 +9,24 @@ function getInitialState(input) {
     if (input.fluid) {
         classes.push('textbox__control--fluid');
     }
+    if (input.floatingLabel) {
+        classes.push('textbox__control--underline');
+    }
     const displayIcon = Boolean(input.icon && !input.multiline && input.iconTag);
     const iconPostfix = input.iconPosition === 'postfix';
     const iconPrefix = input.iconPosition === 'prefix' || !iconPostfix;
     const rootClasses = ['textbox', input.class];
+    const labelClasses = ['floating-label__label'];
+    const htmlAttributes = processHtmlAttributes(input);
     if (displayIcon && iconPostfix) {
         rootClasses.push('textbox--icon-end');
     }
+    if (htmlAttributes.disabled) {
+        labelClasses.push('floating-label__label--disabled');
+    }
 
     return {
-        htmlAttributes: processHtmlAttributes(input),
+        htmlAttributes,
         rootClass: rootClasses,
         style: input.style,
         classes,
@@ -28,12 +37,20 @@ function getInitialState(input) {
         iconPostfix,
         tag: input.fluid ? 'div' : 'span',
         textboxTag: Boolean(input.multiline) ? 'textarea' : 'input',
-        invalid: String(Boolean(input.invalid))
+        invalid: String(Boolean(input.invalid)),
+        floatingLabel: input.floatingLabel,
+        labelClasses
     };
 }
 
 function getTemplateData(state) {
     return state;
+}
+
+function init() {
+    if (this.state.floatingLabel) {
+        this.floatingLabel = new FloatingLabel(this.el);
+    }
 }
 
 function handleEvent(originalEvent, eventName) {
@@ -49,6 +66,7 @@ module.exports = markoWidgets.defineComponent({
     template,
     getInitialState,
     getTemplateData,
+    init,
     handleEvent,
     handleChange,
     handleInput,

--- a/src/components/ebay-textbox/template.marko
+++ b/src/components/ebay-textbox/template.marko
@@ -1,4 +1,11 @@
 <${data.tag} class=data.rootClass style=data.style w-bind>
+    <if (data.floatingLabel)>
+        <label
+        class=data.labelClasses
+        w-for="textbox">
+            ${data.floatingLabel}
+        </label>
+    </if>
     <if (data.displayIcon && data.iconPrefix)>
         <span body-only-if(true) w-body=data.iconTag/>
     </if>
@@ -10,6 +17,7 @@
     w-oninput="handleInput"
     w-onfocus="handleFocus"
     w-onblur="handleBlur"
+    w-id="textbox"
     ${data.htmlAttributes} />
     <if (data.displayIcon && data.iconPostfix)>
         <span body-only-if(true) w-body=data.iconTag/>

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -33,3 +33,33 @@ describe('given an input textbox', () => {
         });
     });
 });
+
+describe('given an input textbox with floating label', () => {
+    let root;
+    let input;
+    let label;
+    beforeEach(() => {
+        widget = renderer.renderSync({ 'floatingLabel': 'Email address' }).appendTo(document.body).getWidget();
+        root = document.querySelector('.textbox');
+        input = root.querySelector('input');
+        label = root.querySelector('label');
+    });
+    afterEach(() => widget.destroy());
+
+    describe('when the input is focused', () => {
+        test('then the inline class is removed', () => {
+            expect(label.classList.contains('floating-label__label--inline')).to.equal(true);
+            testUtils.triggerEvent(input, 'focus');
+            expect(label.classList.contains('floating-label__label--inline')).to.equal(false);
+        });
+    });
+
+    describe('when the input is blurred', () => {
+        test('then the inline class is added', () => {
+            label.classList.remove('floating-label__label--inline');
+            expect(label.classList.contains('floating-label__label--inline')).to.equal(false);
+            testUtils.triggerEvent(input, 'blur');
+            expect(label.classList.contains('floating-label__label--inline')).to.equal(true);
+        });
+    });
+});

--- a/src/components/ebay-textbox/test/test.server.js
+++ b/src/components/ebay-textbox/test/test.server.js
@@ -10,6 +10,9 @@ const fluidInputSelector = `input.textbox__control--fluid`;
 const textareaSelector = `textarea.textbox__control`;
 const iconSelector = `svg.textbox__icon`;
 const inputPostfixSelector = `span.textbox--icon-end`;
+const floatingLabelSelector = `label.floating-label__label`;
+const floatingLabelDisabledSelector = `label.floating-label__label.floating-label__label--disabled`;
+const inputUnderlineSelector = `input.textbox__control.textbox__control--underline`;
 
 describe('ebay-textbox', () => {
     test('renders default input textbox', context => {
@@ -48,6 +51,20 @@ describe('ebay-textbox', () => {
         const $ = testUtils.getCheerio(context.render(input));
         expect($(inputPostfixSelector).length).to.equal(1);
         expect($(iconSelector).length).to.equal(1);
+    });
+
+    test('renders an input textbox with inline floating label', context => {
+        const input = { floatingLabel: 'Email address' };
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($(floatingLabelSelector).text()).to.equal('Email address');
+        expect($(inputUnderlineSelector).length).to.equal(1);
+    });
+
+    test('renders a disabled input textbox with disabled floating label', context => {
+        const input = { floatingLabel: 'Email address', value: 'test@ebay.com', htmlAttributes: { disabled: true } };
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($(floatingLabelDisabledSelector).text()).to.equal('Email address');
+        expect($(inputUnderlineSelector).length).to.equal(1);
     });
 
     test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, inputSelector));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6364,6 +6364,10 @@ makeup-expander@~0.5.0:
     makeup-focusables "~0.0.3"
     makeup-next-id "~0.0.2"
 
+makeup-floating-label@~0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.0.2.tgz#07e65c936f1556f72e60a9d719716ed106dbdf35"
+
 makeup-focusables@~0.0.3:
   version "0.0.3"
   resolved "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.0.3.tgz#e30f36a99beb7c5166daafb8f823fefcc7a551fa"


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
Add support for floating label for ebay-textbox. 

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Allow ebay-textbox to leverage existing Skin styling. 

Make use of [makeup-floating-label](https://github.com/makeup-js/makeup-floating-label) in ebay-textbox to toggle necessary classes and create floating effect. This is the same package already used on the Skin GitHub Page to demo Label/floating label.

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Closes #503 
Jira Ticket: https://jirap.corp.ebay.com/browse/EBAYUI-189
Supporting skin update for DS4 support: https://github.com/eBay/skin/pull/508

## Screenshots
<!-- Upload screenshots if appropriate. -->
### DS4
![image](https://user-images.githubusercontent.com/6880917/51067192-a8b94c00-15c4-11e9-8d06-d616a14c8a80.png)

### DS6
![image](https://user-images.githubusercontent.com/6880917/51067186-9b03c680-15c4-11e9-845b-fe23458fd2a2.png)
