### PR TITLE
Select: Fix handler for select change

### DIFF
--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -14,7 +14,7 @@
     ]
     style=data.style>
     <select
-        w-onchange="optionChanged"
+        w-onchange="handleChange"
         disabled=data.disabled
         ${processHtmlAttributes(data)}>
         <for(option in options)>

--- a/src/components/ebay-select/test/test.browser.js
+++ b/src/components/ebay-select/test/test.browser.js
@@ -1,5 +1,6 @@
 const sinon = require('sinon');
 const expect = require('chai').expect;
+const testUtils = require('../../../common/test-utils/browser');
 const mock = require('../mock');
 const renderer = require('../');
 
@@ -58,6 +59,32 @@ describe('given the select is in the default state', () => {
             spy = sinon.spy();
             widget.on('select-change', spy);
             root.value = expectedValue;
+            setTimeout(done);
+        });
+
+        test('then it emits the select-change event with the correct data', () => {
+            const eventData = spy.getCall(0).args[0];
+            expect(spy.calledOnce).to.equal(true);
+            expect(eventData.index).to.equal(expectedIndex);
+            expect(eventData.selected).to.deep.equal([expectedValue]);
+            expect(root.value).to.equal(expectedValue);
+            expect(root.selectedIndex).to.equal(expectedIndex);
+            expect(selectElement.value).to.equal(expectedValue);
+            expect(selectElement.selectedIndex).to.equal(expectedIndex);
+        });
+    });
+
+    describe('when the index is set through dom change event', () => {
+        const expectedIndex = 1;
+        const expectedValue = '2';
+        let spy;
+
+        beforeEach((done) => {
+            spy = sinon.spy();
+            widget.on('select-change', spy);
+            const select = root.querySelector('select');
+            select.selectedIndex = expectedIndex;
+            testUtils.triggerEvent(select, 'change');
             setTimeout(done);
         });
 


### PR DESCRIPTION
## Description
In my refactor I renamed the event handler for the `ebay-select` without updating it in the template.
This PR fixes the name in the template and adds a test that ensures it is handled.

## References
Fixes #686 

