### PR TITLE
Tabs: Fix keyboard arrow keys a11y (#422)

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -267,6 +267,7 @@
         "@style": "string",
         "@index": "string",
         "@fake": "boolean",
+        "@activation": "string",
         "@headings <heading>[]": {
             "@*": "expression",
             "@html-attributes": "expression",

--- a/src/common/event-utils/index.js
+++ b/src/common/event-utils/index.js
@@ -24,6 +24,10 @@ function handleUpDownArrowsKeydown(e, callback) {
     handleKeydown([38, 40], e, callback);
 }
 
+function handleLeftRightArrowsKeydown(e, callback) {
+    handleKeydown([37, 39], e, callback);
+}
+
 function preventDefaultIfHijax(e, hijax) {
     if (hijax) {
         e.preventDefault();
@@ -57,6 +61,7 @@ module.exports = {
     handleActionKeydown,
     handleEscapeKeydown,
     handleUpDownArrowsKeydown,
+    handleLeftRightArrowsKeydown,
     preventDefaultIfHijax,
     resizeUtil: {
         addEventListener,

--- a/src/common/event-utils/test/test.browser.js
+++ b/src/common/event-utils/test/test.browser.js
@@ -7,6 +7,7 @@ const testUtils = require('../../test-utils/browser');
 const handleActionKeydown = eventUtils.handleActionKeydown;
 const handleEscapeKeydown = eventUtils.handleEscapeKeydown;
 const handleUpDownArrowsKeydown = eventUtils.handleUpDownArrowsKeydown;
+const handleLeftRightArrowsKeydown = eventUtils.handleLeftRightArrowsKeydown;
 const preventDefaultIfHijax = eventUtils.preventDefaultIfHijax;
 
 describe('handleActionKeydown()', () => {
@@ -52,6 +53,25 @@ describe('handleUpDownArrowsKeydown()', () => {
     test('doesn\'t call callback for other keyCode', () => {
         const callback = sinon.spy();
         handleUpDownArrowsKeydown({ keyCode: 1 }, callback);
+        expect(callback.called).to.equal(false);
+    });
+});
+
+describe('handleLeftRightArrowsKeydown()', () => {
+    [
+        { keyCode: 37 },
+        { keyCode: 39 }
+    ].forEach(event => {
+        test(`calls callback for keyCode=${event.keyCode}`, () => {
+            const callback = sinon.spy();
+            handleLeftRightArrowsKeydown(event, callback);
+            expect(callback.calledOnce).to.equal(true);
+        });
+    });
+
+    test('doesn\'t call callback for other keyCode', () => {
+        const callback = sinon.spy();
+        handleLeftRightArrowsKeydown({ keyCode: 1 }, callback);
         expect(callback.called).to.equal(false);
     });
 });

--- a/src/components/ebay-tab/README.md
+++ b/src/components/ebay-tab/README.md
@@ -19,6 +19,7 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `index` | String | Yes | 0-based index of selected tab heading and panel
 `fake` | Boolean | No | Whether to use link behavior for tab headings
+`activation` | String | Yes | whether to use automatic or manual activation when navigating by keyboard, "auto" (default) / "manual"
 
 ## ebay-tab Events
 

--- a/src/components/ebay-tab/examples/05-manual-activation/template.marko
+++ b/src/components/ebay-tab/examples/05-manual-activation/template.marko
@@ -1,0 +1,17 @@
+<ebay-tab activation="manual">
+    <ebay-tab-heading>Tab 1</ebay-tab-heading>
+    <ebay-tab-heading>Tab 2</ebay-tab-heading>
+    <ebay-tab-heading>Tab 3</ebay-tab-heading>
+    <ebay-tab-panel>
+        <h3>Panel 1</h3>
+        <p>1. Lorem ipsum dolor sit amet</p>
+    </ebay-tab-panel>
+    <ebay-tab-panel>
+        <h3>Panel 2</h3>
+        <p>2. Lorem ipsum dolor sit amet</p>
+    </ebay-tab-panel>
+    <ebay-tab-panel>
+        <h3>Panel 3</h3>
+        <p>3. Lorem ipsum dolor sit amet</p>
+    </ebay-tab-panel>
+</ebay-tab>

--- a/src/components/ebay-tab/template.marko
+++ b/src/components/ebay-tab/template.marko
@@ -1,4 +1,4 @@
-<div w-bind class=data.classes style=data.style ${data.htmlAttributes}>
+<div w-bind class=data.classes style=data.style activation=data.activation ${data.htmlAttributes}>
     <if(data.fake)>
         <ul class="fake-tabs__items">
             <for(i, heading in data.headings)>

--- a/src/components/ebay-tab/test/test.browser.js
+++ b/src/components/ebay-tab/test/test.browser.js
@@ -31,6 +31,7 @@ describe('given tabs with first heading selected', () => {
     let headingEls;
     let firstHeadingEl;
     let secondHeadingEl;
+    let thirdHeadingEl;
     let secondHeadingInnerEl;
 
     beforeEach(() => {
@@ -39,6 +40,7 @@ describe('given tabs with first heading selected', () => {
         headingEls = document.querySelectorAll('.tabs__item');
         firstHeadingEl = headingEls[0];
         secondHeadingEl = headingEls[1];
+        thirdHeadingEl = headingEls[2];
         secondHeadingInnerEl = secondHeadingEl.querySelector('span');
     });
     afterEach(() => widget.destroy());
@@ -104,6 +106,74 @@ describe('given tabs with first heading selected', () => {
 
         test('then it emits the select event with correct data', () => testSelectEvent(spy, 1));
         test('then the heading is selected', (context, done) => testSelectBehavior(secondHeadingEl, done));
+    });
+
+    describe('when the second heading is selected via keyboard right arrow key', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('tab-select', spy);
+            testUtils.triggerEvent(firstHeadingEl, 'keydown', 39);
+        });
+
+        test('then it emits the select event with correct data', () => testSelectEvent(spy, 1));
+        test('then the heading is selected', (context, done) => testSelectBehavior(secondHeadingEl, done));
+    });
+
+    describe('when the third heading is selected via keyboard left arrow key', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('tab-select', spy);
+            testUtils.triggerEvent(firstHeadingEl, 'keydown', 37);
+        });
+
+        test('then it emits the select event with correct data', () => testSelectEvent(spy, 2));
+        test('then the heading is selected', (context, done) => testSelectBehavior(thirdHeadingEl, done));
+    });
+});
+
+describe('given tabs with third heading selected', () => {
+    let widget;
+    let headingEls;
+    let firstHeadingEl;
+    let secondHeadingEl;
+    let thirdHeadingEl;
+
+    beforeEach(() => {
+        widget = renderer.renderSync({
+            headings: mock.headings,
+            index: 2
+        }).appendTo(document.body).getWidget();
+        headingEls = document.querySelectorAll('.tabs__item');
+        firstHeadingEl = headingEls[0];
+        secondHeadingEl = headingEls[1];
+        thirdHeadingEl = headingEls[2];
+    });
+    afterEach(() => widget.destroy());
+
+    describe('when the second heading is selected via keyboard left arrow key', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('tab-select', spy);
+            testUtils.triggerEvent(thirdHeadingEl, 'keydown', 37);
+        });
+
+        test('then it emits the select event with correct data', () => testSelectEvent(spy, 1));
+        test('then the heading is selected', (context, done) => testSelectBehavior(secondHeadingEl, done));
+    });
+
+    describe('when the first heading is selected via keyboard right arrow key', () => {
+        let spy;
+        beforeEach(() => {
+            spy = sinon.spy();
+            widget.on('tab-select', spy);
+            testUtils.triggerEvent(thirdHeadingEl, 'keydown', 39);
+        });
+
+        test('then it emits the select event with correct data', () => testSelectEvent(spy, 0));
+        test('then the heading is selected', (context, done) => testSelectBehavior(firstHeadingEl, done));
     });
 });
 


### PR DESCRIPTION
## Description
<!--- What are the changes? -->
Fix keyboard accessibility for Tabs component to be consistent with MIND patterns, specifically allowing for navigation through tabs by arrow keys.

## Context
<!--- Why did you make these changes, and why in this particular way? -->
* Adds new functionality where user can navigate through tabs via `left` and `right` arrow keys. Navigation loops between first and last tab headings if the user tries to navigate beyond them.
* Adds new attribute `activation` which determines whether the keyboard navigation is `auto` or `manual`. 
  * `auto` is default, and is the recommended default in WAI-ARIA. Tabs activate automatically as the user navigates.
  * `manual` is recommended in WAI-ARIA for cases where tabpanel content is not preloaded, and requires a service call, so as to avoid slowing down the experience when navigating through multiple tab headings. Focus follows arrow key actions, but requires `enter` or `space` to activate the tab.
* Changes to existing keyboard interaction: per MIND patterns and WAI-ARIA 1.1, `left`/`right` arrow keys and `space` no longer scroll the page if tab headings are focused.

### Existing issues to be resolved in later PRs
* Hybrid mouse and keyboard functionality is not fully supported, as clicks do not seem to update the tabindex, so can throw off the tab order (resolved if a user tabs off the headings, tabs back, and resume arrow key navigation)
* In manual activation, `makeup-roving-tabindex` is following focus, not activation. E.g. if tab 1 is activated, user arrow keys to tab 2, navigates out of tab headings and navigates back on, then the focus is brought to tab 2 again, even though tab 1 is still activated. Not necessarily an issue, depending on user expectation, as user has visual affordance of the focus outline on tab 2 and activated CSS on tab 1, as well as screen reader announcing focus on tab 2 (but would not say it was selected).

## References 
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Closes #422 
JIRA ticket: https://jirap.corp.ebay.com/browse/EBAYUI-194
MIND patterns: https://ebay.gitbooks.io/mindpatterns/content/disclosure/tabs.html
MIND patterns tabs example: http://ebay.github.io/mindpatterns/disclosure/tabs/
WAI-ARIA 1.1 Practices for tabs: https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel
WAI-ARIA 1.1 Example for tabs: https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-2/tabs.html

## Screenshots
<!-- Upload screenshots if appropriate. -->
### Automatic activation tabs
![tabs-auto](https://user-images.githubusercontent.com/6880917/51415084-6b574000-1b29-11e9-8eba-47faa7d56114.gif)

### Manual activation tabs
![tabs-manual](https://user-images.githubusercontent.com/6880917/51415093-76aa6b80-1b29-11e9-9310-ccecd6f57204.gif)