### PR TITLE
Fix build scripts

### DIFF
--- a/scripts/postpublish.js
+++ b/scripts/postpublish.js
@@ -1,23 +1,14 @@
 const fs = require('fs');
+const path = require('path');
 const del = require('del');
-
-const pathPrefix = `${ __dirname }/..`;
+const rootDir = path.join(__dirname, '..');
 
 // remove files created by prepublish
-del.sync([`${pathPrefix}/*.browser.json`, `${pathPrefix}/dist`]);
+del.sync([path.join(rootDir, '*.browser.json'), path.join(rootDir, 'dist')]);
 
 // undo marko.json changes made by prepublish
-const markoConfigPath = `${pathPrefix}/marko.json`;
-const markoConfig = require(markoConfigPath);
-Object.keys(markoConfig).forEach((key) => {
-    const tagConfig = markoConfig[key];
-
-    if (tagConfig.renderer) {
-        tagConfig.renderer = tagConfig.renderer.replace('./dist', './src');
-    }
-
-    if (tagConfig.transformer) {
-        tagConfig.transformer = tagConfig.transformer.replace('./dist', './src');
-    }
-});
-fs.writeFileSync(markoConfigPath, `${JSON.stringify(markoConfig, null, 4)}\n`);
+const markoConfigPath = path.join(rootDir, '/marko.json');
+fs.writeFileSync(
+    markoConfigPath,
+    fs.readFileSync(markoConfigPath, 'utf-8').replace(/\.\/dist\//g, './src/')
+);


### PR DESCRIPTION
## Description

The current build script only updates the `src` => `dist` paths in the `marko.json` for `renderer` and `transformers`.

In this PR I made the build script more generic and just replace `./src/` with `./dist/` in the entire `marko.json` to avoid this issue in the future.

I also cleaned them up a little bit to avoid using string concat for building paths, and to remove a section of code related to updating the `src` => `dist` within the `browser.json` for individual components. This is not needed because all dependencies of components should be within the `src` folder anyways, with relative paths, or a node_module.

## Context
My refactor in 2.4.0 changed some of the components to no longer need a renderer. Since their config now just points to a template the build script was not updating the `marko.json` path properly.
