### PR TITLE
Made infotip render in a paragraph element

### DIFF
--- a/src/components/components/ebay-tooltip-overlay/template.marko
+++ b/src/components/components/ebay-tooltip-overlay/template.marko
@@ -17,7 +17,7 @@
     bottom: data.styleBottom
 } : pointerStyles[data.pointer || "bottom"])/>
 
-<div
+<span
     class="${data.type}__overlay"
     role=typeRoles[data.type]
     aria-labelledby=(data.type === "tourtip" && widget.elId("tourtip-label"))
@@ -25,11 +25,11 @@
     style=overlayStyles
     w-bind>
     <span class="${data.type}__pointer ${data.type}__pointer--${data.pointer}"/>
-    <div class="${data.type}__mask">
-        <div class="${data.type}__cell">
-            <div class="${data.type}__content">
+    <span class="${data.type}__mask">
+        <span class="${data.type}__cell">
+            <span class="${data.type}__content">
                 <if(data.heading)>
-                    <h2
+                    <span
                         class=["${data.type}__heading", data.heading.class]
                         style=data.heading.style
                         w-id="tourtip-label"
@@ -37,13 +37,13 @@
                 </if>
 
                 <if(data.content)>
-                    <div
+                    <span
                         body-only-if(!data.content.class && !data.content.style)
                         class=data.content.class
                         style=data.content.style
-                        w-body=data.content.renderBody/>
+                        w-body=data.content.renderBody></span>
                 </if>
-            </div>
+            </span>
 
             <if(data.type !== "tooltip")>
                 <button
@@ -54,6 +54,6 @@
                     <span aria-hidden="true" role="img"/>
                 </button>
             </if>
-        </div>
-    </div>
-</div>
+        </span>
+    </span>
+</span>

--- a/src/components/ebay-infotip/examples/04-intotip-in-paragraph/template.marko
+++ b/src/components/ebay-infotip/examples/04-intotip-in-paragraph/template.marko
@@ -11,5 +11,4 @@
         </ebay-infotip>
         More paragraph content
     </p>
-
 </div>

--- a/src/components/ebay-infotip/examples/04-intotip-in-paragraph/template.marko
+++ b/src/components/ebay-infotip/examples/04-intotip-in-paragraph/template.marko
@@ -1,0 +1,15 @@
+<div>
+    <em>
+        NOTE: No block elements can be nested in p elements, like div, h1-6, or other p elements.
+        Any content with that will break
+    </em>
+    <p>
+        Some paragraph content
+        <ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information">
+            <ebay-infotip-heading>Important</ebay-infotip-heading>
+            <ebay-infotip-content>This is some important info</ebay-infotip-content>
+        </ebay-infotip>
+        More paragraph content
+    </p>
+
+</div>

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -21,7 +21,7 @@ describe('given the notice is in the default state', () => {
             spy = sinon.spy();
             widget.on('notice-close', spy);
             testUtils.triggerEvent(button, 'click');
-            setTimeout(done, 1000);
+            setTimeout(done);
         });
         test('then root not present in the DOM', () => {
             expect(document.querySelector('section.page-notice')).to.equal(null);

--- a/src/components/ebay-notice/test/test.browser.js
+++ b/src/components/ebay-notice/test/test.browser.js
@@ -21,7 +21,7 @@ describe('given the notice is in the default state', () => {
             spy = sinon.spy();
             widget.on('notice-close', spy);
             testUtils.triggerEvent(button, 'click');
-            setTimeout(done);
+            setTimeout(done, 1000);
         });
         test('then root not present in the DOM', () => {
             expect(document.querySelector('section.page-notice')).to.equal(null);


### PR DESCRIPTION
## Description
<!--- What are the changes? -->
Changed all `<div>`, `<h1-6>`, and `<p>` elements in tooltip overlay to be spans. Since this change is in tooltip, it will affect infotip and tourtip

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This allows us to render inside a `<p>` element but still keep backwards compatibility outside of `<p>` elements.
Also a change in skin `7.4.3` will allow the spans to be formatted correctly: (see https://github.com/eBay/skin/pull/692)

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #729

## Screenshots
<!-- Upload screenshots if appropriate. -->
![image](https://user-images.githubusercontent.com/1755269/61403609-86153200-a88a-11e9-816c-6a2e60e9730f.png)
