### PR TITLE
Menu: fix event firing when radio item already selected

### DIFF
--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -195,11 +195,6 @@ function onRender(event) {
     }
 }
 
-/**
- * Internal marko function, can be triggered from both makeup and API
- * http://v3.markojs.com/docs/marko-widgets/javascript-api/#setstatedirtyname-value
- * @param {Boolean} expanded
- */
 function update_expanded(expanded) { // eslint-disable-line camelcase
     if ((expanded && this.buttonEl.getAttribute('aria-expanded') === 'false') ||
         (!expanded && this.buttonEl.getAttribute('aria-expanded') === 'true')) {
@@ -207,10 +202,6 @@ function update_expanded(expanded) { // eslint-disable-line camelcase
     }
 }
 
-/**
- * Common processing after data change via both UI and API
- * @param {Array} itemIndexes
- */
 function processAfterStateChange(itemIndexes) {
     const itemIndex = itemIndexes[(itemIndexes.length - 1)];
     const itemEl = this.itemEls[itemIndex];
@@ -244,11 +235,6 @@ function processAfterStateChange(itemIndexes) {
     }
 }
 
-/**
- * Handle normal mouse click for item
- * @param {MouseEvent} e
- * @param {HTMLElement} itemEl
- */
 function handleItemClick(e, itemEl) {
     const itemElIndex = getItemElementIndex(itemEl);
     if (this.getCheckedList().indexOf(itemElIndex) === -1) {
@@ -258,11 +244,6 @@ function handleItemClick(e, itemEl) {
     }
 }
 
-/**
- * Set the checked item based on the index
- * @param {Integer} itemIndex
- * @param {Boolean} toggle
- */
 function setCheckedItem(itemIndex, toggle) {
     const item = this.state.items[itemIndex];
 
@@ -288,8 +269,6 @@ function setCheckedItem(itemIndex, toggle) {
 /**
  * Handle a11y for item (is not handled by makeup)
  * https://ebay.gitbooks.io/mindpatterns/content/input/menu.html#keyboard
- * @param {KeyboardEvent} e
- * @param {HTMLElement} itemEl
  */
 function handleItemKeydown(e, itemEl) {
     eventUtils.handleActionKeydown(e, () => {
@@ -306,7 +285,6 @@ function handleItemKeydown(e, itemEl) {
  * For any key that corresponds to a printable character, move focus to
  * the first menu item whose label begins with that character.
  * https://www.w3.org/TR/wai-aria-practices-1.1/#menu
- * @param {KeyboardEvent} e
  */
 function handleItemKeypress(e) {
     const itemIndex = NodeListUtils.findNodeWithFirstChar(this.itemEls, e.key);
@@ -333,10 +311,6 @@ function handleCollapse() {
     scrollKeyPreventer.remove(this.contentEl);
 }
 
-/**
- * Determine currently checked items (for checkbox case)
- * @returns {Array} checked indexes
- */
 function getCheckedList() {
     const checked = [];
     this.state.items.forEach((item, i) => {
@@ -351,10 +325,6 @@ function getItemElementIndex(itemEl) {
     return Array.prototype.slice.call(itemEl.parentNode.children).indexOf(itemEl);
 }
 
-/**
- * Set the list of options by their index
- * @param {Array} indexArray
- */
 function setCheckedList(indexArray) {
     if (indexArray) {
         this.state.items.forEach((item) => {

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -250,7 +250,12 @@ function processAfterStateChange(itemIndexes) {
  * @param {HTMLElement} itemEl
  */
 function handleItemClick(e, itemEl) {
-    this.setCheckedItem(getItemElementIndex(itemEl), true);
+    const itemElIndex = getItemElementIndex(itemEl);
+    if (this.getCheckedList().indexOf(itemElIndex) === -1) {
+        this.setCheckedItem(itemElIndex, true);
+    } else if (this.state.isCheckbox) {
+        this.setCheckedItem(itemElIndex, true);
+    }
 }
 
 /**

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -188,25 +188,6 @@ describe('given the menu is in the expanded state', () => {
         });
     });
 
-    // these two tests are failing on CI.
-    // they are now temporarily disabled in order to unblock v2.3.0-0 prerelease.
-    /*
-    describe('when \'b\' key is pressed on first item', () => {
-        beforeEach((done) => {
-            testUtils.triggerEvent(firstItem, 'keypress', 66, 'b');
-            setTimeout(done);
-        });
-
-        test('then first item loses roving tabindex', () => {
-            expect(firstItem.getAttribute('tabindex')).to.equal('-1');
-        });
-
-        test('then second item gains roving tabindex', () => {
-            expect(secondItem.getAttribute('tabindex')).to.equal('0');
-        });
-    });
-    */
-
     describe('when the escape key is pressed from an item', () => {
         let spy;
         beforeEach((done) => {
@@ -392,6 +373,28 @@ describe('given the menu is in the expanded state with radio items', () => {
         test('then it only selects the second item', () => {
             expect(firstItem.getAttribute('aria-checked')).to.equal('false');
             expect(secondItem.getAttribute('aria-checked')).to.equal('true');
+        });
+    });
+
+    describe('when an already checked item is clicked', () => {
+        let spy;
+        beforeEach((done) => {
+            spy = sinon.spy();
+            widget.on('menu-change', spy);
+            testUtils.triggerEvent(firstItem, 'click');
+            testUtils.triggerEvent(firstItem, 'click');
+            setTimeout(done);
+        });
+
+        test('then it emits the menu-change events with correct data', () => {
+            const firstEventData = spy.getCall(0).args[0];
+            expect(spy.calledOnce).to.equal(true);
+            expect(firstEventData.index).to.equal(0);
+            expect(firstEventData.checked).to.deep.equal([0]);
+        });
+
+        test('then it selects the first item', () => {
+            expect(firstItem.getAttribute('aria-checked')).to.equal('true');
         });
     });
 


### PR DESCRIPTION
## Description
- adds a check for existing index selection before proceeding with checking the item

## Context
When a user would click an already-checked radio menu item we would still fire the `menu-change` event. Adding this check prevents the component from even trying to go through the "change" flow if the item is already selected.

## References
Relates to #700 
