### PR TITLE
Infotip: disable attribute

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -144,6 +144,7 @@
         "@class": "string",
         "@style": "string",
         "@icon": "string",
+        "@disabled": "boolean",
         "@pointer": "string",
         "@style-top": "string",
         "@style-left": "string",

--- a/src/components/ebay-infotip/README.md
+++ b/src/components/ebay-infotip/README.md
@@ -22,7 +22,7 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `icon` | String | No | name of an `<ebay-icon>` to show for the icon button
 `pointer` | String | No | options are `top-left`, `top`, `top-right`, `right`, `right-bottom`, `right-top`, `bottom-left`, `bottom-right`, `bottom`, `left`, `left-bottom`, `left-top`
-`disabled` | Boolean | No | adds a `disabled` attribute to the button
+`disabled` | Boolean | Yes | adds a `disabled` attribute to the button
 `style-top` | String | No | a style property for the CSS `top` rule
 `style-left` | String | No | a style property for the CSS `left` rule
 `style-right` | String | No | a style property for the CSS `right` rule

--- a/src/components/ebay-infotip/README.md
+++ b/src/components/ebay-infotip/README.md
@@ -22,6 +22,7 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `icon` | String | No | name of an `<ebay-icon>` to show for the icon button
 `pointer` | String | No | options are `top-left`, `top`, `top-right`, `right`, `right-bottom`, `right-top`, `bottom-left`, `bottom-right`, `bottom`, `left`, `left-bottom`, `left-top`
+`disabled` | Boolean | No | adds a `disabled` attribute to the button
 `style-top` | String | No | a style property for the CSS `top` rule
 `style-left` | String | No | a style property for the CSS `left` rule
 `style-right` | String | No | a style property for the CSS `right` rule

--- a/src/components/ebay-infotip/examples/03-disabled/template.marko
+++ b/src/components/ebay-infotip/examples/03-disabled/template.marko
@@ -1,0 +1,4 @@
+<ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information" disabled>
+    <ebay-infotip-heading>Important</ebay-infotip-heading>
+    <ebay-infotip-content><p>This is some important info</p></ebay-infotip-content>
+</ebay-infotip>

--- a/src/components/ebay-infotip/index.js
+++ b/src/components/ebay-infotip/index.js
@@ -4,6 +4,7 @@ const template = require('./template.marko');
 
 function getInitialState(input) {
     return Object.assign({}, input, {
+        disabled: Boolean(input.disabled),
         pointer: input.pointer || 'bottom',
         htmlAttributes: processHtmlAttributes(input),
         hostSelector: '.infotip__host',

--- a/src/components/ebay-infotip/template.marko
+++ b/src/components/ebay-infotip/template.marko
@@ -13,6 +13,7 @@
             <button
                 w-preserve-attrs="aria-expanded,aria-controls,aria-described-by"
                 class="infotip__host icon-btn"
+                disabled=data.disabled
                 aria-label=data.ariaLabel>
                 <if(data.icon)>
                     <span if(data.iconTag) w-body=data.iconTag body-only-if(true)/>

--- a/src/components/ebay-infotip/test/test.server.js
+++ b/src/components/ebay-infotip/test/test.server.js
@@ -29,6 +29,17 @@ describe('infotip', () => {
         const $ = testUtils.getCheerio(context.render(input));
         expect($('.infotip__heading').length).to.equal(1);
     });
+
+    test('renders default infotip disabled', context => {
+        const input = {
+            content: {
+                renderyBody: ''
+            },
+            disabled: true
+        };
+        const $ = testUtils.getCheerio(context.render(input));
+        expect($('button.infotip__host[disabled]').length).to.equal(1);
+    });
 });
 
 describe('transformer', () => {


### PR DESCRIPTION
## Description
- add a disabled attribute to the host button

## Context
The button for the expander should have the ability to be disabled.

## References
Closes #599.

## Screenshots
<!-- Upload screenshots if appropriate. -->
![image](https://user-images.githubusercontent.com/105656/55515064-db546d00-5626-11e9-9169-41be01cdd8e3.png)