### PR TITLE
DS 6.5 buttons

### DIFF
--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -10,15 +10,15 @@
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`priority` | String | No | "primary" / "secondary" (default) / "none"
-`size` | String | No | "small" or "large" (default: medium)
+`priority` | String | No | "primary" / "secondary" (default) / "delete" / "none"
+`size` | String | No | "large" (default: "none")
 `no-text` | Boolean | No | used to adjust padding for "expand" variant without text
 `href` | String | No | for link that looks like a button
 `fluid` | Boolean | No |
 `disabled` | Boolean | Yes |
 `partially-disabled` | Boolean | No |
-`variant` | String | No | optional, to alter Skin classes: "expand" / "fake-link"
-`fixed-height` | Boolean | No | fixes the height based on `size`; defaults to `medium` when no size is specified
+`variant` | String | No | optional, to alter Skin classes: "expand" / "fake-link" / "delete"
+`fixed-height` | Boolean | No | fixes the height based on `size`
 `truncate` | Boolean | No | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows
 `badge-number` | Number | No | used as the number to be placed in the badge
 `badge-aria-label` | String | No | passed as the `aria-label` directly to the badge

--- a/src/components/ebay-button/examples/03-delete/template.marko
+++ b/src/components/ebay-button/examples/03-delete/template.marko
@@ -1,0 +1,1 @@
+<ebay-button priority="delete">text</ebay-button>

--- a/src/components/ebay-button/examples/03-small/template.marko
+++ b/src/components/ebay-button/examples/03-small/template.marko
@@ -1,1 +1,0 @@
-<ebay-button size="small">text</ebay-button>

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -3,7 +3,7 @@
     var processHtmlAttributes = require("../../common/html-attributes");
 </script>
 
-<var size=(data.size || "medium")/>
+<var size=data.size/>
 <var priority=(data.priority || "secondary")/>
 <var variant=(!data.variant && data.href ? "fake" : data.variant)/>
 <var isIconVariant=(variant === 'icon')/>
@@ -11,7 +11,9 @@
 <var isBadged=Boolean(data.badgeNumber && isIconVariant)/>
 <var noText=(isIconVariant || isBadged || (isExpandVariant && data.noText))/>
 <var baseClass=(variant ? (variant === 'fake-link' ? variant : "${variant}-btn") : "btn")/>
-<var sizeClass="${baseClass}--${size}"/>
+<var sizeClass=(size && "${baseClass}--${size}")/>
+<var truncateClass=(data.truncate && (sizeClass ? "${sizeClass}-truncated" : "${baseClass}--truncated"))/>
+<var fixedHeightClass=(data.fixedHeight && (sizeClass ? "${sizeClass}-fixed-height" : "${baseClass}--fixed-height"))/>
 <var htmlAttributes=processHtmlAttributes(data)/>
 <var tag=(data.href ? "a" : "button")/>
 
@@ -27,10 +29,10 @@
         noText && "${baseClass}--no-text",
         isBadged && "${baseClass}--badged",
         data.fluid && "${baseClass}--fluid",
-        data.truncate && "${sizeClass}-truncated",
-        data.fixedHeight && "${sizeClass}-fixed-height",
-        !data.fixedHeight && !data.truncate && sizeClass,
-        (priority === "secondary" || priority === "primary") && "${baseClass}--${priority}"
+        truncateClass,
+        fixedHeightClass,
+        !truncateClass && !fixedHeightClass && sizeClass,
+        (priority === "secondary" || priority === "primary" || priority === "delete") && "${baseClass}--${priority}"
     ]
     style=data.style
     href=data.href

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -6,8 +6,8 @@ const template = require('..');
 use(require('chai-dom'));
 
 const properties = {
-    priority: ['primary', 'secondary'],
-    size: ['small', 'large']
+    priority: ['primary', 'secondary', 'delete'],
+    size: ['large']
 };
 
 Object.keys(properties).forEach(property => {
@@ -52,7 +52,7 @@ it('does not apply priority class for unsupported value', async() => {
 it('renders fake version', async() => {
     const { getByLabelText } = await render(template, {
         href: '#',
-        size: 'small',
+        size: 'large',
         priority: 'primary',
         htmlAttributes: {
             ariaLabel: 'fake button'
@@ -63,7 +63,7 @@ it('renders fake version', async() => {
     expect(btn).has.attr('href', '#');
     expect(btn).has.property('tagName', 'A');
     expect(btn)
-        .has.class('fake-btn--small')
+        .has.class('fake-btn--large')
         .and.class('fake-btn--primary');
 });
 
@@ -115,6 +115,36 @@ it('renders badged icon variant', async() => {
 
     expect(getByLabelText('Badged button')).has.class('icon-btn--badged');
     expect(getByLabelText('5 Items')).has.text('5');
+});
+
+it('renders truncated button', async() => {
+    const { getByRole } = await render(template, {
+        truncate: true
+    });
+    expect(getByRole('button')).has.class('btn--truncated');
+});
+
+it('renders large truncated button', async() => {
+    const { getByRole } = await render(template, {
+        truncate: true,
+        size: 'large'
+    });
+    expect(getByRole('button')).has.class('btn--large-truncated');
+});
+
+it('renders fixed-height button', async() => {
+    const { getByRole } = await render(template, {
+        fixedHeight: true
+    });
+    expect(getByRole('button')).has.class('btn--fixed-height');
+});
+
+it('renders large fixed-height button', async() => {
+    const { getByRole } = await render(template, {
+        fixedHeight: true,
+        size: 'large'
+    });
+    expect(getByRole('button')).has.class('btn--large-fixed-height');
 });
 
 testPassThroughAttributes(template);


### PR DESCRIPTION
## Description
Update Button component to match the new DS6.5 styles.  Including support for the `delete` button.

## Context
Even though we only support "large" as a size override now, I left size as an attribute for backwards compatibility and just in case we need to add additional sizes back in later.

## References
https://github.com/eBay/skin/pull/756
https://github.com/eBay/skin/pull/749
https://github.com/eBay/skin/issues/700

## Screenshots
![Screen Shot 2019-08-14 at 12 22 37 PM](https://user-images.githubusercontent.com/1562843/63049745-3ed09000-be8e-11e9-8101-31e557c7128a.png)
![Screen Shot 2019-08-14 at 12 22 46 PM](https://user-images.githubusercontent.com/1562843/63049753-42fcad80-be8e-11e9-8bd3-6044c6c01359.png)

