### PR TITLE
766 ebay menu marko json

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -224,6 +224,15 @@
     "<ebay-listbox-button-option>": {
         "transformer": "./src/common/transformers/attribute-tags/index.js"
     },
+    "<ebay-menu>": {
+        "transformer": "./src/common/migrators/tag-name/index.js"
+    },
+    "<ebay-menu-item>": {
+        "transformer": "./src/common/migrators/tag-name/index.js"
+    },
+    "<ebay-menu-label>": {
+        "transformer": "./src/common/migrators/tag-name/index.js"
+    },
     "<ebay-menu-button>": {
         "renderer": "./src/components/ebay-menu-button/index.js",
         "transformer": "./src/components/ebay-menu-button/transformer.js",


### PR DESCRIPTION
## Description
In my previous PR to rename the listbox and menu I forgot to add the migrator transforms for the menu which means they are broken in the current version.

This PR adds the missing migrators to the `marko.json`

## References
Fixes #766