### PR TITLE
Upgraded Skin for Edge/IE textbox issue

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -99,6 +99,7 @@
         "@borderless": "boolean",
         "@disabled": "boolean",
         "@autocomplete": "string",
+        "@expand-on-focus": "boolean",
         "@options <option>[]": {
             "@*": "expression",
             "@html-attributes": "expression",

--- a/marko.json
+++ b/marko.json
@@ -99,7 +99,6 @@
         "@borderless": "boolean",
         "@disabled": "boolean",
         "@autocomplete": "string",
-        "@expand-on-focus": "boolean",
         "@options <option>[]": {
             "@*": "expression",
             "@html-attributes": "expression",

--- a/marko.json
+++ b/marko.json
@@ -106,7 +106,6 @@
             "@style": "string",
             "@value": "string",
             "@text": "string",
-            "@meta-text": "string",
             "@selected": "boolean"
         }
     },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   ],
   "devDependencies": {
     "@ebay/browserslist-config": "^1.0.0",
-    "@ebay/skin": "7.1.1",
+    "@ebay/skin": "7.1.2",
     "@lasso/marko-taglib": "^1.0.15",
     "async": "^2.6.2",
     "babel-cli": "^6.26.0",
@@ -103,7 +103,7 @@
     "wdio-browserstack-service": "^0.1.18"
   },
   "peerDependencies": {
-    "@ebay/skin": "7.1.1",
+    "@ebay/skin": "7.1.2",
     "marko": "^3 || ^4",
     "marko-widgets": "^6 || ^7"
   },

--- a/src/components/ebay-combobox/README.md
+++ b/src/components/ebay-combobox/README.md
@@ -45,7 +45,8 @@ Name | Required | Type | Stateful | Description
 `name` | Yes | String | No | used for the `name` attribute of the native `<select>`
 `borderless` | No | Boolean | No | whether button has borders
 `disabled` | No | Boolean | Yes | sets the disabled attribute of the input
-`autocomplete` | No | String | Yes | available values are `none` and `list`
+`autocomplete` | No | String | Yes | default is `none`; available values are `none` and `list`
+`expand-on-focus` | No | Boolean | No | whether to expand on focus
 
 Note: For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 
@@ -72,4 +73,4 @@ Event | Data |  Description
 Name | Required | Type | Stateful | Description
 --- | --- | --- | --- | ---
 `text` | No | String | No | string to use in the option
