### PR TITLE
Carousel: Parse `gap` attribute string as number

### DIFF
--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -17,7 +17,7 @@ function getInitialState(input) {
         classes: ['carousel', input.class],
         style: input.style,
         config: {}, // A place to store values that should not trigger an update by themselves.
-        gap: input.gap || 16,
+        gap: parseInt(input.gap, 10) || 16,
         noDots: input.noDots,
         index: parseInt(input.index, 10) || 0,
         itemsPerSlide: parseFloat(input.itemsPerSlide, 10) || undefined,

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -12,12 +12,13 @@ const LEFT = -1;
 const RIGHT = 1;
 
 function getInitialState(input) {
+    const gap = parseInt(input.gap, 10);
     const state = {
         htmlAttributes: processHtmlAttributes(input),
         classes: ['carousel', input.class],
         style: input.style,
         config: {}, // A place to store values that should not trigger an update by themselves.
-        gap: parseInt(input.gap, 10) || 16,
+        gap: isNaN(gap) ? 16 : gap,
         noDots: input.noDots,
         index: parseInt(input.index, 10) || 0,
         itemsPerSlide: parseFloat(input.itemsPerSlide, 10) || undefined,


### PR DESCRIPTION
## Description
Currently the `<carousel>` `gap` attribute will not be parsed properly if a string is provided.
