### PR TITLE
Listbox: Fix invalid id selector

### DIFF
--- a/src/components/ebay-listbox-button/index.js
+++ b/src/components/ebay-listbox-button/index.js
@@ -39,7 +39,7 @@ module.exports = require('marko-widgets').defineComponent({
         this.expander = new Expander(this.el, {
             autoCollapse: true,
             expandOnClick: !this.state.disabled,
-            contentSelector: `#${optionsContainer.id}`,
+            contentSelector: `.listbox__options`,
             hostSelector: '.listbox__control',
             expandedClass: 'listbox--expanded',
             focusManagement: 'content',

--- a/src/components/ebay-listbox-button/index.js
+++ b/src/components/ebay-listbox-button/index.js
@@ -39,7 +39,7 @@ module.exports = require('marko-widgets').defineComponent({
         this.expander = new Expander(this.el, {
             autoCollapse: true,
             expandOnClick: !this.state.disabled,
-            contentSelector: `.listbox__options`,
+            contentSelector: '.listbox__options',
             hostSelector: '.listbox__control',
             expandedClass: 'listbox--expanded',
             focusManagement: 'content',


### PR DESCRIPTION
## Description
Fixes the listbox element so that it uses a valid class selector instead of a potentially invalid id selector.

## References
Fixes #786
