### PR TITLE
CTA: Move out of button and into its own tag

### DIFF
--- a/demo/browser.json
+++ b/demo/browser.json
@@ -12,6 +12,7 @@
         "../src/components/ebay-checkbox",
         "../src/components/ebay-combobox",
         "../src/components/ebay-combobox-readonly",
+        "../src/components/ebay-cta-button",
         "../src/components/ebay-dialog",
         "../src/components/ebay-icon",
         "../src/components/ebay-infotip",

--- a/marko.json
+++ b/marko.json
@@ -135,6 +135,15 @@
     "<ebay-combobox-readonly-option>": {
         "transformer": "./src/common/transformers/attribute-tags/index.js"
     },
+    "<ebay-cta-button>": {
+        "template": "./src/components/ebay-cta-button/index.marko",
+        "@*": "expression",
+        "@html-attributes": "expression",
+        "@id": "string",
+        "@class": "string",
+        "@style": "string",
+        "@size": "size"
+    },
     "<ebay-dialog>": {
         "renderer": "./src/components/ebay-dialog/index.js",
         "@*": "expression",

--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -17,7 +17,7 @@ Name | Type | Stateful | Description
 `fluid` | Boolean | No |
 `disabled` | Boolean | Yes |
 `partially-disabled` | Boolean | No |
-`variant` | String | No | optional, to alter Skin classes: "expand" / "cta" / "fake-link"
+`variant` | String | No | optional, to alter Skin classes: "expand" / "fake-link"
 `fixed-height` | Boolean | No | fixes the height based on `size`; defaults to `medium` when no size is specified
 `truncate` | Boolean | No | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows
 `badge-number` | Number | No | used as the number to be placed in the badge

--- a/src/components/ebay-button/examples/13-cta/template.marko
+++ b/src/components/ebay-button/examples/13-cta/template.marko
@@ -1,1 +1,0 @@
-<ebay-button variant="cta" href="https://www.ebay.com">cta text</ebay-button>

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -8,7 +8,6 @@
 <var variant=(!data.variant && data.href ? "fake" : data.variant)/>
 <var isIconVariant=(variant === 'icon')/>
 <var isExpandVariant=(variant === 'expand')/>
-<var isCtaVariant=(variant === 'cta')/>
 <var isBadged=Boolean(data.badgeNumber && isIconVariant)/>
 <var noText=(isIconVariant || isBadged || (isExpandVariant && data.noText))/>
 <var baseClass=(variant ? (variant === 'fake-link' ? variant : "${variant}-btn") : "btn")/>
@@ -39,21 +38,13 @@
     disabled=data.disabled
     aria-disabled=(data.partiallyDisabled && "true")>
 
-    <if(isCtaVariant)>
-        <span class="cta-btn__cell">
-            <span w-body/>
-            <ebay-icon type="inline" name="arrow-right-bold" class="cta-btn__icon" no-skin-classes/>
-        </span>
+    <var hasAriaLabel=Boolean(htmlAttributes.ariaLabel)/>
+    <span body-only-if(!hasAriaLabel) w-body aria-hidden="true"/>
+    <if(isBadged)>
+        <ebay-badge
+            number=data.badgeNumber
+            type="icon"
+            aria-label=(hasAriaLabel && data.badgeAriaLabel)
+            aria-hidden=(hasAriaLabel && "true")/>
     </if>
-    <else>
-        <var hasAriaLabel=Boolean(htmlAttributes.ariaLabel)/>
-        <span body-only-if(!hasAriaLabel) w-body aria-hidden="true"/>
-        <if(isBadged)>
-            <ebay-badge
-                number=data.badgeNumber
-                type="icon"
-                aria-label=(hasAriaLabel && data.badgeAriaLabel)
-                aria-hidden=(hasAriaLabel && "true")/>
-        </if>
-    </else>
 </>

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -92,12 +92,6 @@ test('renders expand variant with no text', context => {
     expect($('.expand-btn.expand-btn--no-text').length).to.equal(1);
 });
 
-test('renders cta variant', context => {
-    const input = { variant: 'cta', href: 'https://www.ebay.com' };
-    const $ = testUtils.getCheerio(context.render(input));
-    expect($('a.cta-btn > .cta-btn__cell').length).to.equal(1);
-});
-
 test('renders icon variant', context => {
     const input = { variant: 'icon' };
     const $ = testUtils.getCheerio(context.render(input));

--- a/src/components/ebay-cta-button/README.md
+++ b/src/components/ebay-cta-button/README.md
@@ -1,0 +1,18 @@
+# ebay-cta-button
+
+## ebay-cta-button Usage
+
+```marko
+<ebay-cta-button href="http://www.ebay.com">text</ebay-cta-button>
+```
+
+## ebay-cta-button Attributes
+
+Name | Type | Stateful | Description
+--- | --- | --- | ---
+`size` | String | No | "small" or "large" (default: medium)
+`href` | String | No | link target
+
+## ebay-cta-button Events
+
+None

--- a/src/components/ebay-cta-button/browser.json
+++ b/src/components/ebay-cta-button/browser.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": [
+        {
+            "if-not-flag": "ebayui-no-skin",
+            "path": "@ebay/skin/cta-button"
+        }
+    ]
+}

--- a/src/components/ebay-cta-button/examples/01-basic/template.marko
+++ b/src/components/ebay-cta-button/examples/01-basic/template.marko
@@ -1,0 +1,1 @@
+<ebay-cta-button href="https://www.ebay.com">cta text</ebay-cta-button>

--- a/src/components/ebay-cta-button/examples/02-small/template.marko
+++ b/src/components/ebay-cta-button/examples/02-small/template.marko
@@ -1,0 +1,1 @@
+<ebay-cta-button size="small" href="https://www.ebay.com">cta text</ebay-cta-button>

--- a/src/components/ebay-cta-button/examples/03-large/template.marko
+++ b/src/components/ebay-cta-button/examples/03-large/template.marko
@@ -1,0 +1,1 @@
+<ebay-cta-button size="large" href="https://www.ebay.com">cta text</ebay-cta-button>

--- a/src/components/ebay-cta-button/index.marko
+++ b/src/components/ebay-cta-button/index.marko
@@ -1,0 +1,25 @@
+<script marko-init>
+    var getWidgetId = require("../../common/get-marko-3-widget-id");
+    var processHtmlAttributes = require("../../common/html-attributes");
+</script>
+
+<var size=(data.size || "medium")/>
+<var baseClass="cta-btn"/>
+<var sizeClass="${baseClass}--${size}"/>
+<var htmlAttributes=processHtmlAttributes(data)/>
+
+<a
+    ${htmlAttributes}
+    id=(data.id || getWidgetId(out))
+    class=[
+        data.class,
+        baseClass,
+        sizeClass
+    ]
+    style=data.style>
+
+    <span class="cta-btn__cell">
+        <span><invoke data.renderBody(out) if(data.renderBody)/></span>
+        <ebay-icon type="inline" name="arrow-right-bold" class="cta-btn__icon" no-skin-classes/>
+    </span>
+</>

--- a/src/components/ebay-cta-button/test/test.server.js
+++ b/src/components/ebay-cta-button/test/test.server.js
@@ -1,0 +1,20 @@
+const expect = require('chai').expect;
+const testUtils = require('../../../common/test-utils/server');
+
+test('renders basic cta button', context => {
+    const input = { href: 'https://www.ebay.com' };
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($('a.cta-btn > .cta-btn__cell').length).to.equal(1);
+});
+
+test('renders small cta button', context => {
+    const input = { size: 'small', href: 'https://www.ebay.com' };
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($('a.cta-btn.cta-btn--small > .cta-btn__cell').length).to.equal(1);
+});
+
+test('renders large cta button', context => {
+    const input = { size: 'large', href: 'https://www.ebay.com' };
+    const $ = testUtils.getCheerio(context.render(input));
+    expect($('a.cta-btn.cta-btn--large > .cta-btn__cell').length).to.equal(1);
+});


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
Move the CTA button variant out of `<ebay-button>` and into its own `<ebay-cta-button>` component. 

## Context
This simplifies the normal button and the CTA button logic. It follows the changes made to skin. It also sets us up to be ready for the more complex CTA buttons coming in DS 6.5.

## References
Related to https://github.com/eBay/ebayui-core/issues/733

## Screenshots
![Screen Shot 2019-07-30 at 3 33 00 PM](https://user-images.githubusercontent.com/1562843/62170170-6268d780-b2df-11e9-86d4-ec4e5a074f77.png)
![Screen Shot 2019-07-30 at 3 33 12 PM](https://user-images.githubusercontent.com/1562843/62170172-6268d780-b2df-11e9-8969-6942ccc8188b.png)

