### PR TITLE
703 - Fix missing type attribute

### DIFF
--- a/src/components/ebay-listbox/template.marko
+++ b/src/components/ebay-listbox/template.marko
@@ -23,6 +23,7 @@
             data.borderless && "expand-btn--borderless"
         ]
         value=selectedText
+        type="button"
         disabled=data.disabled
         aria-haspopup="listbox"
         w-preserve-attrs="aria-expanded,aria-controls">


### PR DESCRIPTION
## Description
- adds `type="button"` to the `<ebay-listbox>` button

## Context
Because the `type` was omitted, `<ebay-listbox>` defaulted the button to a submit type, which is incorrect.

## References
Fixes #703 