### PR TITLE
Adds back missing browser json for menu and listbox

### DIFF
--- a/src/components/ebay-listbox/browser.json
+++ b/src/components/ebay-listbox/browser.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": [
+    "../ebay-listbox-button"
+  ]
+}

--- a/src/components/ebay-menu/browser.json
+++ b/src/components/ebay-menu/browser.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": [
+    "../ebay-menu-button"
+  ]
+}


### PR DESCRIPTION
## Description
With the changes to rename the listbox and menu their folders were deleted along with their `browser.json`. This meant the explicit dependencies to the `browser.json` from apps would error since the name changed. This PR add's back these `browser.json` files and points to the new folders. 

## References
Fixes #772
