### PR TITLE
Menu: Fix nested attribute transforms not running

### DIFF
--- a/src/common/migrators/tag-name/index.js
+++ b/src/common/migrators/tag-name/index.js
@@ -2,7 +2,8 @@ const RENAMES = {
     'ebay-listbox': 'ebay-listbox-button',
     'ebay-listbox-option': 'ebay-listbox-button-option',
     'ebay-menu': 'ebay-menu-button',
-    'ebay-menu-option': 'ebay-menu-button-option'
+    'ebay-menu-item': 'ebay-menu-button-item',
+    'ebay-menu-label': 'ebay-menu-button-label'
 };
 
 /**
@@ -19,7 +20,12 @@ function migrate(el, context) {
             el
         );
 
-        el.setTagName(newName);
+        const replacement = context.createNodeForEl(
+            newName,
+            el.getAttributes()
+        );
+        replacement.body = replacement.makeContainer(el.body.items);
+        el.replaceWith(replacement);
     }
 }
 


### PR DESCRIPTION
## Description
This PR fixes two things:

1. The renames were wrong for the nested items for eBay menu.
2. After switching this to use a transform instead of a migrator (to support Marko 3) it stopped working for the nested tags since only the single rename transform was running and not our `attribute-tags` transform. By completely replacing the node, as we do in the other transform, I was able to get it to be re-registered and it now runs both transforms.

Fixes #774