### PR TITLE
Allow textbox ID to be configured

### DIFF
--- a/src/components/ebay-textbox/examples/01-default/template.marko
+++ b/src/components/ebay-textbox/examples/01-default/template.marko
@@ -1,1 +1,1 @@
-<ebay-textbox value="ebay-textbox" />
+<ebay-textbox value="ebay-textbox" id="some-textbox" />

--- a/src/components/ebay-textbox/examples/01-default/template.marko
+++ b/src/components/ebay-textbox/examples/01-default/template.marko
@@ -1,1 +1,1 @@
-<ebay-textbox value="ebay-textbox" id="some-textbox" />
+<ebay-textbox value="ebay-textbox" />

--- a/src/components/ebay-textbox/template.marko
+++ b/src/components/ebay-textbox/template.marko
@@ -10,15 +10,15 @@
         <span body-only-if(true) w-body=data.iconTag/>
     </if>
     <${data.textboxTag}
-    class=data.classes
-    type="text"
-    aria-invalid=data.invalid
-    w-onchange="handleChange"
-    w-oninput="handleInput"
-    w-onfocus="handleFocus"
-    w-onblur="handleBlur"
-    w-id="textbox"
-    ${data.htmlAttributes} />
+        w-id=(data.htmlAttributes.id || "textbox")
+        class=data.classes
+        type="text"
+        aria-invalid=data.invalid
+        w-onchange="handleChange"
+        w-oninput="handleInput"
+        w-onfocus="handleFocus"
+        w-onblur="handleBlur"
+        ${data.htmlAttributes} />
     <if (data.displayIcon && data.iconPostfix)>
         <span body-only-if(true) w-body=data.iconTag/>
     </if>


### PR DESCRIPTION
## Description
- added check to the `w-id` for the ID attribute if passed (otherwise it's swallowed by Marko)

## Context
We need to allow a custom ID to be created (based on the Marko component ID) for developers to work with different input fields individually.

## References
Fixes #520 
