### PR TITLE
Combobox: fixes logic with no options;

### DIFF
--- a/src/components/ebay-combobox/examples/05-no-options/template.marko
+++ b/src/components/ebay-combobox/examples/05-no-options/template.marko
@@ -1,0 +1,1 @@
+<ebay-combobox name="example2text" autocomplete="list"></ebay-combobox>

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -46,7 +46,7 @@ module.exports = require('marko-widgets').defineComponent({
         const isExpanded = this.expanded = this.state.expanded;
         const wasToggled = isExpanded !== wasExpanded;
 
-        if (!this.state.disabled && this.state.options.length) {
+        if (!this.state.disabled && this.state.options.length > 0) {
             const selectedIndex = this.getSelectedIndex(this.state.options, this.state.currentValue);
 
             const autoInit = (selectedIndex === -1 || this.state.autocomplete === 'none') ? -1 : 0;
@@ -148,7 +148,9 @@ module.exports = require('marko-widgets').defineComponent({
             this.setState('currentValue', newValue);
             this.setSelectedIndex();
             this.emitChangeEvent();
-            this.toggleListbox();
+            if (this.expander) {
+                this.toggleListbox();
+            }
         });
     },
     handleComboboxBlur(evt) {
@@ -159,9 +161,10 @@ module.exports = require('marko-widgets').defineComponent({
         }
 
         if (this.expander && this.expander.isExpanded() && !wasClickedOption) {
-            this.emitChangeEvent('change');
             this.expander.collapse();
         }
+
+        this.emitChangeEvent('change');
     },
     handleOptionClick(evt) {
         const selectedEl = evt.target.nodeName === 'DIV' ? evt.target : evt.target.parentNode;
@@ -194,7 +197,7 @@ module.exports = require('marko-widgets').defineComponent({
             (this.state.autocomplete === 'list' && this.state.options.some(option => queryReg.test(option.text)))
             || this.state.autocomplete === 'none';
 
-        if (!showListbox) {
+        if (!showListbox && this.expander) {
             this.expander.collapse();
         } else {
             this.expander.expand();

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -197,10 +197,12 @@ module.exports = require('marko-widgets').defineComponent({
             (this.state.autocomplete === 'list' && this.state.options.some(option => queryReg.test(option.text)))
             || this.state.autocomplete === 'none';
 
-        if (!showListbox && this.expander) {
-            this.expander.collapse();
-        } else {
-            this.expander.expand();
+        if (this.expander) {
+            if (!showListbox) {
+                this.expander.collapse();
+            } else {
+                this.expander.expand();
+            }
         }
     }
 });


### PR DESCRIPTION
## Description
- adds no options example
- proper options length check in render
- expander check in keyUp handler
- expander check in `toggleListbox` function
- moves change event to make it work properly with the `blur`

## Context
Where there were no options available there would be errors. Also, the blur was not sending the change event when there were no options.

## References
Fixes #651 & #710 