### PR TITLE
Fix docs for incorrect priority option;

### DIFF
--- a/src/components/ebay-pill/README.md
+++ b/src/components/ebay-pill/README.md
@@ -10,7 +10,6 @@
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`priority` | String | No | "primary" / "secondary" (default) / "none"
 `href` | String | No | for link that looks like a button
 `disabled` | Boolean | No |
 `pressed` | Boolean | No |


### PR DESCRIPTION
## Description
- removed `priority` from pill docs as it does not apply to pills

## References
Fixes #534 