### PR TITLE
Button - fixes double event firing on Space or Enter keys

### DIFF
--- a/src/components/ebay-button/index.js
+++ b/src/components/ebay-button/index.js
@@ -17,15 +17,7 @@ module.exports = require('marko-widgets').defineComponent({
             emitAndFire(this, 'button-click', { originalEvent });
         }
     },
-    /**
-     * Handle a11y features
-     * https://ebay.gitbooks.io/mindpatterns/content/input/button.html#keyboard
-     * @param {MouseEvent} e
-     */
     handleKeydown(originalEvent) {
-        eventUtils.handleActionKeydown(originalEvent, () => {
-            this.handleClick(originalEvent);
-        });
         eventUtils.handleEscapeKeydown(originalEvent, () => {
             if (!this.state.disabled) {
                 emitAndFire(this, 'button-escape', { originalEvent });

--- a/src/components/ebay-button/test/test.browser.js
+++ b/src/components/ebay-button/test/test.browser.js
@@ -33,20 +33,6 @@ describe('given button is enabled', () => {
         });
     });
 
-    describe('when button is clicked via action key', () => {
-        let spy;
-        beforeEach(() => {
-            spy = sinon.spy();
-            widget.on('button-click', spy);
-            testUtils.triggerEvent(root, 'keydown', 32);
-        });
-
-        test('then it emits the event with correct data', () => {
-            expect(spy.calledOnce).to.equal(true);
-            testUtils.testOriginalEvent(spy);
-        });
-    });
-
     describe('when escape key is pressed', () => {
         let spy;
         beforeEach(() => {

--- a/src/components/ebay-pill/test/test.browser.js
+++ b/src/components/ebay-pill/test/test.browser.js
@@ -49,20 +49,6 @@ describe('given pill is enabled', () => {
         });
     });
 
-    describe('when pill is clicked via action key', () => {
-        let spy;
-        beforeEach(() => {
-            spy = sinon.spy();
-            widget.on('button-click', spy);
-            testUtils.triggerEvent(root, 'keydown', 32);
-        });
-
-        test('then it emits the event with correct data', () => {
-            expect(spy.calledOnce).to.equal(true);
-            testUtils.testOriginalEvent(spy);
-        });
-    });
-
     describe('when escape key is pressed', () => {
         let spy;
         beforeEach(() => {


### PR DESCRIPTION
## Description
- removes keydown event listener for "action" keys (space/enter)

## Context
When a button is clicked via the mouse it will fire a `click` event as is expected. Also, when a button is "pressed" via an action key (Space bar or Enter key), it will fire both a `keydown` event _and_ and `click` event. Therefore, both were emitting the `button-click` event from the component, when in reality only the `click` event should be handled.

I tested this with IE11 (as well as other browsers) where I confirmed the `click` event fires with the action keys.

## References
Fixes #666 