### PR TITLE
Check for option text;

### DIFF
--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -41,7 +41,7 @@
                 <var isSelected=(selectedOption === option)/>
                 <var isVisible=(data.autocomplete === 'list' && (isSelected || currentValueReg.test(option.text)) || data.autocomplete === 'none')/>
                 <div
-                    if(isVisible)
+                    if(isVisible && option.text)
                     w-id="option[]"
                     role='option'
                     class=['combobox__option', option.class]

--- a/src/components/ebay-combobox/test/test.server.js
+++ b/src/components/ebay-combobox/test/test.server.js
@@ -1,10 +1,8 @@
 const expect = require('chai').expect;
 const testUtils = require('../../../common/test-utils/server');
 const options = [{
-    value: 1,
     text: 'option 1'
 }, {
-    value: 2,
     text: 'option 2'
 }];
 const emptyOptions = [];
@@ -57,6 +55,9 @@ describe('combobox', () => {
 });
 
 describe('combobox-option', () => {
-    test('handles pass-through html attributes', c => testUtils.testHtmlAttributes(c, '.combobox__option', 'options'));
-    test('handles custom class and style', c => testUtils.testClassAndStyle(c, '.combobox__option', 'options'));
+    test('handles pass-through html attributes', c =>
+        testUtils.testHtmlAttributes(c, '.combobox__option', 'options', options[0]));
+
+    test('handles custom class and style', c =>
+        testUtils.testClassAndStyle(c, '.combobox__option', 'options', options[0]));
 });


### PR DESCRIPTION
## Description
- added simple check for option text being present

## Context
When no text is supplied for a given combobox option then it still adds an element to the DOM making some weird spacing.

## References
Fixes #630 

## Screenshots
![image](https://user-images.githubusercontent.com/105656/56533496-fc68f900-6514-11e9-8a1b-f6594e6336c0.png)

