### PR TITLE
Textbox: Event when floating label is present and component is updated;

### DIFF
--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -27,4 +27,4 @@ Event | Data | Description
 `textbox-focus` | `{ originalEvent, value }` |
 `textbox-blur` | `{ originalEvent, value }` |
 `textbox-keydown` | `{ originalEvent, value }` |
-`textbox-floating-label-init` | `{ null, value }` |
+`textbox-floating-label-init` | `{ originalEvent: null, value: null }` |

--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -27,3 +27,4 @@ Event | Data | Description
 `textbox-focus` | `{ originalEvent, value }` |
 `textbox-blur` | `{ originalEvent, value }` |
 `textbox-keydown` | `{ originalEvent, value }` |
+`textbox-floating-label-init` | `{ null, value }` |

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -77,6 +77,7 @@ function init() {
 function onUpdate() {
     if (this.state.floatingLabel) {
         this.initFloatingLabel();
+        this.handleEvent(null, 'floating-label-init');
     }
 }
 
@@ -89,14 +90,19 @@ function initFloatingLabel() {
 }
 
 function handleEvent(originalEvent, eventName) {
-    emitAndFire(this, `textbox-${eventName}`, { originalEvent, value: originalEvent.target.value });
+    const inputEl = this.el.querySelector('input, textarea');
+
+    emitAndFire(this, `textbox-${eventName}`, {
+        originalEvent,
+        value: inputEl.value
+    });
 }
 
-const handleChange = function(originalEvent) { this.handleEvent(originalEvent, 'change'); };
-const handleInput = function(originalEvent) { this.handleEvent(originalEvent, 'input'); };
-const handleFocus = function(originalEvent) { this.handleEvent(originalEvent, 'focus'); };
-const handleBlur = function(originalEvent) { this.handleEvent(originalEvent, 'blur'); };
-const handleKeydown = function(originalEvent) { this.handleEvent(originalEvent, 'keydown'); };
+function handleChange(originalEvent) { this.handleEvent(originalEvent, 'change'); }
+function handleInput(originalEvent) { this.handleEvent(originalEvent, 'input'); }
+function handleFocus(originalEvent) { this.handleEvent(originalEvent, 'focus'); }
+function handleBlur(originalEvent) { this.handleEvent(originalEvent, 'blur'); }
+function handleKeydown(originalEvent) { this.handleEvent(originalEvent, 'keydown'); }
 
 module.exports = markoWidgets.defineComponent({
     template,

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -63,4 +63,19 @@ describe('given an input textbox with floating label', () => {
             expect(label.classList.contains('floating-label__label--inline')).to.equal(true);
         });
     });
+
+    describe('when the component is updated/re-rendered', () => {
+        let updateSpy;
+
+        beforeEach(() => {
+            updateSpy = sinon.spy();
+            widget.on('textbox-floating-label-init', updateSpy);
+            widget.setStateDirty('test');
+            widget.update();
+        });
+
+        test('it should send a textbox floating label init event', () => {
+            expect(updateSpy.calledOnce).to.equal(true);
+        });
+    });
 });


### PR DESCRIPTION
## Description
- new event `textbox-floating-label-init` was added

## Context
When the textbox is updated, it re-initializes the floating label. Because of the three-way relationship with `makeup-floating-label`, this component, and Marko, we send out an event whenever the parent component forces an update on the textbox component we need to know about it. This helps developers to know when the floating label was refreshed/re-initialized.

## References
Closes #594.