### PR TITLE
Added check to see where the click started from on dialog

### DIFF
--- a/src/components/ebay-dialog/index.js
+++ b/src/components/ebay-dialog/index.js
@@ -36,8 +36,17 @@ module.exports = require('marko-widgets').defineComponent({
             bodyScroll.restore();
         }
     },
+    handleStartClick({ target }) {
+        this.startEl = target;
+    },
     handleDialogClick({ target, clientY }) {
-        const { closeEl, windowEl } = this;
+        const { closeEl, windowEl, startEl } = this;
+
+        this.startEl = null;
+        if (windowEl.contains(startEl)) {
+            // Started on dialog window and user dragged out, don't close
+            return;
+        }
 
         // Checks if we clicked inside the white panel of the dialog.
         if (!closeEl.contains(target) && windowEl.contains(target)) {

--- a/src/components/ebay-dialog/template.marko
+++ b/src/components/ebay-dialog/template.marko
@@ -20,6 +20,7 @@
     role="dialog"
     w-preserve-attrs="hidden"
     w-onclick="handleDialogClick"
+    w-onmousedown="handleStartClick"
     ${processHtmlAttributes(data)}>
     <div
         w-id="window"


### PR DESCRIPTION
Fixes #734

<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
Added a mousedown event to track the element which has been clicked

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Click triggers when on mouseup if mousedown has been triggered on the same element. Since the dialog is inside the backdrop, it always triggers. 
If the user clicks inside the dialog but then drags outside it will trigger the dialog close. The change was made to check the initial element and only trigger the dialog close when the initial element is not inside the dialog element. 

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
#734 
