### PR TITLE
Fix providing an id to ebay-textbox

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -351,6 +351,7 @@
         "renderer": "./src/components/ebay-textbox/index.js",
         "@*": "expression",
         "@html-attributes": "expression",
+        "@id": "string",
         "@class": "string",
         "@style": "string",
         "@invalid": "boolean",

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -27,6 +27,7 @@ function getInitialState(input) {
 
     return {
         htmlAttributes,
+        id: input.id,
         rootClass: rootClasses,
         style: input.style,
         classes,

--- a/src/components/ebay-textbox/template.marko
+++ b/src/components/ebay-textbox/template.marko
@@ -1,8 +1,8 @@
 <${data.tag} class=data.rootClass style=data.style w-bind>
+    <var textboxId=(data.id || widget.elId("textbox"))/>
+
     <if (data.floatingLabel)>
-        <label
-        class=data.labelClasses
-        w-for="textbox">
+        <label class=data.labelClasses for=textboxId>
             ${data.floatingLabel}
         </label>
     </if>
@@ -10,7 +10,7 @@
         <span body-only-if(true) w-body=data.iconTag/>
     </if>
     <${data.textboxTag}
-        w-id=(data.htmlAttributes.id || "textbox")
+        id=textboxId
         class=data.classes
         type="text"
         aria-invalid=data.invalid

--- a/src/components/ebay-textbox/test/test.server.js
+++ b/src/components/ebay-textbox/test/test.server.js
@@ -17,8 +17,16 @@ const inputUnderlineSelector = `input.textbox__control.textbox__control--underli
 describe('ebay-textbox', () => {
     test('renders default input textbox', context => {
         const $ = testUtils.getCheerio(context.render());
+        const $input = $(inputSelector);
         expect($(rootSelector).length).to.equal(1);
-        expect($(inputSelector).length).to.equal(1);
+        expect($input.length).to.equal(1);
+        expect($input.attr('id')).to.be.a('string');
+    });
+
+    test('renders default input textbox with an id', context => {
+        const $ = testUtils.getCheerio(context.render({ id: 'test' }));
+        const $input = $(inputSelector);
+        expect($input.attr('id')).to.equal('test');
     });
 
     test('renders fluid input textbox', context => {
@@ -56,8 +64,22 @@ describe('ebay-textbox', () => {
     test('renders an input textbox with inline floating label', context => {
         const input = { floatingLabel: 'Email address' };
         const $ = testUtils.getCheerio(context.render(input));
-        expect($(floatingLabelSelector).text()).to.equal('Email address');
+        const $floatingLabel = $(floatingLabelSelector);
+        const $input = $(inputSelector);
+        expect($floatingLabel.text()).to.equal('Email address');
         expect($(inputUnderlineSelector).length).to.equal(1);
+        expect($input.attr('id')).to.be.a('string').and.to.equal($floatingLabel.attr('for'));
+    });
+
+    test('renders an input textbox with inline floating label and an id', context => {
+        const input = { floatingLabel: 'Email address', id: 'test' };
+        const $ = testUtils.getCheerio(context.render(input));
+        const $floatingLabel = $(floatingLabelSelector);
+        const $input = $(inputSelector);
+        expect($floatingLabel.text()).to.equal('Email address');
+        expect($(inputUnderlineSelector).length).to.equal(1);
+        expect($input.attr('id')).to.equal('test');
+        expect($floatingLabel.attr('for')).to.equal('test');
     });
 
     test('renders a disabled input textbox with disabled floating label', context => {


### PR DESCRIPTION
## Description
Manually pass `id` through to avoid Marko 3 stepping on the user provided value. Also defaults to a Marko generated `id` since Marko requires this to be there when `w-on` attributes are set.

## References
Fixes #520 
