### PR TITLE
Fix button types to avoid form submission

### DIFF
--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -19,6 +19,7 @@
         </>
         <button
             class="carousel__control carousel__control--prev"
+            type="button"
             w-onclick=(!data.prevControlDisabled && "handleMove")
             data-direction=-1
             aria-describedby=statusId
@@ -46,6 +47,7 @@
         <button
             w-id="next"
             class="carousel__control carousel__control--next"
+            type="button"
             w-onclick=(!data.nextControlDisabled && "handleMove")
             data-direction=1
             aria-describedby=statusId
@@ -58,6 +60,7 @@
             <if(data.paused)>
                 <button
                     class="carousel__play"
+                    type="button"
                     aria-label=data.a11yPlayText
                     w-onclick="togglePlay">
                     <ebay-icon type="inline" name="play"/>
@@ -66,6 +69,7 @@
             <else>
                 <button
                     class="carousel__pause"
+                    type="button"
                     aria-label=data.a11yPauseText
                     w-onclick="togglePlay">
                     <ebay-icon type="inline" name="pause"/>
@@ -79,6 +83,7 @@
             <var isActive=(i === data.slide)/>
             <button
                 class={"carousel__dot--active": isActive}
+                type="button"
                 w-onclick=(!isActive && "handleDotClick")
                 data-slide=i
                 aria-describedby=statusId

--- a/src/components/ebay-infotip/template.marko
+++ b/src/components/ebay-infotip/template.marko
@@ -20,6 +20,7 @@
                 w-id="host"
                 w-preserve-attrs="aria-expanded,aria-controls,aria-described-by"
                 class="infotip__host icon-btn"
+                type="button"
                 disabled=data.disabled
                 aria-label=data.ariaLabel>
                 <if(data.iconTag)>

--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -30,6 +30,7 @@
         <if(data.dismissible)>
             <button
                 class="page-notice__close"
+                type="button"
                 aria-label=data.a11yCloseText
                 w-onclick="onDismiss">
                 <span/>

--- a/src/components/ebay-tooltip/examples/01-icon-button-host/template.marko
+++ b/src/components/ebay-tooltip/examples/01-icon-button-host/template.marko
@@ -4,6 +4,7 @@
             name="icon-btn-1"
             accesskey="i"
             class='icon-btn tooltip__host'
+            type="button"
             aria-label='Developer-handled label'>
             <ebay-icon type="inline" name="cart"/>
         </button>


### PR DESCRIPTION
## Description
- adds `type="button"` to all native buttons to keep them from submitting forms

## Context
Any `<button>` without a type becomes `type="submit"`. Adding a hard-coded type makes sure it does not submit form if the component happens to find itself there.

## References
Fixes #791 