### PR TITLE
Force svg namespace for icons in marko 4

### DIFF
--- a/src/components/ebay-icon/index.marko
+++ b/src/components/ebay-icon/index.marko
@@ -23,6 +23,7 @@
         data.class,
         !data.noSkinClasses && "icon icon--${data.name}"
     ]
+    xmlns=(isInline && "http://www.w3.org/2000/svg")
     style=data.style
     focusable=(isInline && "false")
     ${processHtmlAttributes(data)}


### PR DESCRIPTION
## Description
In my refactor I changed the icon component to use a dynamic tag to switch between `span` and `svg`. Currently there is an issue in Marko 4 where the dynamic tag does not properly set the proper namespace unless explicitly supplied when using the dynamic tag: https://github.com/marko-js/marko/issues/1098

## Context
I'm attempting to make a proper fix to this (and namespaces in general) in Marko 4, but this PR will ensure that the icon continues to work with older versions of Marko 4 as well.

## References
Fixes #665 