### PR TITLE
Carousel: Disable scroll snapping for FireFox

### DIFF
--- a/src/components/ebay-carousel/style-touch.less
+++ b/src/components/ebay-carousel/style-touch.less
@@ -22,6 +22,13 @@
     }
 }
 
+@supports (-moz-appearance:none) {
+    // always show paddles in firefox.
+    .carousel__control {
+        .carousel-control-visible();
+    }
+}
+
 /* autoprefixer: off */
 @supports not/*!Y */ (
     /*!Y */(-webkit-scroll-snap-coordinate: 0 0) or

--- a/src/components/ebay-carousel/style.less
+++ b/src/components/ebay-carousel/style.less
@@ -148,6 +148,16 @@
  * Not all browsers that have implemented scroll snapping have done so in a way that we can leverage.
  * Currently the below media query ensures that the browser supports exactly what we need.
  */
+
+@supports (-moz-appearance:none) {
+    // Explicitly disable support in firefox since we can't easily hide the scrollbar.
+    .carousel__list {
+        &&&& {
+            overflow-x: visible;
+        }
+    }
+}
+
 /* autoprefixer: off */
 @supports (
     /*!Y */(-webkit-scroll-snap-coordinate: 0 0) or


### PR DESCRIPTION
## Description
Currently in Firefox the carousel component shows scroll bars when scroll snapping is supported. Because there is not straight forward way to hide this scroll bar (perhaps we can look at this more in the future) this PR opts to disable to scroll snapping in FireFox and fall back to transition based implementation used in browsers without scroll snap support (IE/Edge).