### PR TITLE
Floating label refresh using onUpdate

### DIFF
--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -74,6 +74,10 @@ function onRender() {
     }
 }
 
+function onUpdate() {
+    this.initFloatingLabel();
+}
+
 function initFloatingLabel() {
     if (!this.floatingLabel) {
         this.floatingLabel = this.el && new FloatingLabel(this.el);
@@ -96,6 +100,7 @@ module.exports = markoWidgets.defineComponent({
     getInitialState,
     getTemplateData,
     onRender,
+    onUpdate,
     initFloatingLabel,
     handleEvent,
     handleChange,

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -67,15 +67,15 @@ function getTemplateData(state) {
 }
 
 function onRender() {
-    if (this.state.floatingLabel && !this.floatingLabel && document.readyState === 'complete') {
-        this.initFloatingLabel();
-    } else if (this.state.floatingLabel) {
+    if (this.state.floatingLabel && document.readyState !== 'complete') {
         window.addEventListener('load', this.initFloatingLabel.bind(this));
     }
 }
 
 function onUpdate() {
-    this.initFloatingLabel();
+    if (this.state.initFloatingLabel) {
+        this.initFloatingLabel();
+    }
 }
 
 function initFloatingLabel() {

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -66,7 +66,7 @@ function getTemplateData(state) {
     return state;
 }
 
-function onRender() {
+function init() {
     if (this.state.floatingLabel && !this.floatingLabel && document.readyState === 'complete') {
         this.initFloatingLabel();
     } else if (this.state.floatingLabel) {
@@ -75,8 +75,8 @@ function onRender() {
 }
 
 function onUpdate() {
-    if (this.state.floatingLabel && this.floatingLabel) {
-        this.floatingLabel.refresh();
+    if (this.state.floatingLabel) {
+        this.initFloatingLabel();
     }
 }
 
@@ -101,7 +101,7 @@ module.exports = markoWidgets.defineComponent({
     template,
     getInitialState,
     getTemplateData,
-    onRender,
+    init,
     onUpdate,
     initFloatingLabel,
     handleEvent,

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -67,14 +67,16 @@ function getTemplateData(state) {
 }
 
 function onRender() {
-    if (this.state.floatingLabel && document.readyState !== 'complete') {
+    if (this.state.floatingLabel && !this.floatingLabel && document.readyState === 'complete') {
+        this.initFloatingLabel();
+    } else if (this.state.floatingLabel) {
         window.addEventListener('load', this.initFloatingLabel.bind(this));
     }
 }
 
 function onUpdate() {
-    if (this.state.initFloatingLabel) {
-        this.initFloatingLabel();
+    if (this.state.floatingLabel && this.floatingLabel) {
+        this.floatingLabel.refresh();
     }
 }
 


### PR DESCRIPTION
## Description
- add the `onUpdate` lifecycle method, and call `initFloatingLabel`

## Context
When updating the state from a parent component, the `value` gets changed to an empty string. This should trigger a refresh of the floating label, but the textbox component wasn't doing anything during the update part of the lifecycle.

## References
Fixes #581 

## Screenshots

### Before
![screen shot 2019-03-07 at 1 58 05 pm](https://user-images.githubusercontent.com/2268244/53993383-1b860580-40e4-11e9-98c2-94954561752d.png)

### After
![image](https://user-images.githubusercontent.com/105656/54569411-6f280700-49a0-11e9-8df8-c6108e8079e5.png)

