### PR TITLE
2.4.1 - Sanity check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebay/ebayui-core",
-  "version": "2.4.0",
+  "version": "2.4.1-0",
   "description": "Collection of core eBay components; considered to be the building blocks for all composite structures, pages & apps.",
   "scripts": {
     "installMarkoV3": "yarn add marko@^3 marko-widgets@^6 -D",

--- a/src/components/ebay-select/README.md
+++ b/src/components/ebay-select/README.md
@@ -41,8 +41,6 @@ Note: For this component, `class`/`style` are applied to the root tag, while all
 
 Event | Data |  Description
 --- | --- | ---
-`select-collapse` | | collapse content
-`select-expand` | | expand content
 `select-change` | `{ el, index, selected }` | option selected
 ---
 

--- a/src/components/ebay-select/template.marko
+++ b/src/components/ebay-select/template.marko
@@ -14,7 +14,7 @@
     ]
     style=data.style>
     <select
-        w-onchange="optionChanged"
+        w-onchange="handleChange"
         disabled=data.disabled
         ${processHtmlAttributes(data)}>
         <for(option in options)>

--- a/src/components/ebay-select/test/test.browser.js
+++ b/src/components/ebay-select/test/test.browser.js
@@ -1,5 +1,6 @@
 const sinon = require('sinon');
 const expect = require('chai').expect;
+const testUtils = require('../../../common/test-utils/browser');
 const mock = require('../mock');
 const renderer = require('../');
 
@@ -58,6 +59,32 @@ describe('given the select is in the default state', () => {
             spy = sinon.spy();
             widget.on('select-change', spy);
             root.value = expectedValue;
+            setTimeout(done);
+        });
+
+        test('then it emits the select-change event with the correct data', () => {
+            const eventData = spy.getCall(0).args[0];
+            expect(spy.calledOnce).to.equal(true);
+            expect(eventData.index).to.equal(expectedIndex);
+            expect(eventData.selected).to.deep.equal([expectedValue]);
+            expect(root.value).to.equal(expectedValue);
+            expect(root.selectedIndex).to.equal(expectedIndex);
+            expect(selectElement.value).to.equal(expectedValue);
+            expect(selectElement.selectedIndex).to.equal(expectedIndex);
+        });
+    });
+
+    describe('when the index is set through dom change event', () => {
+        const expectedIndex = 1;
+        const expectedValue = '2';
+        let spy;
+
+        beforeEach((done) => {
+            spy = sinon.spy();
+            widget.on('select-change', spy);
+            const select = root.querySelector('select');
+            select.selectedIndex = expectedIndex;
+            testUtils.triggerEvent(select, 'change');
             setTimeout(done);
         });
 


### PR DESCRIPTION
## Description
- fixes `select-change` event handler
- removes invalid events named in docs

## Context
This is a sanity check PR.

## References
Fixes #686 