### PR TITLE
Fixing wrapping issue by re-instituting a span;

### DIFF
--- a/src/components/ebay-menu/template.marko
+++ b/src/components/ebay-menu/template.marko
@@ -33,11 +33,13 @@
                 w-onkeydown="handleItemKeydown"
                 w-preserve-attrs="tabindex,data-makeup-index"
                 ${item.htmlAttributes}>
-                <span body-only-if(!item.badgeNumber) aria-hidden='true'>
-                    <span body-only-if(true) w-body=item.renderBody/>
-                    <if(item.badgeNumber)>
-                        <ebay-badge type='menu' number=item.badgeNumber/>
-                    </if>
+                <span w-preserve-body>
+                    <span body-only-if(!item.badgeNumber) aria-hidden='true'>
+                        <span body-only-if(true) w-body=item.renderBody/>
+                        <if(item.badgeNumber)>
+                            <ebay-badge type='menu' number=item.badgeNumber/>
+                        </if>
+                    </span>
                 </span>
                 <span if(item.useCheckIcon) class="menu__status"/>
             </>


### PR DESCRIPTION
## Description
- adds an additional span inside the `<ebay-menu-item>`
- preserves the body on render

## Context
The menu was reported as looking funky in #517, and it was also reported that we removed a span which helped to properly truncate and keep the content from wrapping.

## References
Fixes #517 

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/3631216/51913240-137bcd00-23a4-11e9-87e7-a1f8694cb451.png)

### After
![image](https://user-images.githubusercontent.com/105656/51960389-11eaed00-2416-11e9-868d-ffd881e45932.png)

