### PR TITLE
Changed icon to not use w-id which causes an error in marko 3

### DIFF
--- a/src/components/ebay-icon/transformer.js
+++ b/src/components/ebay-icon/transformer.js
@@ -24,7 +24,8 @@ function transform(el, context) {
         const ds6Path = path.join(iconPath, 'ds6.marko');
         if (!el.hasAttribute('w-id') && context.compilerVersion && context.compilerVersion.indexOf('4.') !== 0) {
             // can be removed in Marko 4
-            el.setAttributeValue('id', builder.expression(`typeof widget !== "undefined" && widget.elId("use_icon_${iconName}")`));
+            el.setAttributeValue('id', 
+                builder.expression(`typeof widget !== "undefined" && widget.elId("use_icon_${iconName}")`));
         }
         el.setAttributeValue('_themes', context.addStaticVar(`icon_${iconName}`, builder.arrayExpression([
             toRequire(ds4Path),

--- a/src/components/ebay-icon/transformer.js
+++ b/src/components/ebay-icon/transformer.js
@@ -24,7 +24,7 @@ function transform(el, context) {
         const ds6Path = path.join(iconPath, 'ds6.marko');
         if (!el.hasAttribute('w-id') && context.compilerVersion && context.compilerVersion.indexOf('4.') !== 0) {
             // can be removed in Marko 4
-            el.setAttributeValue('id', 
+            el.setAttributeValue('id',
                 builder.expression(`typeof widget !== "undefined" && widget.elId("use_icon_${iconName}")`));
         }
         el.setAttributeValue('_themes', context.addStaticVar(`icon_${iconName}`, builder.arrayExpression([

--- a/src/components/ebay-icon/transformer.js
+++ b/src/components/ebay-icon/transformer.js
@@ -22,9 +22,9 @@ function transform(el, context) {
         const iconPath = path.join(__dirname, 'symbols', iconName);
         const ds4Path = path.join(iconPath, 'ds4.marko');
         const ds6Path = path.join(iconPath, 'ds6.marko');
-        if (!el.hasAttribute('w-id')) {
+        if (!el.hasAttribute('w-id') && context.compilerVersion && context.compilerVersion.indexOf('4.') !== 0) {
             // can be removed in Marko 4
-            el.setAttributeValue('w-id', builder.literal(`use_icon_${iconName}`));
+            el.setAttributeValue('id', builder.expression(`typeof widget !== "undefined" && widget.elId("use_icon_${iconName}")`));
         }
         el.setAttributeValue('_themes', context.addStaticVar(`icon_${iconName}`, builder.arrayExpression([
             toRequire(ds4Path),


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
This code was causing a widget lookup before render which was throwing a server side error on marko v3. On marko v4 it was fine.

## Context
<!--- Why did you make these changes, and why in this particular way? -->
In order to not look up during runtime, we added an expression to set the widget elId. This works on marko v3 but on v4 it breaks. So we added a check for it not to render in v4 since it should be working fine in v4. 

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
#779 

## Screenshots
<!-- Upload screenshots if appropriate. -->
