### PR TITLE
Checkbox: removed redundant skin classes

### DIFF
--- a/src/components/ebay-checkbox/template.marko
+++ b/src/components/ebay-checkbox/template.marko
@@ -9,7 +9,7 @@
         disabled=data.disabled
         ${data.htmlAttributes} />
     <span class="checkbox__icon" hidden>
-        <ebay-icon type="inline" name="checkbox-unchecked" class="checkbox__unchecked" focusable="false"/>
-        <ebay-icon type="inline" name="checkbox-checked" class="checkbox__checked" focusable="false"/>
+        <ebay-icon type="inline" name="checkbox-unchecked" class="checkbox__unchecked" focusable="false" no-skin-classes/>
+        <ebay-icon type="inline" name="checkbox-checked" class="checkbox__checked" focusable="false" no-skin-classes/>
     </span>
 </span>

--- a/src/components/ebay-radio/template.marko
+++ b/src/components/ebay-radio/template.marko
@@ -9,7 +9,7 @@
         disabled=data.disabled
         ${data.htmlAttributes}/>
     <span class="radio__icon" hidden>
-        <ebay-icon type="inline" name="radio-unchecked" class="radio__unchecked" focusable="false"/>
-        <ebay-icon type="inline" name="radio-checked" class="radio__checked" focusable="false"/>
+        <ebay-icon type="inline" name="radio-unchecked" class="radio__unchecked" focusable="false" no-skin-classes/>
+        <ebay-icon type="inline" name="radio-checked" class="radio__checked" focusable="false" no-skin-classes/>
     </span>
 </span>


### PR DESCRIPTION
Fixes #595 and https://github.com/eBay/skin/issues/592

There was some mis-documentation on the skin side (now fixed), resulting in some redundant classes and a possible cascade issue (depending on bundling order). This PR removes those classes from the component template.