### PR TITLE
Fix issue with icons not rendering

### DIFF
--- a/src/components/ebay-icon/index.marko
+++ b/src/components/ebay-icon/index.marko
@@ -2,9 +2,10 @@
     var getWidgetId = require("../../common/get-marko-3-widget-id");
     var processHtmlAttributes = require("../../common/html-attributes");
     var isBrowser = typeof window !== "undefined";
-    var defined = isBrowser ? (window.$ebayIcons = window.$ebayIcons || {}) : {};
+    var browserLookup = {};
 </script>
 
+<var lookup=(isBrowser ? browserLookup : out.global)/>
 <var isInline=(data.type === "inline")/>
 <var a11yAttributes/>
 <var titleId/>
@@ -30,12 +31,12 @@
     ${a11yAttributes}>
     <if(isInline)>
         <!-- Here we check if we should render the inline svg symbol. -->
-        <!-- Server side we store a flag in `out` to check if the symbol was rendered. -->
-        <!-- Client side we check the `defined` object to see if the symbol is already present in root svg. -->
+        <!-- Server side we store a flag in `out.global` to check if the symbol was rendered. -->
+        <!-- Client side we check the `browserLookup` object to see if the symbol is already present in root svg. -->
         <var themes=data._themes/>
-        <var lookupName="rendered_ebay_icon_${data.name}"/>
-        <var renderDefs=(!out[lookupName] && !defined[lookupName])/>
-        <assign out[lookupName]=true/>
+        <var lookupName=("rendered_ebay_icon_" + data.name)/>
+        <var renderDefs=!lookup[lookupName]/>
+        <assign lookup[lookupName]=true/>
 
         <if(renderDefs && themes)>
             <defs w-id="defs">

--- a/src/components/ebay-icon/widget.js
+++ b/src/components/ebay-icon/widget.js
@@ -1,4 +1,3 @@
-const defined = window.$ebayIcons = window.$ebayIcons || {};
 let rootSvg;
 
 module.exports = require('marko-widgets').defineWidget({
@@ -18,9 +17,6 @@ module.exports = require('marko-widgets').defineWidget({
             defs.parentNode.removeChild(defs);
 
             if (symbol) {
-                // Here we get the name of the symbol by removing the `icon-` part.
-                // We then mark this symbol as `defined` so that no other `ebay-icons` render it.
-                defined[`rendered_ebay_icon_${ symbol.id.slice(5)}`] = true;
                 rootSvg.appendChild(symbol);
             }
         }


### PR DESCRIPTION
## Description
There is a regression in the auto migrations for Marko 4 which is causing https://github.com/eBay/ebayui-core/compare/2.4.0...678-carousel-icons?expand=1#diff-e903ebc606321df3c58edb92295b2388L36 to become a literal string without interpolating the `data.name`. This is making it so that effectively only the first icon is ever sent to the browser in Marko 4.

This PR updates it to use regular string concatenation which works in all versions of Marko 3 & 4, but this should be given a closer look in Marko 4 to fix the regression.

I also updated this to simplify the lookup which actually isn't needed in the widget file since we can mark the symbols as defined immediately after checking if we are going to render it. This allowed me to easily avoid using a global variable for storing which symbols were defined in the browser which is a bit cleaner and would avoid any issues with having multiple versions of the icon component on the page.

## References
Fixes #678 