### PR TITLE
Listbox: close on select

### DIFF
--- a/src/components/ebay-listbox-button/index.js
+++ b/src/components/ebay-listbox-button/index.js
@@ -58,6 +58,9 @@ module.exports = require('marko-widgets').defineComponent({
     handleCollapse() {
         this.emit('listbox-collapse');
     },
+    handleMouseDown() {
+        this.wasClicked = true;
+    },
     handleListboxChange(event) {
         const selectedIndex = parseInt(event.detail.toIndex, 10);
         const el = this.getEls('option')[selectedIndex];
@@ -66,11 +69,15 @@ module.exports = require('marko-widgets').defineComponent({
         elementScroll.scroll(el);
         this.setState('selectedIndex', selectedIndex);
 
-        // TODO: we should not cast the selected value to a string here, but this is a breaking change.
         this.emit('listbox-change', {
             index: selectedIndex,
-            selected: [String(option.value)],
+            selected: [option.value],
             el
         });
+
+        if (this.wasClicked) {
+            this.expander.collapse();
+            this.wasClicked = false;
+        }
     }
 });

--- a/src/components/ebay-listbox-button/template.marko
+++ b/src/components/ebay-listbox-button/template.marko
@@ -49,6 +49,7 @@
                     role="option"
                     tabindex="-1"
                     aria-selected=(selectedOption === option && "true")
+                    w-on-mousedown="handleMouseDown"
                     ${processHtmlAttributes(option)}>
                     <span>${option.text}</span>
                     <span class="listbox-button__status"/>

--- a/src/components/ebay-listbox-button/test/test.browser.js
+++ b/src/components/ebay-listbox-button/test/test.browser.js
@@ -47,7 +47,7 @@ describe('given the listbox is in the default state', () => {
             expect(spy.calledOnce).to.equal(true);
             const eventData = spy.getCall(0).args[0];
             expect(eventData.index).to.equal(1);
-            expect(eventData.selected).to.deep.equal(['2']);
+            expect(eventData.selected).to.deep.equal([2]);
             const nativeOption = nativeSelect.options[eventData.index].value;
             expect(nativeOption).to.equal('2');
         });
@@ -71,7 +71,7 @@ describe('given the listbox is in the default state', () => {
             expect(spy.calledTwice).to.equal(true);
             const eventData = spy.getCall(1).args[0];
             expect(eventData.index).to.equal(0);
-            expect(eventData.selected).to.deep.equal(['1']);
+            expect(eventData.selected).to.deep.equal([1]);
             const nativeOption = nativeSelect.options[eventData.index].value;
             expect(nativeOption).to.equal('1');
         });
@@ -139,7 +139,7 @@ describe('given the listbox is in an expanded state', () => {
             expect(selectSpy.calledOnce).to.equal(true);
             const eventData = selectSpy.getCall(0).args[0];
             expect(eventData.index).to.equal(1);
-            expect(eventData.selected).to.deep.equal(['2']);
+            expect(eventData.selected).to.deep.equal([2]);
             expect(eventData.el).to.deep.equal(secondOption);
         });
     });
@@ -157,7 +157,7 @@ describe('given the listbox is in an expanded state', () => {
             expect(selectSpy.calledOnce).to.equal(true);
             const eventData = selectSpy.getCall(0).args[0];
             expect(eventData.index).to.equal(1);
-            expect(eventData.selected).to.deep.equal(['2']);
+            expect(eventData.selected).to.deep.equal([2]);
             expect(eventData.el).to.deep.equal(secondOption);
         });
     });
@@ -175,7 +175,7 @@ describe('given the listbox is in an expanded state', () => {
             expect(spy.calledOnce).to.equal(true);
             const eventData = spy.getCall(0).args[0];
             expect(eventData.index).to.equal(1);
-            expect(eventData.selected).to.deep.equal(['2']);
+            expect(eventData.selected).to.deep.equal([2]);
         });
     });
 
@@ -193,7 +193,7 @@ describe('given the listbox is in an expanded state', () => {
             expect(spy.calledTwice).to.equal(true);
             const eventData = spy.getCall(1).args[0];
             expect(eventData.index).to.equal(0);
-            expect(eventData.selected).to.deep.equal(['1']);
+            expect(eventData.selected).to.deep.equal([1]);
         });
     });
 });


### PR DESCRIPTION
## Description
- adds close on click functionality
- fix the option be cast as a String for the emitted event data

## Context
When a user clicks on the listbox option we kept the listbox open. This isn't a great experience for mouse users, so we opted to close the dropdown when it was clicked with a mouse.

## References
Fixes #707 
