### PR TITLE
601 infotip expander

### DIFF
--- a/src/components/components/ebay-tooltip-base/index.js
+++ b/src/components/components/ebay-tooltip-base/index.js
@@ -47,6 +47,12 @@ function onRender() {
     }
 }
 
+function onBeforeUpdate() {
+    if (this.expander) {
+        this.expander.cancelAsync();
+    }
+}
+
 function handleExpand() {
     this.emit('base-expand');
 }
@@ -59,6 +65,7 @@ module.exports = require('marko-widgets').defineComponent({
     template,
     getInitialState,
     onRender,
+    onBeforeUpdate,
     handleExpand,
     handleCollapse
 });

--- a/src/components/ebay-infotip/template.marko
+++ b/src/components/ebay-infotip/template.marko
@@ -6,9 +6,11 @@
         w-on-base-expand="handleExpand"
         w-on-base-collapse="handleCollapse">
         <span
+            w-preserve-attrs="class,id"
             class="infotip"
             ${data.htmlAttributes}>
             <button
+                w-preserve-attrs="aria-expanded,aria-controls,aria-described-by"
                 class="infotip__host icon-btn"
                 aria-label=data.ariaLabel>
                 <if(data.icon)>

--- a/src/components/ebay-infotip/test/test.browser.js
+++ b/src/components/ebay-infotip/test/test.browser.js
@@ -19,30 +19,43 @@ describe('given the default infotip', () => {
 
     afterEach(() => widget.destroy());
 
-    describe('when the host element is clicked', () => {
-        let spy;
-        beforeEach(() => {
-            spy = sinon.spy();
-            widget.on('tooltip-expand', spy);
-            testUtils.triggerEvent(host, 'click');
+    thenItCanBeOpenAndClosed();
+
+    describe('after it is rerendered', () => {
+        before(() => {
+            widget.setStateDirty('test');
+            widget.update();
         });
 
-        test('then it emits the tooltip-expand event', () => {
-            expect(spy.calledOnce).to.equal(true);
-        });
+        thenItCanBeOpenAndClosed();
     });
 
-    describe('when the host element is clicked a second time to close', () => {
-        let spy;
-        beforeEach(() => {
-            spy = sinon.spy();
-            widget.on('tooltip-collapse', spy);
-            testUtils.triggerEvent(host, 'click');
-            testUtils.triggerEvent(host, 'click');
+    function thenItCanBeOpenAndClosed() {
+        describe('when the host element is clicked', () => {
+            let spy;
+            beforeEach(() => {
+                spy = sinon.spy();
+                widget.on('tooltip-expand', spy);
+                testUtils.triggerEvent(host, 'click');
+            });
+
+            test('then it emits the tooltip-expand event', () => {
+                expect(spy.calledOnce).to.equal(true);
+            });
         });
 
-        test('then it emits the tooltip-collapse event', () => {
-            expect(spy.calledOnce).to.equal(true);
+        describe('when the host element is clicked a second time to close', () => {
+            let spy;
+            beforeEach(() => {
+                spy = sinon.spy();
+                widget.on('tooltip-collapse', spy);
+                testUtils.triggerEvent(host, 'click');
+                testUtils.triggerEvent(host, 'click');
+            });
+
+            test('then it emits the tooltip-collapse event', () => {
+                expect(spy.calledOnce).to.equal(true);
+            });
         });
-    });
+    }
 });

--- a/src/components/ebay-tourtip/test/test.browser.js
+++ b/src/components/ebay-tourtip/test/test.browser.js
@@ -19,16 +19,29 @@ describe('given the default tourtip', () => {
 
     afterEach(() => widget.destroy());
 
-    describe('when the closeButton element is closed', () => {
-        let spy;
-        beforeEach(() => {
-            spy = sinon.spy();
-            widget.on('tooltip-collapse', spy);
-            testUtils.triggerEvent(closeButton, 'click');
+    thenItCanBeClosed();
+
+    describe('after it is rerendered', () => {
+        before(() => {
+            widget.setStateDirty('test');
+            widget.update();
         });
 
-        test('then it emits the tooltip-collapse event', () => {
-            expect(spy.calledOnce).to.equal(true);
-        });
+        thenItCanBeClosed();
     });
+
+    function thenItCanBeClosed() {
+        describe('when the closeButton element is closed', () => {
+            let spy;
+            beforeEach(() => {
+                spy = sinon.spy();
+                widget.on('tooltip-collapse', spy);
+                testUtils.triggerEvent(closeButton, 'click');
+            });
+
+            test('then it emits the tooltip-collapse event', () => {
+                expect(spy.calledOnce).to.equal(true);
+            });
+        });
+    }
 });


### PR DESCRIPTION
## Description
Fixes the issue where `infotip` and `tourtip` were not expanding (or closing) properly after a rerender and adds tests.

## References
Fixes #601 
