### PR TITLE
Fix issue with menu-button icon transformer using the wrong tag

### DIFF
--- a/src/components/ebay-menu-button/test/test.server.js
+++ b/src/components/ebay-menu-button/test/test.server.js
@@ -201,7 +201,7 @@ describe('transformer', () => {
         const tagString = '<ebay-menu-button icon="settings"/>';
         const { el } = testUtils.runTransformer(transformer, tagString, componentPath);
         const { body: { array: [iconEl] } } = el;
-        expect(iconEl.tagName).to.equal('ebay-menu:icon');
+        expect(iconEl.tagName).to.equal('ebay-menu-button:icon');
     });
 
     test('does not transform when icon attribute is missing', () => {

--- a/src/components/ebay-menu-button/transformer.js
+++ b/src/components/ebay-menu-button/transformer.js
@@ -18,7 +18,7 @@ function transform(el, context) {
                 value: builder.literal('inline')
             }
         ]);
-        const menuIconTag = context.createNodeForEl('ebay-menu:icon');
+        const menuIconTag = context.createNodeForEl('ebay-menu-button:icon');
         menuIconTag.appendChild(iconTag);
         el.prependChild(menuIconTag);
     }


### PR DESCRIPTION
## Description
The transformer for the menu was not properly updated for it's new name (menu-button). This caused the menu icon (added by a transformer) to use the wrong tag name and output incorrectly.

