### PR TITLE
Checkbox and radio now use <ebay-icon>;

### DIFF
--- a/src/components/ebay-checkbox/browser.json
+++ b/src/components/ebay-checkbox/browser.json
@@ -7,6 +7,7 @@
                 "@ebay/skin/field"
             ]
         },
+        "../../../src/components/ebay-icon",
         "require: marko-widgets",
         "require: ./index.js"
     ]

--- a/src/components/ebay-checkbox/template.marko
+++ b/src/components/ebay-checkbox/template.marko
@@ -9,11 +9,7 @@
         disabled=data.disabled
         ${data.htmlAttributes} />
     <span class="checkbox__icon" hidden>
-        <svg aria-hidden="true" class="checkbox__unchecked" focusable="false" viewBox="4.12 4.1 15.77 15.8">
-            <path fill-rule="evenodd" d="M18.56 5.25H5.44a.19.19 0 0 0-.19.187v13.126a.19.19 0 0 0 .19.187h13.12a.19.19 0 0 0 .19-.187V5.437a.19.19 0 0 0-.19-.187zM4.116 19.9h15.768V4.1H4.116v15.8z"/>
-        </svg>
-        <svg aria-hidden="true" class="checkbox__checked" focusable="false" viewBox="4.12 4.1 15.77 15.8">
-            <path d="M4.116 19.9V4.1h15.768v15.8H4.116zm4.28-7.782a.725.725 0 0 0-1.06 0 .816.816 0 0 0 0 1.114l2.998 3.013a.725.725 0 0 0 1.061 0l6.001-6.3a.816.816 0 0 0 0-1.114.725.725 0 0 0-1.06 0l-5.471 5.744-2.469-2.457z"/>
-        </svg>
+        <ebay-icon type="inline" name="checkbox-unchecked" class="checkbox__unchecked" focusable="false"/>
+        <ebay-icon type="inline" name="checkbox-checked" class="checkbox__checked" focusable="false"/>
     </span>
 </span>

--- a/src/components/ebay-radio/browser.json
+++ b/src/components/ebay-radio/browser.json
@@ -7,6 +7,7 @@
                 "@ebay/skin/field"
             ]
         },
+        "../../../src/components/ebay-icon",
         "require: marko-widgets",
         "require: ./index.js"
     ]

--- a/src/components/ebay-radio/template.marko
+++ b/src/components/ebay-radio/template.marko
@@ -9,11 +9,7 @@
         disabled=data.disabled
         ${data.htmlAttributes}/>
     <span class="radio__icon" hidden>
-        <svg aria-hidden="true" class="radio__unchecked" focusable="false" viewBox="3 3 18 18">
-            <path d="M12 3a9 9 0 1 0 9 9 9 9 0 0 0-9-9m0 1.059c4.38 0 7.941 3.563 7.941 7.941S16.38 19.941 12 19.941 4.059 16.378 4.059 12 7.62 4.059 12 4.059"/>
-        </svg>
-        <svg aria-hidden="true" class="radio__checked" focusable="false" viewBox="3 3 18 18">
-            <path d="M12 3a9 9 0 1 0 9 9 9 9 0 0 0-9-9m0 1.059c4.38 0 7.941 3.563 7.941 7.941S16.38 19.941 12 19.941 4.059 16.378 4.059 12 7.62 4.059 12 4.059zm0 13.191a5.25 5.25 0 1 0 0-10.5 5.25 5.25 0 0 0 0 10.5z"/>
-        </svg>
+        <ebay-icon type="inline" name="radio-unchecked" class="radio__unchecked" focusable="false"/>
+        <ebay-icon type="inline" name="radio-checked" class="radio__checked" focusable="false"/>
     </span>
 </span>


### PR DESCRIPTION
## Description
- now uses `<ebay-icon>` instead of directly using SVG symbols

## Context
This is a bug because the DS6 checkbox was being used for DS4 and could not be switched out.

## References
Fixes #554 