### PR TITLE
Textbox: Additional types

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -355,6 +355,7 @@
         "@id": "string",
         "@class": "string",
         "@style": "string",
+        "@type": "string",
         "@invalid": "boolean",
         "@fluid": "boolean",
         "@multiline": "boolean",

--- a/src/components/ebay-textbox/examples/01-default/template.marko
+++ b/src/components/ebay-textbox/examples/01-default/template.marko
@@ -1,1 +1,1 @@
-<ebay-textbox value="ebay-textbox" />
+<ebay-textbox value="ebay-textbox"/>

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -19,13 +19,23 @@ function getInitialState(input) {
     const labelClasses = ['floating-label__label'];
     const htmlAttributes = processHtmlAttributes(input);
     const textboxTag = Boolean(input.multiline) ? 'textarea' : 'input';
+    let type = input.type || 'text';
     let textareaValue = '';
+
+    // only allow type to be text or password at the moment
+    // other types to be addressed later: https://github.com/eBay/ebayui-core/issues/575
+    if (type !== 'text' && type !== 'password') {
+        type = 'text';
+    }
+
     if (displayIcon && iconPostfix) {
         rootClasses.push('textbox--icon-end');
     }
+
     if (htmlAttributes.disabled) {
         labelClasses.push('floating-label__label--disabled');
     }
+
     if (textboxTag === 'textarea' && htmlAttributes.value) {
         textareaValue = htmlAttributes.value;
         htmlAttributes.value = null;
@@ -36,6 +46,7 @@ function getInitialState(input) {
         id: input.id,
         rootClass: rootClasses,
         style: input.style,
+        type,
         classes,
         icon: input.icon,
         iconTag: input.iconTag && input.iconTag.renderBody,

--- a/src/components/ebay-textbox/template.marko
+++ b/src/components/ebay-textbox/template.marko
@@ -12,7 +12,7 @@
     <${data.textboxTag}
         id=textboxId
         class=data.classes
-        type="text"
+        type=data.type
         aria-invalid=data.invalid
         w-onchange="handleChange"
         w-oninput="handleInput"


### PR DESCRIPTION
## Description
- add allowance for a "password" type

## Context
When working with users one of the immediate uses for textbox is as a password field. This allows support for that.

## References
Relates to #575 