### PR TITLE
Refactor ebay-icon to keep the DOM more inline with what Marko expects

### DIFF
--- a/src/components/ebay-icon/template.marko
+++ b/src/components/ebay-icon/template.marko
@@ -5,21 +5,19 @@
 <else-if(data.isInline)>
     <svg w-bind class=data.classes style=data.style ${data.htmlAttributes} ${data.a11yAttributes} focusable="false">
         <if(data.renderDefs && data.themes)>
-            <defs w-id="defs" w-preserve-body>
-                <%
-                    var theme;
+            <defs w-id="defs">
+                <var theme/>
+                <if(typeof window === "undefined")>
+                    <!-- Actual magic, please do not try to replicate. -->
+                    <var lassoContext=out.global["lasso/LassoRenderContext"]/>
+                    <var flags=(lassoContext && lassoContext.data.config.flags)/>
+                    <assign theme=data.themes[!flags || flags.indexOf("skin-ds6") !== -1 ? 1 : 0]/>
+                </if>
+                <else>
+                    <assign theme=data.themes.filter(Boolean)[0]/>
+                </else>
 
-                    if (process.browser) {
-                        theme = data.themes.filter(Boolean)[0];
-                    } else {
-                        // Actual magic, please do not try to replicate.
-                        var lassoContext = out.global["lasso/LassoRenderContext"];
-                        var flags = lassoContext && lassoContext.data.config.flags;
-                        theme = data.themes[!flags || flags.indexOf("skin-ds6") !== -1 ? 1 : 0];
-                    }
-
-                    if (theme) theme.render({}, out);
-                %>
+                <include(theme)/>
             </defs>
         </if>
         <title if(data.a11yText) id=data.titleId>${data.a11yText}</title>

--- a/src/components/ebay-icon/widget.js
+++ b/src/components/ebay-icon/widget.js
@@ -12,13 +12,17 @@ function init() {
 
     // If there were any symbols rendered then we move them to the svg above after rendering them.
     const defs = this.getEl('defs');
-    const symbol = defs && defs.querySelector('symbol');
 
-    if (symbol) {
-        // Here we get the name of the symbol by removing the `icon-` part.
-        // We then mark this symbol as `defined` so that no other `ebay-icons` render it.
-        defined[symbol.id.slice(5)] = true;
-        rootSvg.appendChild(symbol);
+    if (defs) {
+        const symbol = defs.querySelector('symbol');
+        defs.parentNode.removeChild(defs);
+
+        if (symbol) {
+            // Here we get the name of the symbol by removing the `icon-` part.
+            // We then mark this symbol as `defined` so that no other `ebay-icons` render it.
+            defined[symbol.id.slice(5)] = true;
+            rootSvg.appendChild(symbol);
+        }
     }
 }
 


### PR DESCRIPTION
## Description
While digging into #601 I discovered that the `ebay-icon` was mutating the DOM on the first render which I thought may be causing the issue. It turns out this was fine But I have created a fix to avoid this anyways.

I also refactored the template to use standard Marko syntax instead of inline scripts which will make the code slightly better after a future migration to Marko 4.