### PR TITLE
Combobox: chrome autofill and name passthrough

### DIFF
--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -111,13 +111,15 @@ module.exports = require('marko-widgets').defineComponent({
         });
 
         eventUtils.handleEnterKeydown(originalEvent, () => {
-            newValue = selectedEl && selectedEl.textContent || newValue;
-            this.setState('currentValue', newValue);
-            this.setSelectedIndex();
-            if (selectedEl) {
-                this.emitChangeEvent('select');
+            if (this.expander.isExpanded()) {
+                newValue = selectedEl && selectedEl.textContent || newValue;
+                this.setState('currentValue', newValue);
+                this.setSelectedIndex();
+                if (selectedEl) {
+                    this.emitChangeEvent('select');
+                }
+                this.toggleListbox();
             }
-            this.toggleListbox();
         });
 
         eventUtils.handleEscapeKeydown(originalEvent, () => {

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -15,9 +15,14 @@
     w-preserve-attrs="class,id"
     w-bind>
     <span class=['combobox__control', { 'combobox__control--borderless': data.borderless }]>
+        <!--
+        NOTE: Uses autocomplete="new-password" because of a problem with Chrome where the autfill does not
+        respect the "off" key. Tested and works in all other browsers properly as well.
+        -->
         <input
             w-id="input"
             type='text'
+            name=data.name
             role="combobox"
             value=currentValue
             readonly=data.readonly
@@ -26,7 +31,7 @@
             aria-haspopup='listbox'
             w-on-blur='handleComboboxBlur'
             w-on-keyup='handleComboboxKeyUp'
-            autocomplete="off"
+            autocomplete="new-password"
             w-preserve-attrs="aria-controls,aria-activedescendant,aria-owns,aria-expanded"
             ${processHtmlAttributes(data)}/>
         <span class="combobox__icon" aria-hidden="true"></span>

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -26,7 +26,7 @@
             aria-haspopup='listbox'
             w-on-blur='handleComboboxBlur'
             w-on-keyup='handleComboboxKeyUp'
-            autocomplete="off"
+            autocomplete="new-password"
             w-preserve-attrs="aria-controls,aria-activedescendant,aria-owns,aria-expanded"
             ${processHtmlAttributes(data)}/>
         <span class="combobox__icon" aria-hidden="true"></span>

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -26,7 +26,7 @@
             aria-haspopup='listbox'
             w-on-blur='handleComboboxBlur'
             w-on-keyup='handleComboboxKeyUp'
-            autocomplete="new-password"
+            autocomplete="off"
             w-preserve-attrs="aria-controls,aria-activedescendant,aria-owns,aria-expanded"
             ${processHtmlAttributes(data)}/>
         <span class="combobox__icon" aria-hidden="true"></span>


### PR DESCRIPTION
## Description
- adds check for whether listbox is expanded before selecting an item when Enter key is pressed
- fixes `name` passthrough
- adds `autocomplete="new-password"` to fix Chrome's autocomplete behavior

## Context
Chrome was not respecting `autocomplete="off"` because it was "auto-detecting" one of the comboboxes as needing to be autofilled. To force all comboboxes to not use autocomplete we use the `new-password` key (as defined in the [W3C spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute)). This still allows entry, but tells all the browsers not to store, remember, or autofill that form field.

## References
Fixes #639 
Fixes #645 