### PR TITLE
Fix dependency paths in src

### DIFF
--- a/src/components/ebay-button/browser.json
+++ b/src/components/ebay-button/browser.json
@@ -7,8 +7,8 @@
                 "@ebay/skin/button"
             ]
         },
-        "../../../src/components/ebay-badge",
-        "../../../src/components/ebay-icon",
+        "../ebay-badge",
+        "../ebay-icon",
         "require: ./index.js"
     ]
 }

--- a/src/components/ebay-carousel/browser.json
+++ b/src/components/ebay-carousel/browser.json
@@ -3,7 +3,7 @@
         "require: marko-widgets",
         "require-run: nodelist-foreach-polyfill",
         "require: ./index.js",
-        "../../../src/components/ebay-icon",
+        "../ebay-icon",
         {
             "if-not-flag": "ebayui-no-skin",
             "dependencies": [

--- a/src/components/ebay-checkbox/browser.json
+++ b/src/components/ebay-checkbox/browser.json
@@ -7,7 +7,7 @@
                 "@ebay/skin/field"
             ]
         },
-        "../../../src/components/ebay-icon",
+        "../ebay-icon",
         "require: ./index.js"
     ]
 }

--- a/src/components/ebay-dialog/browser.json
+++ b/src/components/ebay-dialog/browser.json
@@ -1,7 +1,7 @@
 {
     "dependencies": [
         "require: ./index.js",
-        "../../../src/components/ebay-icon",
+        "../ebay-icon",
         {
             "if-not-flag": "ebayui-no-skin",
             "path": "@ebay/skin/dialog"

--- a/src/components/ebay-menu/browser.json
+++ b/src/components/ebay-menu/browser.json
@@ -4,9 +4,9 @@
             "if-not-flag": "ebayui-no-skin",
             "path": "@ebay/skin/menu"
         },
-        "../../../src/components/ebay-badge",
-        "../../../src/components/ebay-button",
-        "../../../src/components/ebay-icon",
+        "../ebay-badge",
+        "../ebay-button",
+        "../ebay-icon",
         "require-run: nodelist-foreach-polyfill",
         "require-run: element-closest/browser",
         "require: marko-widgets",

--- a/src/components/ebay-pill/browser.json
+++ b/src/components/ebay-pill/browser.json
@@ -3,7 +3,7 @@
             "if-not-flag": "ebayui-no-skin",
             "path": "@ebay/skin/button"
         },
-        "../../../src/components/ebay-button",
+        "../ebay-button",
         "require: ./index.js",
         "./style.less"
     ]

--- a/src/components/ebay-radio/browser.json
+++ b/src/components/ebay-radio/browser.json
@@ -7,7 +7,7 @@
                 "@ebay/skin/field"
             ]
         },
-        "../../../src/components/ebay-icon",
+        "../ebay-icon",
         "require: ./index.js"
     ]
 }

--- a/src/components/ebay-select/browser.json
+++ b/src/components/ebay-select/browser.json
@@ -7,7 +7,7 @@
                 "@ebay/skin/icon/foreground"
             ]
         },
-        "../../../src/components/ebay-button",
+        "../ebay-button",
         "require: ./index.js"
     ]
 }

--- a/src/components/ebay-textbox/browser.json
+++ b/src/components/ebay-textbox/browser.json
@@ -7,7 +7,7 @@
         "@ebay/skin/textbox"
       ]
     },
-    "../../../src/components/ebay-icon",
+    "../ebay-icon",
     "require: ./index.js"
   ]
 }


### PR DESCRIPTION
## Description
This is a continuation of #662. I thought I checked all of the paths but I must have made a mistake. The new build script assumes that the browser.json's inside of src do not reference the src directory since they should not need too. However a few of our components for some reason walk all the way up to src instead of just referencing the dependency using the shortest relative path.

This PR updates those browser.json's to just use a relative path that does not reference the `src` folder.

## References
Continuation of #662 and should fix #663 
