### PR TITLE
Combobox: Fix to not force cursor to end of text

### DIFF
--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -63,8 +63,6 @@ module.exports = require('marko-widgets').defineComponent({
                 simulateSpacebarClick: true
             });
         }
-
-        this.moveCursorToEnd();
     },
     onBeforeUpdate() {
         this._handleDestroy();


### PR DESCRIPTION
## Description
- removes forced cursor to end on re-render

## Context
When typing users were always pushed to the end, even if they were typing in the middle or beginning of the field.

## References
Fixes #641 