-`meta-text | No | String | No | supporting text on the option (for more clearly explaining the option, e.g. a category or aspect)
+`meta-text` | No | String | No | supporting text on the option (for more clearly explaining the option, e.g. a category or aspect)

--- a/src/components/ebay-combobox/README.md
+++ b/src/components/ebay-combobox/README.md
@@ -73,4 +73,3 @@ Event | Data |  Description
 Name | Required | Type | Stateful | Description
 --- | --- | --- | --- | ---
 `text` | No | String | No | string to use in the option
-`meta-text` | No | String | No | supporting text on the option (for more clearly explaining the option, e.g. a category or aspect)

--- a/src/components/ebay-combobox/README.md
+++ b/src/components/ebay-combobox/README.md
@@ -46,7 +46,6 @@ Name | Required | Type | Stateful | Description
 `borderless` | No | Boolean | No | whether button has borders
 `disabled` | No | Boolean | Yes | sets the disabled attribute of the input
 `autocomplete` | No | String | Yes | default is `none`; available values are `none` and `list`
-`expand-on-focus` | No | Boolean | No | whether to expand on focus
 
 Note: For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -22,7 +22,8 @@ module.exports = require('marko-widgets').defineComponent({
         return Object.assign({}, input, {
             autocomplete,
             selectedIndex: index === -1 ? null : index,
-            currentValue
+            currentValue,
+            showAllOptions: false
         });
     },
     init() {
@@ -54,7 +55,7 @@ module.exports = require('marko-widgets').defineComponent({
 
             this.expander = new Expander(this.el, {
                 autoCollapse: true,
-                expandOnFocus: true,
+                expandOnFocus: this.state.expandOnFocus || true,
                 expandOnClick: this.state.readonly && !this.state.disabled,
                 collapseOnFocusOut: !this.state.readonly,
                 contentSelector: '.combobox__options',
@@ -86,6 +87,7 @@ module.exports = require('marko-widgets').defineComponent({
         elementScroll.scroll(this.getEls('option')[index]);
         this.moveCursorToEnd();
         emitAndFire(this, 'combobox-expand');
+        this.setState('showAllOptions', true);
     },
     handleCollapse() {
         emitAndFire(this, 'combobox-collapse');
@@ -106,6 +108,7 @@ module.exports = require('marko-widgets').defineComponent({
         eventUtils.handleUpDownArrowsKeydown(originalEvent, () => {
             if (this.expander && !this.expander.isExpanded() && this.getEls('option').length > 0) {
                 this.expander.expand();
+                this.setState('showAllOptions', true);
             }
             this.moveCursorToEnd();
         });
@@ -119,11 +122,13 @@ module.exports = require('marko-widgets').defineComponent({
                     this.emitChangeEvent('select');
                 }
                 this.toggleListbox();
+                this.setState('showAllOptions', false);
             }
         });
 
         eventUtils.handleEscapeKeydown(originalEvent, () => {
             this.expander.collapse();
+            this.setState('showAllOptions', false);
         });
 
         eventUtils.handleTextInput(originalEvent, () => {
@@ -131,7 +136,11 @@ module.exports = require('marko-widgets').defineComponent({
             this.setSelectedIndex();
             this.emitChangeEvent();
             this.toggleListbox();
+            this.setState('showAllOptions', false);
         });
+    },
+    handleComboboxFocus() {
+        this.setState('showAllOptions', true);
     },
     handleComboboxBlur(evt) {
         const wasClickedOption = this.getEls('option').some(option => option === evt.relatedTarget);
@@ -152,6 +161,8 @@ module.exports = require('marko-widgets').defineComponent({
         this.setSelectedIndex();
         this.emitChangeEvent('select');
         this.expander.collapse();
+
+        this.setState('showAllOptions', false);
     },
     setSelectedIndex(index = 0) {
         const newIndex = index || this.getSelectedIndex(this.state.options, this.state.currentValue);

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -22,8 +22,7 @@ module.exports = require('marko-widgets').defineComponent({
         return Object.assign({}, input, {
             autocomplete,
             selectedIndex: index === -1 ? null : index,
-            currentValue,
-            showAllOptions: false
+            currentValue
         });
     },
     init() {
@@ -55,7 +54,7 @@ module.exports = require('marko-widgets').defineComponent({
 
             this.expander = new Expander(this.el, {
                 autoCollapse: true,
-                expandOnFocus: this.state.expandOnFocus || true,
+                expandOnFocus: true,
                 expandOnClick: this.state.readonly && !this.state.disabled,
                 collapseOnFocusOut: !this.state.readonly,
                 contentSelector: '.combobox__options',
@@ -87,7 +86,6 @@ module.exports = require('marko-widgets').defineComponent({
         elementScroll.scroll(this.getEls('option')[index]);
         this.moveCursorToEnd();
         emitAndFire(this, 'combobox-expand');
-        this.setState('showAllOptions', true);
     },
     handleCollapse() {
         emitAndFire(this, 'combobox-collapse');
@@ -108,7 +106,6 @@ module.exports = require('marko-widgets').defineComponent({
         eventUtils.handleUpDownArrowsKeydown(originalEvent, () => {
             if (this.expander && !this.expander.isExpanded() && this.getEls('option').length > 0) {
                 this.expander.expand();
-                this.setState('showAllOptions', true);
             }
             this.moveCursorToEnd();
         });
@@ -122,13 +119,11 @@ module.exports = require('marko-widgets').defineComponent({
                     this.emitChangeEvent('select');
                 }
                 this.toggleListbox();
-                this.setState('showAllOptions', false);
             }
         });
 
         eventUtils.handleEscapeKeydown(originalEvent, () => {
             this.expander.collapse();
-            this.setState('showAllOptions', false);
         });
 
         eventUtils.handleTextInput(originalEvent, () => {
@@ -136,11 +131,7 @@ module.exports = require('marko-widgets').defineComponent({
             this.setSelectedIndex();
             this.emitChangeEvent();
             this.toggleListbox();
-            this.setState('showAllOptions', false);
         });
-    },
-    handleComboboxFocus() {
-        this.setState('showAllOptions', true);
     },
     handleComboboxBlur(evt) {
         const wasClickedOption = this.getEls('option').some(option => option === evt.relatedTarget);
@@ -161,8 +152,6 @@ module.exports = require('marko-widgets').defineComponent({
         this.setSelectedIndex();
         this.emitChangeEvent('select');
         this.expander.collapse();
-
-        this.setState('showAllOptions', false);
     },
     setSelectedIndex(index = 0) {
         const newIndex = index || this.getSelectedIndex(this.state.options, this.state.currentValue);

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -29,7 +29,6 @@
             disabled=data.disabled
             aria-autocomplete=data.autocomplete
             aria-haspopup='listbox'
-            w-on-focus='handleComboboxFocus'
             w-on-blur='handleComboboxBlur'
             w-on-keyup='handleComboboxKeyUp'
             autocomplete="new-password"
@@ -47,7 +46,7 @@
                 <var isSelected=(selectedOption === option)/>
                 <var isVisible=(data.autocomplete === 'list' && (isSelected || currentValueReg.test(option.text)) || data.autocomplete === 'none')/>
                 <div
-                    if(data.showAllOptions || isVisible && option.text)
+                    if(isVisible && option.text)
                     w-id="option[]"
                     role='option'
                     class=['combobox__option', option.class]

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -29,6 +29,7 @@
             disabled=data.disabled
             aria-autocomplete=data.autocomplete
             aria-haspopup='listbox'
+            w-on-focus='handleComboboxFocus'
             w-on-blur='handleComboboxBlur'
             w-on-keyup='handleComboboxKeyUp'
             autocomplete="new-password"
@@ -46,7 +47,7 @@
                 <var isSelected=(selectedOption === option)/>
                 <var isVisible=(data.autocomplete === 'list' && (isSelected || currentValueReg.test(option.text)) || data.autocomplete === 'none')/>
                 <div
-                    if(isVisible && option.text)
+                    if(data.showAllOptions || isVisible && option.text)
                     w-id="option[]"
                     role='option'
                     class=['combobox__option', option.class]

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -58,9 +58,6 @@
                     data-option-value=option.value
                     ${processHtmlAttributes(option)}>
                     <span>${option.text}</span>
-                    <if(data.metaText)>
-                        <span class="combobox__option-meta">${data.metaText}</span>
-                    </if>
                 </div>
             </for>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,10 @@
   version "1.0.1"
   resolved "https://registry.npmjs.org/@ebay/browserslist-config/-/browserslist-config-1.0.1.tgz#deccafb04101fa52507b8f2204161c8ed5e70375"
 
-"@ebay/skin@7.1.1":
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-7.1.1.tgz#a9ff804e2b920feda0d3010ded2ee0415acde3c1"
-  integrity sha512-5JazouPK1r7EyhZ2YSyY8rY7zH4qTR+330QuSR7omrYfKlM6h0TT1OZyxpD/ZovpMRHKC/3mbe0cM4Ml5Czgag==
+"@ebay/skin@7.1.2":
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/@ebay/skin/-/skin-7.1.2.tgz#5f16dcede0de4ce34d5a275c8be28a7cf6e8bd80"
+  integrity sha512-Cu7CDlqh0OYHPn2DEHR+y5mYMNi6kqHn4uaxRXzE67q00V2Qz6F15PM8ilNOfIvDu/zWSuQRV+MtfEtmuvxxXg==
 
 "@lasso/marko-taglib@^1.0.13":
   version "1.0.13"


### PR DESCRIPTION
## Description
- updated Skin for Edge/IE clear button fix
- <strike>on first expand of the listbox now show all options</strike>
- <strike>added a `expand-on-focus` attribute to allow turning off the `makeup-expander`'s expandOnFocus option flag</strike>

## Context
The Edge/IE clear button fix will allow for a better experience for those users, as there was some conflict with how it worked and how the combobox should behave.

<strike>When a combobox has a pre-filled value and users first expand focus on the listbox input the may not have an understanding that there are multiple options. Showing all options when first focus the listbox will help with discoverability and usability going forward.</strike>

<strike>Adding the `expand-on-focus` attribute is a nice-to-have that was low effort and can squeeze into these other changes.</strike>

## References
<strike>Fixes #649 </strike>
Fixes #640