### PR TITLE
Add ponyfill for unsupported javascript APIs

### DIFF
--- a/demo/template.marko
+++ b/demo/template.marko
@@ -2,11 +2,14 @@
 <var currentComponent=data.params.component/>
 
 <lasso-page name="demo" package-path="./browser.json" flags=data.lassoFlags dependencies=data.model.dependencies/>
+
+<!DOCTYPE html>
 <html class=designSystem>
     <head>
         <lasso-head/>
         <title>ebayui-core</title>
         <link rel="shortcut icon" href="/favicon.ico">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width">
     </head>
     <body>

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "marko-widgets": "^6 || ^7"
   },
   "dependencies": {
+    "core-js": "^2.6.5",
     "element-closest": "^3.0.1",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",

--- a/src/components/ebay-breadcrumb/examples/05-hijax/template.marko
+++ b/src/components/ebay-breadcrumb/examples/05-hijax/template.marko
@@ -4,8 +4,3 @@
     <ebay-breadcrumb-item href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</ebay-breadcrumb-item>
     <ebay-breadcrumb-item>Smart Watch Bands</ebay-breadcrumb-item>
 </ebay-breadcrumb>
-
-<script>(function() {
-    var breadcrumb = document.querySelector(".breadcrumb--hijax");
-    breadcrumb.addEventListener("breadcrumb-select", e => console.log(e.detail));
-})()</script>

--- a/src/components/ebay-checkbox/examples/03-grouped-checkbox/template.marko
+++ b/src/components/ebay-checkbox/examples/03-grouped-checkbox/template.marko
@@ -25,8 +25,3 @@
             <label class="field__label field__label--end" for="group-checkbox-3">Option 3</label>
     </span>
 </fieldset>
-
-<script>(function() {
-    var fieldSet = document.querySelector("fieldset");
-    fieldSet.addEventListener("checkbox-change", e => console.log(e.detail), true);
-})()</script>

--- a/src/components/ebay-combobox-readonly/index.js
+++ b/src/components/ebay-combobox-readonly/index.js
@@ -1,5 +1,6 @@
 const markoWidgets = require('marko-widgets');
 const Expander = require('makeup-expander');
+const findIndex = require('core-js/library/fn/array/find-index');
 const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 const elementScroll = require('../../common/element-scroll');
 const emitAndFire = require('../../common/emit-and-fire');
@@ -139,7 +140,7 @@ function handleOptionClick(event) {
  */
 function handleComboboxKeyDown(event) {
     eventUtils.handleUpDownArrowsKeydown(event, () => {
-        const currentSelectedIndex = this.state.options.findIndex(option => option.selected);
+        const currentSelectedIndex = findIndex(this.state.options, option => option.selected);
         const options = clearComboboxSelections(this.state.options);
         const optionEls = this.el.querySelectorAll(comboboxOptionSelector);
         let selectElementIndex = currentSelectedIndex;

--- a/src/components/ebay-listbox/index.js
+++ b/src/components/ebay-listbox/index.js
@@ -1,5 +1,6 @@
 const markoWidgets = require('marko-widgets');
 const Expander = require('makeup-expander');
+const findIndex = require('core-js/library/fn/array/find-index');
 const ActiveDescendant = require('makeup-active-descendant');
 const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 const elementScroll = require('../../common/element-scroll');
@@ -71,7 +72,7 @@ function getTemplateData(state) {
 
 function init() {
     const optionEls = this.el.querySelectorAll(listboxOptionSelector);
-    const selectedOptionIndex = this.state.options.findIndex(option => option.selected);
+    const selectedOptionIndex = findIndex(this.state.options, option => option.selected);
 
     const activeDescendantOwnedEl = this.el.querySelector(`.${listboxOptionsClass}`);
 

--- a/src/components/ebay-menu/browser.json
+++ b/src/components/ebay-menu/browser.json
@@ -8,7 +8,7 @@
         "../../../src/components/ebay-button",
         "../../../src/components/ebay-icon",
         "require-run: nodelist-foreach-polyfill",
-        "require-run: element-closest",
+        "require-run: element-closest/browser",
         "require: marko-widgets",
         "require: ./index.js"
     ]

--- a/src/components/ebay-pagination/examples/05-buttons/template.marko
+++ b/src/components/ebay-pagination/examples/05-buttons/template.marko
@@ -11,8 +11,3 @@
     <ebay-pagination-item>9</ebay-pagination-item>
     <ebay-pagination-item type="next"></ebay-pagination-item>
 </ebay-pagination>
-
-<script>(function() {
-    var pagination = document.querySelector(".example-05");
-    pagination.addEventListener("pagination-select", e => console.log(e.detail));
-})()</script>

--- a/src/components/ebay-radio/examples/03-grouped-radio/template.marko
+++ b/src/components/ebay-radio/examples/03-grouped-radio/template.marko
@@ -25,8 +25,3 @@
         <label class="field__label field__label--end" for="group-radio-3">Option 3</label>
     </span>
 </fieldset>
-
-<script>(function() {
-    var fieldSet = document.querySelector("fieldset");
-    fieldSet.addEventListener("radio-change", e => console.log(e.detail), true);
-})()</script>

--- a/src/components/ebay-select/index.js
+++ b/src/components/ebay-select/index.js
@@ -1,4 +1,5 @@
 const markoWidgets = require('marko-widgets');
+const find = require('core-js/library/fn/array/find');
 const emitAndFire = require('../../common/emit-and-fire');
 const processHtmlAttributes = require('../../common/html-attributes');
 const observer = require('../../common/property-observer');
@@ -67,7 +68,7 @@ function init() {
 
     const valueObserverCallback = (optionValue) => {
         const optionFind = (option) => option.value.toString() === optionValue.toString();
-        const newOptionSelected = this.state.options.find(optionFind);
+        const newOptionSelected = find(this.state.options, optionFind);
         let optionIndex;
 
         if (newOptionSelected) {
@@ -108,7 +109,7 @@ function processAfterStateChange(el) {
  */
 function setSelectedOption(optionValue) {
     const optionFind = (option) => option.value.toString() === optionValue.toString();
-    const newOptionSelected = this.state.options.find(optionFind);
+    const newOptionSelected = find(this.state.options, optionFind);
     const newOptionSelectedValue = newOptionSelected && newOptionSelected.value;
     let options = this.state.options;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,6 +2210,11 @@ core-js@^2.2.0, core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.3"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz#4b70938bdffdaf64931e66e2db158f0892289c49"
 
+core-js@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
## Description
Improves the ability to run the ebayui demo page in IE and adds [ponyfills](http://ponyfill.com) from [core-js](https://github.com/zloirock/core-js) a few unsupported api's.

## Context
I opted to use core-js ponyfills (more info [here](http://ponyfill.com) on what a ponyfill is) so that we can avoid polluting globals with the polyfills we are adding. We still add some (element-closest) which we could address in the future.

I chose `core-js` because it comes with every javascript runtime polypill we could want but we can cherrypick the ones we need with minimal effort. `core-js` is also used by `babel-polyfill` and teams using this will actually cause these dependencies to be deduped.

## References
Fixes #588 