### PR TITLE
Placing floating label init behind load event;

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "lodash.set": "^4.3.2",
     "makeup-active-descendant": "~0.0.6",
     "makeup-expander": "~0.6.1",
-    "makeup-floating-label": "~0.0.2",
+    "makeup-floating-label": "~0.0.3",
     "makeup-focusables": "~0.0.3",
     "makeup-key-emitter": "~0.0.3",
     "makeup-keyboard-trap": "~0.1.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   ],
   "devDependencies": {
     "@ebay/browserslist-config": "^1.0.0",
-    "@ebay/skin": "7.0.2",
+    "@ebay/skin": "7.0.3",
     "@lasso/marko-taglib": "^1.0.15",
     "async": "^2.6.2",
     "babel-cli": "^6.26.0",
@@ -102,7 +102,7 @@
     "wdio-browserstack-service": "^0.1.18"
   },
   "peerDependencies": {
-    "@ebay/skin": "7.0.2",
+    "@ebay/skin": "7.0.3",
     "marko": "^3 || ^4",
     "marko-widgets": "^6 || ^7"
   },

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -59,7 +59,7 @@ function onRender() {
     if (this.state.floatingLabel && !this.floatingLabel && document.readyState === 'complete') {
         this.initFloatingLabel();
     } else if (this.state.floatingLabel) {
-        window.addEventListener('load', this.initFloatingLabel);
+        window.addEventListener('load', this.initFloatingLabel.bind(this));
     }
 }
 

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -57,17 +57,17 @@ function getTemplateData(state) {
 
 function onRender() {
     if (this.state.floatingLabel && !this.floatingLabel && document.readyState === 'complete') {
-        this.initFloatingLabel();
-    } else {
-        window.addEventListener('load', this.initFloatingLabel);
+        this.initFloatingLabel(this);
+    } else if (this.state.floatingLabel) {
+        window.addEventListener('load', this.initFloatingLabel(this));
     }
 }
 
-function initFloatingLabel() {
-    if (!this.floatingLabel) {
-        this.floatingLabel = this.el && new FloatingLabel(this.el);
+function initFloatingLabel(_this) {
+    if (!_this.floatingLabel) {
+        _this.floatingLabel = _this.el && new FloatingLabel(_this.el);
     } else {
-        this.floatingLabel.refresh();
+        _this.floatingLabel.refresh();
     }
 }
 

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -57,17 +57,17 @@ function getTemplateData(state) {
 
 function onRender() {
     if (this.state.floatingLabel && !this.floatingLabel && document.readyState === 'complete') {
-        this.initFloatingLabel(this);
+        this.initFloatingLabel();
     } else if (this.state.floatingLabel) {
-        window.addEventListener('load', this.initFloatingLabel(this));
+        window.addEventListener('load', this.initFloatingLabel);
     }
 }
 
-function initFloatingLabel(_this) {
-    if (!_this.floatingLabel) {
-        _this.floatingLabel = _this.el && new FloatingLabel(_this.el);
+function initFloatingLabel() {
+    if (!this.floatingLabel) {
+        this.floatingLabel = this.el && new FloatingLabel(this.el);
     } else {
-        _this.floatingLabel.refresh();
+        this.floatingLabel.refresh();
     }
 }
 

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -55,10 +55,12 @@ function getTemplateData(state) {
     return state;
 }
 
-function init() {
-    if (this.state.floatingLabel) {
+function onRender() {
+    if (this.state.floatingLabel && !this.floatingLabel) {
         window.addEventListener('load', () => {
-            this.floatingLabel = new FloatingLabel(this.el);
+            if (!this.floatingLabel) {
+                this.floatingLabel = this.el && new FloatingLabel(this.el);
+            }
         });
     }
 }
@@ -76,7 +78,7 @@ module.exports = markoWidgets.defineComponent({
     template,
     getInitialState,
     getTemplateData,
-    init,
+    onRender,
     handleEvent,
     handleChange,
     handleInput,

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -56,12 +56,18 @@ function getTemplateData(state) {
 }
 
 function onRender() {
-    if (this.state.floatingLabel && !this.floatingLabel) {
-        window.addEventListener('load', () => {
-            if (!this.floatingLabel) {
-                this.floatingLabel = this.el && new FloatingLabel(this.el);
-            }
-        });
+    if (this.state.floatingLabel && !this.floatingLabel && document.readyState === 'complete') {
+        this.initFloatingLabel();
+    } else {
+        window.addEventListener('load', this.initFloatingLabel);
+    }
+}
+
+function initFloatingLabel() {
+    if (!this.floatingLabel) {
+        this.floatingLabel = this.el && new FloatingLabel(this.el);
+    } else {
+        this.floatingLabel.refresh();
     }
 }
 
@@ -79,6 +85,7 @@ module.exports = markoWidgets.defineComponent({
     getInitialState,
     getTemplateData,
     onRender,
+    initFloatingLabel,
     handleEvent,
     handleChange,
     handleInput,

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -57,7 +57,9 @@ function getTemplateData(state) {
 
 function init() {
     if (this.state.floatingLabel) {
-        this.floatingLabel = new FloatingLabel(this.el);
+        window.addEventListener('load', () => {
+            this.floatingLabel = new FloatingLabel(this.el);
+        });
     }
 }
 

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -43,6 +43,7 @@ describe('given an input textbox with floating label', () => {
         root = document.querySelector('.textbox');
         input = root.querySelector('input');
         label = root.querySelector('label');
+        testUtils.triggerEvent(window, 'load');
     });
     afterEach(() => widget.destroy());
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,6 +549,7 @@ anymatch@^2.0.0:
 app-module-path@^1.0.5:
   version "1.1.0"
   resolved "https://registry.npmjs.org/app-module-path/-/app-module-path-1.1.0.tgz#a6ac5368450f209b9f5b86e9a3e4a6ab6fe7531c"
+  integrity sha1-pqxTaEUPIJufW4bpo+Smq2/nUxw=
 
 app-module-path@^2.2.0:
   version "2.2.0"
@@ -5095,6 +5096,7 @@ lasso-marko@^2.4.2, lasso-marko@^2.4.6:
 lasso-modules-client@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/lasso-modules-client/-/lasso-modules-client-1.0.0.tgz#9c147fd6600ef3fc304a608a907346a0b6a0c051"
+  integrity sha1-nBR/1mAO8/wwSmCKkHNGoLagwFE=
   dependencies:
     lasso-package-root "^1.0.0"
     raptor-polyfill "^1.0.2"
@@ -5282,6 +5284,7 @@ lintspaces@~0.6.2:
 listener-tracker@^1.0.2:
   version "1.2.0"
   resolved "https://registry.npmjs.org/listener-tracker/-/listener-tracker-1.2.0.tgz#cf8bd58d79d995d95224b82788eed260167e135e"
+  integrity sha1-z4vVjXnZldlSJLgniO7SYBZ+E14=
 
 listener-tracker@^2.0.0:
   version "2.0.0"
@@ -5584,6 +5587,7 @@ marko-prettyprint@^1.4.1:
 marko-widgets@^6:
   version "6.6.6"
   resolved "https://registry.npmjs.org/marko-widgets/-/marko-widgets-6.6.6.tgz#3d44480619a18830b67fc1bc4fc4cf8ae64ec670"
+  integrity sha512-mtChb95DY0XP1gZzYbRVXIPndCVKyIGIXtlo5CrUvTR3LjLl08rGfeEyYqdIHdRNwxMONp20q05BdyjkBhYJ7A==
   dependencies:
     complain "^1.0.0"
     events "^1.0.2"
@@ -5605,6 +5609,7 @@ marko-widgets@^6:
 marko@^3:
   version "3.14.4"
   resolved "https://registry.npmjs.org/marko/-/marko-3.14.4.tgz#31aa9b9df5efc9941338afe98beeac9805fdf4be"
+  integrity sha512-B4AWtrgqoLA3VuaTF0Ov8+bvpoi8Eb71BGXdbgheOaLDaMK2u7XE0WdKf1fA7BtbqzZCUcpf90oynZow3nEPkA==
   dependencies:
     app-module-path "^1.0.5"
     async-writer "^2.0.0"
@@ -6000,6 +6005,7 @@ module-deps@^6.0.0:
 morphdom@^1.4.6:
   version "1.4.6"
   resolved "https://registry.npmjs.org/morphdom/-/morphdom-1.4.6.tgz#0bd4f8207ec87c38157b676ec7b9bcf318f0838d"
+  integrity sha1-C9T4IH7IfDgVe2dux7m88xjwg40=
 
 ms@2.0.0:
   version "2.0.0"
@@ -7111,6 +7117,7 @@ raptor-util@^1, raptor-util@^1.0.0, raptor-util@^1.0.10, raptor-util@^1.0.7, rap
 raptor-util@^2.0.0, raptor-util@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/raptor-util/-/raptor-util-2.0.1.tgz#3c628b828ea182d1cee308bb1b5f45eae6fe0f8d"
+  integrity sha1-PGKLgo6hgtHO4wi7G19F6ub+D40=
 
 raptor-util@^3.2.0:
   version "3.2.0"
@@ -8826,6 +8833,7 @@ void-elements@^2.0.0:
 warp10@^1.3.6:
   version "1.3.6"
   resolved "https://registry.npmjs.org/warp10/-/warp10-1.3.6.tgz#edffff4f06382d2e469ba88ccfcb95bb81d3bda6"
+  integrity sha512-7cijX+NprqPV+UGUZXZw1I15JFHPqoy65tNVvP6cL43Vlanpcm8hBYoQTuDYUHa5x90Bct4gHhRtqqOOkLhQkw==
 
 warp10@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5458,9 +5458,9 @@ makeup-expander@~0.6.1:
     makeup-focusables "~0.0.3"
     makeup-next-id "~0.0.2"
 
-makeup-floating-label@~0.0.2:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.0.2.tgz#07e65c936f1556f72e60a9d719716ed106dbdf35"
+makeup-floating-label@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.0.3.tgz#33e6ff2140cf6a03fcf0b218a8daaf1bd5a75888"
 
 makeup-focusables@~0.0.3:
   version "0.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,9 @@
   version "1.0.1"
   resolved "https://registry.npmjs.org/@ebay/browserslist-config/-/browserslist-config-1.0.1.tgz#deccafb04101fa52507b8f2204161c8ed5e70375"
 
-"@ebay/skin@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-7.0.2.tgz#e12d33c8df4617351b3122133958d83b5d550d4b"
-  integrity sha512-a8G7rvk+JuL7VwMmKhsNJR7+LwZ8xZeDjfwiG22oXRv/Hv+DdHKno1mrlTQzjPrntDt9xp53FTdrepJZKYOMjw==
+"@ebay/skin@7.0.3":
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-7.0.3.tgz#c85915a601df133e95f4774b74a2df41b050f207"
 
 "@lasso/marko-taglib@^1.0.13":
   version "1.0.13"
@@ -4116,16 +4115,16 @@ htmlescape@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
 
-htmljs-parser@^2.2.1, htmljs-parser@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.2.tgz#6309da7cb0de40b5d9049eef53b6d56de988c7dc"
+htmljs-parser@^2.2.1, htmljs-parser@^2.6.5:
+  version "2.6.6"
+  resolved "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.6.tgz#e3121346524acdaa7574cd8ce167c90da8985d94"
   dependencies:
     char-props "^0.1.5"
     complain "^1.0.0"
 
-htmljs-parser@^2.6.5:
-  version "2.6.6"
-  resolved "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.6.tgz#e3121346524acdaa7574cd8ce167c90da8985d94"
+htmljs-parser@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.2.tgz#6309da7cb0de40b5d9049eef53b6d56de988c7dc"
   dependencies:
     char-props "^0.1.5"
     complain "^1.0.0"


### PR DESCRIPTION
## Description
- moves floating label init behind the window's load event

## Context
In conjunction with changes made in the `makeup-floating-label` (https://github.com/makeup-js/makeup-floating-label/pull/2) which detects the autofill before applying the proper class, this change will wait until the page is ready and autofill has completed.

## References
Fixes #557 

## Screenshots

### Before

![screen shot 2019-02-19 at 12 29 39 pm](https://user-images.githubusercontent.com/38065/53045336-36008380-3442-11e9-94a1-2d70a2d7ed67.png)

### After

![image](https://user-images.githubusercontent.com/105656/53528712-a6914b00-3aa7-11e9-8b12-ab44bed3f234.png)
