### PR TITLE
Carousel: Pause autoplay on user interaction

### DIFF
--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -50,6 +50,7 @@ function getInitialState(input) {
             state.autoplayInterval = parseInt(input.autoplay, 10) || 4000;
             state.classes.push('carousel__autoplay');
             state.paused = isSingleSlide || input.paused; // Force paused state if not enough slides provided;
+            state.interacting = false;
         }
     }
 
@@ -159,7 +160,7 @@ function init() {
 
 function onRender() {
     const { containerEl, listEl, state } = this;
-    const { config, items, autoplayInterval, paused } = state;
+    const { config, items, autoplayInterval, paused, interacting } = state;
 
     // Do nothing for empty carousels.
     if (!items.length) {
@@ -200,7 +201,7 @@ function onRender() {
             }
         }
 
-        if (autoplayInterval && !paused) {
+        if (autoplayInterval && !paused && !interacting) {
             const moveRight = this.move.bind(this, RIGHT);
             this.autoplayTimeout = setTimeout(() => {
                 if (this.isMoving) {
@@ -344,6 +345,14 @@ function handleScroll(scrollLeft) {
         this.setState('index', closest);
         emitAndFire(this, 'carousel-scroll', { index: closest });
     }
+}
+
+function handleStartInteraction() {
+    this.setState('interacting', true);
+}
+
+function handleEndInteraction() {
+    this.setState('interacting', false);
 }
 
 /**
@@ -529,5 +538,7 @@ module.exports = require('marko-widgets').defineComponent({
     move,
     handleMove,
     handleDotClick,
+    handleStartInteraction,
+    handleEndInteraction,
     togglePlay
 });

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -1,7 +1,15 @@
 <div class=data.classes style=data.style w-bind ${data.htmlAttributes}>
     <var config=data.config/>
     <var statusId=("carousel-status-" + widget.id)/>
-    <div w-id="container" class=["carousel__container", data.bothControlsDisabled && "carousel__container--controls-disabled"]>
+    <div
+        w-id="container"
+        class=["carousel__container", data.bothControlsDisabled && "carousel__container--controls-disabled"]
+        w-onfocusin=(data.autoplayInterval && "handleStartInteraction")
+        w-ontouchstart=(data.autoplayInterval && "handleStartInteraction")
+        w-onmouseover=(data.autoplayInterval && "handleStartInteraction")
+        w-onfocusout=(data.autoplayInterval && "handleEndInteraction")
+        w-onmouseout=(data.autoplayInterval && "handleEndInteraction")
+        w-ontouchend=(data.autoplayInterval && "handleEndInteraction")>
         <${data.a11yStatusTag}
             if(data.totalSlides >= 1)
             id=statusId

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -993,8 +993,10 @@ describe('given an autoplay carousel in the default state', () => {
 
         describe('when the interaction has finished', () => {
             beforeEach((done) => {
+                waitForUpdate(widget, () => {
+                    setTimeout(done, 350);
+                });
                 testUtils.triggerEvent(list, 'mouseout');
-                setTimeout(done, 350);
             });
 
             it('then it does autoplay', () => {

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -977,6 +977,36 @@ describe('given an autoplay carousel in the default state', () => {
         });
     });
 
+    describe('when it is interacted with', () => {
+        let updateSpy;
+
+        beforeEach(done => {
+            updateSpy = sinon.spy();
+
+            waitForUpdate(widget, () => {
+                widget.on('carousel-update', updateSpy);
+                setTimeout(done, 350);
+            });
+
+            testUtils.triggerEvent(list, 'mouseover');
+        });
+
+        describe('when the interaction has finished', () => {
+            beforeEach((done) => {
+                testUtils.triggerEvent(list, 'mouseout');
+                setTimeout(done, 350);
+            });
+
+            it('then it does autoplay', () => {
+                expect(updateSpy.calledOnce).to.equal(true);
+            });
+        });
+
+        it('then it does not autoplay', () => {
+            expect(updateSpy.notCalled).to.equal(true);
+        });
+    });
+
     describe('when the pause button is clicked', () => {
         let updateSpy;
 


### PR DESCRIPTION
## Description
Updates the carousel to prevent any slides from happening when in autoplay mode during a user interaction.

User interactions: Focused, hovered, touched.

## References
Fixes #586 
