### PR TITLE
Textbox: Fix disable capability;

### DIFF
--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -6,6 +6,11 @@ module.exports = require('marko-widgets').defineComponent({
     getWidgetConfig(input) {
         return { floatingLabel: input.floatingLabel };
     },
+    getInitialState(input) {
+        return Object.assign({}, input, {
+            disabled: Boolean(input.disabled)
+        });
+    },
     init(config) {
         this.config = config;
         this.initFloatingLabel();
@@ -38,9 +43,11 @@ module.exports = require('marko-widgets').defineComponent({
 
 function forwardEvent(eventName) {
     return function(originalEvent, el) {
-        emitAndFire(this, `textbox-${eventName}`, {
-            originalEvent,
-            value: (el || this.el.querySelector('input, textarea')).value
-        });
+        if (!this.state.disabled) {
+            emitAndFire(this, `textbox-${eventName}`, {
+                originalEvent,
+                value: (el || this.el.querySelector('input, textarea')).value
+            });
+        }
     };
 }

--- a/src/components/ebay-textbox/index.js
+++ b/src/components/ebay-textbox/index.js
@@ -43,11 +43,9 @@ module.exports = require('marko-widgets').defineComponent({
 
 function forwardEvent(eventName) {
     return function(originalEvent, el) {
-        if (!this.state.disabled) {
-            emitAndFire(this, `textbox-${eventName}`, {
-                originalEvent,
-                value: (el || this.el.querySelector('input, textarea')).value
-            });
-        }
+        emitAndFire(this, `textbox-${eventName}`, {
+            originalEvent,
+            value: (el || this.el.querySelector('input, textarea')).value
+        });
     };
 }

--- a/src/components/ebay-textbox/template.marko
+++ b/src/components/ebay-textbox/template.marko
@@ -43,6 +43,7 @@
             data.type === "password" ? "password" : "text"
         )
         value=(!data.multiline && data.value)
+        disabled=data.disabled
         aria-invalid=(data.invalid && "true")
         w-onkeydown="handleKeydown"
         w-onchange="handleChange"

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -34,6 +34,35 @@ describe('given an input textbox', () => {
     });
 });
 
+describe('given a disabled input textbox', () => {
+    let root;
+    let input;
+
+    beforeEach(() => {
+        widget = renderer.renderSync({ value: 'val', disabled: true }).appendTo(document.body).getWidget();
+        root = document.querySelector('.textbox');
+        input = root.querySelector('input');
+    });
+
+    afterEach(() => widget.destroy());
+
+    ['change', 'input', 'focus', 'blur', 'keydown'].forEach(eventName => {
+        describe(`when native event is fired: ${eventName}`, () => {
+            let spy;
+
+            beforeEach(() => {
+                spy = sinon.spy();
+                widget.on(`textbox-${eventName}`, spy);
+                testUtils.triggerEvent(input, eventName);
+            });
+
+            test('then it does not emit the event', () => {
+                expect(spy.calledOnce).to.equal(false);
+            });
+        });
+    });
+});
+
 describe('given an input textbox with floating label', () => {
     let root;
     let input;

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -34,35 +34,6 @@ describe('given an input textbox', () => {
     });
 });
 
-describe('given a disabled input textbox', () => {
-    let root;
-    let input;
-
-    beforeEach(() => {
-        widget = renderer.renderSync({ value: 'val', disabled: true }).appendTo(document.body).getWidget();
-        root = document.querySelector('.textbox');
-        input = root.querySelector('input');
-    });
-
-    afterEach(() => widget.destroy());
-
-    ['change', 'input', 'focus', 'blur', 'keydown'].forEach(eventName => {
-        describe(`when native event is fired: ${eventName}`, () => {
-            let spy;
-
-            beforeEach(() => {
-                spy = sinon.spy();
-                widget.on(`textbox-${eventName}`, spy);
-                testUtils.triggerEvent(input, eventName);
-            });
-
-            test('then it does not emit the event', () => {
-                expect(spy.calledOnce).to.equal(false);
-            });
-        });
-    });
-});
-
 describe('given an input textbox with floating label', () => {
     let root;
     let input;

--- a/src/components/ebay-textbox/test/test.server.js
+++ b/src/components/ebay-textbox/test/test.server.js
@@ -104,6 +104,8 @@ describe('ebay-textbox', () => {
         const $ = testUtils.getCheerio(context.render(input));
         expect($(floatingLabelDisabledSelector).text()).to.equal('Email address');
         expect($(inputUnderlineSelector).length).to.equal(1);
+        expect($(inputUnderlineSelector).attr('disabled')).to.not.equal(null);
+        expect($(inputUnderlineSelector).attr('disabled')).to.equal('disabled');
     });
 
     test('handles pass-through html attributes', context => testUtils.testHtmlAttributes(context, inputSelector));


### PR DESCRIPTION
## Description
- adds state with `disabled` property to widget
- adds discrete disabled attribute to text input in the template
- new tests to cover the component when it's disabled to prevent events from firing

## References
Fixes #669