### PR TITLE
Textbox: added textbox-keydown event #612

### DIFF
--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -26,3 +26,4 @@ Event | Data | Description
 `textbox-input` | `{ originalEvent, value }` |
 `textbox-focus` | `{ originalEvent, value }` |
 `textbox-blur` | `{ originalEvent, value }` |
+`textbox-keydown` | `{ originalEvent, value }` |

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -96,6 +96,7 @@ const handleChange = function(originalEvent) { this.handleEvent(originalEvent, '
 const handleInput = function(originalEvent) { this.handleEvent(originalEvent, 'input'); };
 const handleFocus = function(originalEvent) { this.handleEvent(originalEvent, 'focus'); };
 const handleBlur = function(originalEvent) { this.handleEvent(originalEvent, 'blur'); };
+const handleKeydown = function(originalEvent) { this.handleEvent(originalEvent, 'keydown'); };
 
 module.exports = markoWidgets.defineComponent({
     template,
@@ -108,5 +109,6 @@ module.exports = markoWidgets.defineComponent({
     handleChange,
     handleInput,
     handleFocus,
-    handleBlur
+    handleBlur,
+    handleKeydown
 });

--- a/src/components/ebay-textbox/template.marko
+++ b/src/components/ebay-textbox/template.marko
@@ -18,6 +18,7 @@
         w-oninput="handleInput"
         w-onfocus="handleFocus"
         w-onblur="handleBlur"
+        w-onkeydown="handleKeydown"
         ${data.htmlAttributes}>
         <if(data.textboxTag === 'textarea')>
             ${data.textareaValue}

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -15,7 +15,7 @@ describe('given an input textbox', () => {
     });
     afterEach(() => widget.destroy());
 
-    ['change', 'input', 'focus', 'blur'].forEach(eventName => {
+    ['change', 'input', 'focus', 'blur', 'keydown'].forEach(eventName => {
         describe(`when native event is fired: ${eventName}`, () => {
             let spy;
             beforeEach(() => {


### PR DESCRIPTION
Fixes #612 

This change simply exposes the keydown event via `textbox-keydown`.

I think `keydown` event is all they need for now. I left out `keyup` and `keypress` because they are less commonly used in my experience.