### PR TITLE
feat: support for fake-link button variant

### DIFF
--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -17,7 +17,7 @@ Name | Type | Stateful | Description
 `fluid` | Boolean | No |
 `disabled` | Boolean | Yes |
 `partially-disabled` | Boolean | No |
-`variant` | String | No | optional, to alter Skin classes: "expand" / "cta"
+`variant` | String | No | optional, to alter Skin classes: "expand" / "cta" / "fake-link"
 `fixed-height` | Boolean | No | fixes the height based on `size`; defaults to `medium` when no size is specified
 `truncate` | Boolean | No | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows
 `badge-number` | Number | No | used as the number to be placed in the badge

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -11,7 +11,7 @@
 <var isCtaVariant=(variant === 'cta')/>
 <var isBadged=Boolean(data.badgeNumber && isIconVariant)/>
 <var noText=(isIconVariant || isBadged || (isExpandVariant && data.noText))/>
-<var baseClass=(variant ? "${variant}-btn" : "btn")/>
+<var baseClass=(variant ? (variant === 'fake-link' ? variant : "${variant}-btn") : "btn")/>
 <var sizeClass="${baseClass}--${size}"/>
 <var htmlAttributes=processHtmlAttributes(data)/>
 <var tag=(data.href ? "a" : "button")/>


### PR DESCRIPTION
#749 
Support for `fake-link` button variant

![fake-link](https://user-images.githubusercontent.com/7815136/61075986-02fa6480-a3d0-11e9-91c8-a72b9b33a4e7.png)
