### PR TITLE
Filter menu;

### DIFF
--- a/demo/browser.json
+++ b/demo/browser.json
@@ -16,6 +16,7 @@
         "../src/components/ebay-dialog",
         "../src/components/ebay-expand-button",
         "../src/components/ebay-filter",
+        "../src/components/ebay-filter-menu",
         "../src/components/ebay-filter-menu-button",
         "../src/components/ebay-icon",
         "../src/components/ebay-infotip",

--- a/marko.json
+++ b/marko.json
@@ -190,6 +190,7 @@
     "@with-button": "boolean",
     "@form-name": "string",
     "@form-action": "string",
+    "@form-method": "string",
     "@a11y-footer-text": "string",
     "@items <item>[]": {
       "@*": "expression",
@@ -216,6 +217,7 @@
     "@pressed": "boolean",
     "@form-name": "string",
     "@form-action": "string",
+    "@form-method": "string",
     "@a11y-text": "string",
     "@a11y-footer-text": "string",
     "@items <item>[]": {

--- a/marko.json
+++ b/marko.json
@@ -186,7 +186,7 @@
     "@footer-text": "string",
     "@class": "string",
     "@style": "string",
-    "@with-button": "boolean",
+    "@class-prefix": "string",
     "@form-name": "string",
     "@form-action": "string",
     "@form-method": "string",

--- a/marko.json
+++ b/marko.json
@@ -178,6 +178,31 @@
     "@pressed": "boolean",
     "@aria-selected-text": "string"
   },
+  "<ebay-filter-menu>": {
+    "renderer": "./src/components/ebay-filter-menu/index.js",
+    "@*": "expression",
+    "@html-attrbibutes": "expression",
+    "@variant": "string",
+    "@text": "string",
+    "@footer-text": "string",
+    "@class": "string",
+    "@style": "string",
+    "@with-button": "boolean",
+    "@form-name": "string",
+    "@form-action": "string",
+    "@a11y-footer-text": "string",
+    "@items <item>[]": {
+      "@*": "expression",
+      "@html-attributes": "expression",
+      "@class": "string",
+      "@style": "string",
+      "@checked": "boolean",
+      "@value": "string"
+    }
+  },
+  "<ebay-filter-menu-item>": {
+    "transformer": "./src/common/transformers/attribute-tags/index.js"
+  },
   "<ebay-filter-menu-button>": {
     "renderer": "./src/components/ebay-filter-menu-button/index.js",
     "@*": "expression",

--- a/marko.json
+++ b/marko.json
@@ -183,7 +183,6 @@
     "@*": "expression",
     "@html-attrbibutes": "expression",
     "@variant": "string",
-    "@text": "string",
     "@footer-text": "string",
     "@class": "string",
     "@style": "string",

--- a/src/components/ebay-filter-menu-button/index.js
+++ b/src/components/ebay-filter-menu-button/index.js
@@ -54,11 +54,13 @@ module.exports = require('marko-widgets').defineComponent({
         });
     },
     handleMenuChange(e) {
-        this.setCheckedItem(this.getItemElementIndex(e.el), e.el);
+        const { el } = e;
+        this.setCheckedItem(this.getItemElementIndex(el), el);
     },
     handleItemKeydown(e) {
-        eventUtils.handleActionKeydown(e.originalEvent, () => {
-            this.setCheckedItem(this.getItemElementIndex(e.el), e.el);
+        const { el, originalEvent } = e;
+        eventUtils.handleActionKeydown(originalEvent, () => {
+            this.setCheckedItem(this.getItemElementIndex(el), el);
         });
     },
     handleFooterButtonClick() {
@@ -68,13 +70,16 @@ module.exports = require('marko-widgets').defineComponent({
         this.buttonEl.setAttribute('aria-pressed', (this.getCheckedItems().length > 0));
     },
     handleFormSubmit(e) {
-        this.emitComponentEvent('form-submit', null, e.originalEvent);
+        const { originalEvent } = e;
+        this.emitComponentEvent('form-submit', null, originalEvent);
     },
     handleExpand(e) {
-        this.emitComponentEvent('expand', null, e.originalEvent);
+        const { originalEvent } = e;
+        this.emitComponentEvent('expand', null, originalEvent);
     },
     handleCollapse(e) {
-        this.emitComponentEvent('collapse', null, e.originalEvent);
+        const { originalEvent } = e;
+        this.emitComponentEvent('collapse', null, originalEvent);
     },
     getItemElementIndex(itemEl) {
         const parentNode = itemEl.parentNode || itemEl.el.parentNode;

--- a/src/components/ebay-filter-menu-button/index.js
+++ b/src/components/ebay-filter-menu-button/index.js
@@ -1,7 +1,5 @@
 const assign = require('core-js-pure/features/object/assign');
 const Expander = require('makeup-expander');
-const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
-const rovingTabindex = require('makeup-roving-tabindex');
 const eventUtils = require('../../common/event-utils');
 const template = require('./template.marko');
 
@@ -28,14 +26,6 @@ module.exports = require('marko-widgets').defineComponent({
                 autoCollapse: true,
                 alwaysDoFocusManagement: true
             });
-
-            if (this.state.variant !== 'form') {
-                // FIXME: should be outside of firstRender, but only when itemEls changes
-                this.rovingTabindex = rovingTabindex.createLinear(
-                    this.contentEl.querySelector('[role="menu"]'), 'div',
-                    { index: 0, autoReset: 0 }
-                );
-            }
         }
     },
     update_expanded(expanded) { // eslint-disable-line camelcase
@@ -59,20 +49,16 @@ module.exports = require('marko-widgets').defineComponent({
             .map(item => item.value);
     },
     handleButtonKeydown(e) {
-        eventUtils.handleEscapeKeydown(e, () => {
+        eventUtils.handleEscapeKeydown(e.originalEvent, () => {
             this.buttonEl.setAttribute('aria-expanded', false);
         });
     },
-    handleItemClick(e, itemEl) {
-        this.setCheckedItem(this.getItemElementIndex(itemEl), itemEl);
+    handleMenuChange(e) {
+        this.setCheckedItem(this.getItemElementIndex(e.el), e.el);
     },
-    handleItemKeydown(e, itemEl) {
-        eventUtils.handleActionKeydown(e, () => {
-            this.setCheckedItem(this.getItemElementIndex(itemEl), itemEl);
-        });
-
-        eventUtils.handleEscapeKeydown(e, () => {
-            this.buttonEl.setAttribute('aria-expanded', false);
+    handleItemKeydown(e) {
+        eventUtils.handleActionKeydown(e.originalEvent, () => {
+            this.setCheckedItem(this.getItemElementIndex(e.el), e.el);
         });
     },
     handleFooterButtonClick() {
@@ -81,19 +67,19 @@ module.exports = require('marko-widgets').defineComponent({
         this.buttonEl.setAttribute('aria-expanded', false);
         this.buttonEl.setAttribute('aria-pressed', (this.getCheckedItems().length > 0));
     },
-    handleFormSubmit(originalEvent) {
-        this.emitComponentEvent('form-submit', null, originalEvent);
+    handleFormSubmit(e) {
+        this.emitComponentEvent('form-submit', null, e.originalEvent);
+        e.originalEvent.preventDefault();
     },
-    handleExpand(originalEvent) {
-        scrollKeyPreventer.add(this.contentEl);
-        this.emitComponentEvent('expand', null, originalEvent);
+    handleExpand(e) {
+        this.emitComponentEvent('expand', null, e.originalEvent);
     },
-    handleCollapse(originalEvent) {
-        scrollKeyPreventer.remove(this.contentEl);
-        this.emitComponentEvent('collapse', null, originalEvent);
+    handleCollapse(e) {
+        this.emitComponentEvent('collapse', null, e.originalEvent);
     },
     getItemElementIndex(itemEl) {
-        return Array.prototype.slice.call(itemEl.parentNode.children).indexOf(itemEl);
+        const parentNode = itemEl.parentNode || itemEl.el.parentNode;
+        return Array.prototype.slice.call(parentNode.children).indexOf(itemEl);
     },
     emitComponentEvent(eventType, itemEl, originalEvent) {
         switch (eventType) {

--- a/src/components/ebay-filter-menu-button/index.js
+++ b/src/components/ebay-filter-menu-button/index.js
@@ -69,7 +69,6 @@ module.exports = require('marko-widgets').defineComponent({
     },
     handleFormSubmit(e) {
         this.emitComponentEvent('form-submit', null, e.originalEvent);
-        e.originalEvent.preventDefault();
     },
     handleExpand(e) {
         this.emitComponentEvent('expand', null, e.originalEvent);

--- a/src/components/ebay-filter-menu-button/template.marko
+++ b/src/components/ebay-filter-menu-button/template.marko
@@ -19,51 +19,31 @@
         aria-expanded=String(data.expanded)
         aria-haspopup="true"
         aria-label=data.a11yText
-        aria-pressed=(checkedItems.length > 0 && !data.footerButton && "true")
-        w-onkeydown="handleButtonKeydown">
+        aria-pressed=(checkedItems.length > 0 && !data.footerButton && "true")>
         <span class="filter-menu-button__button-cell">
             <span class="filter-menu-button__button-text">${data.text}</span>
             <ebay-icon type="inline" name="chevron-down" />
         </span>
     </button>
-    <div class="filter-menu-button__menu">
-        <form body-only-if(!isForm) name=data.formName action=data.formAction w-on-submit="handleFormSubmit">
-            <div class="filter-menu-button__items" role=(!isForm && "menu")>
-                <for(item in data.items)>
-                    <${isForm ? "label" : "div"}
-                        class=["filter-menu-button__item", item.class]
-                        style=item.style
-                        role="menuitemcheckbox"
-                        aria-checked=(item.checked ? "true" : "false" )
-                        data-value=item.value
-                        for=(isForm && widget.elId("checkbox"))
-                        w-onclick="handleItemClick"
-                        w-onkeydown="handleItemKeydown"
-                        ${processHtmlAttributes(item)}>
-                        <if(isForm)>
-                            <ebay-checkbox w-id="checkbox" checked=item.checked/>
-                        </if>
-                        <else>
-                            <span class="filter-menu-button__status">
-                                <if(item.checked)>
-                                    <ebay-icon type="inline" name="checkbox-checked" />
-                                </if>
-                                <else>
-                                    <ebay-icon type="inline" name="checkbox-unchecked" />
-                                </else>
-                            </span>
-                        </else>
-                        <span class="filter-menu-button__text" w-body=item.renderBody />
-                    </>
-                </for>
-            </div>
-            <button
-                if(data.footerText)
-                type=(data.variant === 'form'? "submit": "button")
-                aria-label=data.a11yFooterText
-                class="filter-menu-button__footer"
-                w-onclick=(isForm ? null : "handleFooterButtonClick")
-            >${data.footerText}</button>
-        </form>
-    </div>
+    <ebay-filter-menu
+        w-id="menu"
+        with-button=true
+        variant=data.variant
+        form-name=data.formName
+        form-action=data.formAction
+        footer-text=data.footerText
+        w-on-filter-menu-keydown="handleButtonKeydown"
+        w-on-filter-menu-change="handleMenuChange"
+        w-on-filter-menu-form-submit="handleFormSubmit"
+        w-on-filter-menu-footer-click="handleFooterButtonClick">
+        <for(item in data.items)>
+            <ebay-filter-menu-item
+                style=item.style
+                class=item.class
+                value=item.value
+                checked=item.checked
+                variant=data.variant
+                w-body=item.renderBody/>
+        </for>
+    </ebay-filter-menu>
 </span>

--- a/src/components/ebay-filter-menu-button/template.marko
+++ b/src/components/ebay-filter-menu-button/template.marko
@@ -27,7 +27,7 @@
     </button>
     <ebay-filter-menu
         w-id="menu"
-        with-button=true
+        class-prefix='filter-menu-button'
         variant=data.variant
         form-name=data.formName
         form-action=data.formAction

--- a/src/components/ebay-filter-menu-button/template.marko
+++ b/src/components/ebay-filter-menu-button/template.marko
@@ -31,6 +31,7 @@
         variant=data.variant
         form-name=data.formName
         form-action=data.formAction
+        form-method=data.formMethod
         footer-text=data.footerText
         w-on-filter-menu-keydown="handleButtonKeydown"
         w-on-filter-menu-change="handleMenuChange"

--- a/src/components/ebay-filter-menu-button/test/test.browser.js
+++ b/src/components/ebay-filter-menu-button/test/test.browser.js
@@ -148,8 +148,7 @@ describe('given the menu is in the expanded state', () => {
             const changeEvents = component.emitted('filter-menu-button-change');
             expect(changeEvents).to.have.length(2);
 
-            const firstEventData = changeEvents[0][0];
-            const secondEventData = changeEvents[1][0];
+            const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el', firstItem);
             expect(secondEventData).has.property('el', secondItem);
         });
@@ -170,8 +169,7 @@ describe('given the menu is in the expanded state', () => {
             const changeEvents = component.emitted('filter-menu-button-change');
             expect(changeEvents).to.have.length(2);
 
-            const firstEventData = changeEvents[0][0];
-            const secondEventData = changeEvents[1][0];
+            const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
             expect(secondEventData).has.property('checked').to.deep.equal([]);
         });
@@ -193,7 +191,7 @@ describe('given the menu is in the expanded state', () => {
             const changeEvents = component.emitted('filter-menu-button-change');
             expect(changeEvents).to.have.length(1);
 
-            const firstEventData = changeEvents[0][0];
+            const [firstEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el').with.text(firstItemText);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
         });

--- a/src/components/ebay-filter-menu/README.md
+++ b/src/components/ebay-filter-menu/README.md
@@ -24,6 +24,7 @@ Name | Type | Stateful | Description
 `form-name` | String | No | form's `name` attribute (used with `variant="form"`)
 `form-action` | String | No | form's `action` attribute (used with `variant="form"`)
 `form-method` | String | No | form's `method` attribute (used with `variant="form"`)
+`class-prefix` | String | No | "filter-menu" (default) / modifies the base prefix for all Skin classes in the menu
 
 ### ebay-filter-menu Events
 

--- a/src/components/ebay-filter-menu/README.md
+++ b/src/components/ebay-filter-menu/README.md
@@ -7,7 +7,7 @@ The `ebay-filter-menu` component is used as a checkbox menu specificially styled
 ### ebay-filter-menu Usage
 
 ```marko
-<ebay-filter-menu text="text">
+<ebay-filter-menu>
     <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>

--- a/src/components/ebay-filter-menu/README.md
+++ b/src/components/ebay-filter-menu/README.md
@@ -1,0 +1,55 @@
+# ebay-filter-menu-button
+
+**Note:** In previous versions of eBayUI-core this component was named `ebay-menu`. The old naming will continue to work and an automated migration will be made available in the Marko 4 version of eBayUI-core.
+
+## ebay-filter-menu-button Tag
+
+### ebay-filter-menu-button Usage
+
+```marko
+<ebay-filter-menu-button text="text">
+    <ebay-filter-menu-button-item value="item 1">item 1</ebay-filter-menu-button-item>
+    <ebay-filter-menu-button-item value="item 2">item 2</ebay-filter-menu-button-item>
+    <ebay-filter-menu-button-item value="item 3">item 3</ebay-filter-menu-button-item>
+</ebay-filter-menu-button>
+```
+
+### ebay-filter-menu-button Attributes
+
+Name | Type | Stateful | Description
+--- | --- | --- | ---
+`text` | String | Yes | button text
+`footer-text` | String | Yes | footer button text
+`a11y-text` | String | No | a11y text for the button
+`a11y-footer-text` | String | No | a11y text for the footer button
+`pressed` | Boolean | Yes | whether button is pressed (default is `false`)
+`expanded` | Boolean | Yes | whether content is expanded (Note: not supported as initial attribute)
+`disabled` | Boolean | Yes | Will disable the entire dropdown (disables the ebay-button label) if set to true
+`variant` | String | No | "" (default) / "form"
+`form-name` | String | No | form's `name` attribute (used with `variant="form"`)
+`form-action` | String | No | form's `action` attribute (used with `variant="form"`)
+
+### ebay-filter-menu-button Events
+
+Event | Data | Description
+--- | --- | ---
+`filter-menu-button-expand` | | expand content
+`filter-menu-button-collapse` | `{ checked, originalEvent }` | collapse content (emits current checked state)
+`filter-menu-button-change` | `{ el, checked, originalEvent }` | items changed/checked
+`filter-menu-button-footer-click` | `{ checked, originalEvent }` | footer button clicked
+`filter-menu-button-form-submit` |  | `{ checked, originalEvent }` | when using `variant="form"`, and form is submitted (emits current checked state)
+
+## ebay-filter-menu-button-item Tag
+
+### ebay-filter-menu-button-item Usage
+
+```marko
+<ebay-filter-menu-button-item>item 1</ebay-filter-menu-button-item>
+```
+
+### ebay-filter-menu-button-item Attributes
+
+Name | Type | Stateful | Description
+--- | --- | --- | ---
+`checked` | Boolean | Yes | whether or not the item is checked
+`value` | Boolean | Yes | the item's value (returned in emitted events when checked)

--- a/src/components/ebay-filter-menu/README.md
+++ b/src/components/ebay-filter-menu/README.md
@@ -1,53 +1,47 @@
-# ebay-filter-menu-button
+# ebay-filter-menu
 
-**Note:** In previous versions of eBayUI-core this component was named `ebay-menu`. The old naming will continue to work and an automated migration will be made available in the Marko 4 version of eBayUI-core.
+The `ebay-filter-menu` component is used as a checkbox menu specificially styled for filtering actions. Generally it is coupled with the `ebay-filter-menu-button` to create a selectable set of items by which to filter.
 
-## ebay-filter-menu-button Tag
+## ebay-filter-menu Tag
 
-### ebay-filter-menu-button Usage
+### ebay-filter-menu Usage
 
 ```marko
-<ebay-filter-menu-button text="text">
-    <ebay-filter-menu-button-item value="item 1">item 1</ebay-filter-menu-button-item>
-    <ebay-filter-menu-button-item value="item 2">item 2</ebay-filter-menu-button-item>
-    <ebay-filter-menu-button-item value="item 3">item 3</ebay-filter-menu-button-item>
-</ebay-filter-menu-button>
+<ebay-filter-menu text="text">
+    <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>
+</ebay-filter-menu>
 ```
 
-### ebay-filter-menu-button Attributes
+### ebay-filter-menu Attributes
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---
-`text` | String | Yes | button text
 `footer-text` | String | Yes | footer button text
-`a11y-text` | String | No | a11y text for the button
 `a11y-footer-text` | String | No | a11y text for the footer button
-`pressed` | Boolean | Yes | whether button is pressed (default is `false`)
-`expanded` | Boolean | Yes | whether content is expanded (Note: not supported as initial attribute)
-`disabled` | Boolean | Yes | Will disable the entire dropdown (disables the ebay-button label) if set to true
 `variant` | String | No | "" (default) / "form"
 `form-name` | String | No | form's `name` attribute (used with `variant="form"`)
 `form-action` | String | No | form's `action` attribute (used with `variant="form"`)
+`form-method` | String | No | form's `method` attribute (used with `variant="form"`)
 
-### ebay-filter-menu-button Events
+### ebay-filter-menu Events
 
 Event | Data | Description
 --- | --- | ---
-`filter-menu-button-expand` | | expand content
-`filter-menu-button-collapse` | `{ checked, originalEvent }` | collapse content (emits current checked state)
 `filter-menu-button-change` | `{ el, checked, originalEvent }` | items changed/checked
 `filter-menu-button-footer-click` | `{ checked, originalEvent }` | footer button clicked
 `filter-menu-button-form-submit` |  | `{ checked, originalEvent }` | when using `variant="form"`, and form is submitted (emits current checked state)
 
-## ebay-filter-menu-button-item Tag
+## ebay-filter-menu-item Tag
 
-### ebay-filter-menu-button-item Usage
+### ebay-filter-menu-item Usage
 
 ```marko
-<ebay-filter-menu-button-item>item 1</ebay-filter-menu-button-item>
+<ebay-filter-menu-item>item 1</ebay-filter-menu-item>
 ```
 
-### ebay-filter-menu-button-item Attributes
+### ebay-filter-menu-item Attributes
 
 Name | Type | Stateful | Description
 --- | --- | --- | ---

--- a/src/components/ebay-filter-menu/browser.json
+++ b/src/components/ebay-filter-menu/browser.json
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        {
+            "if-not-flag": "ebayui-no-skin",
+            "dependencies": [
+                "@ebay/skin/filter-menu"
+            ]
+        },
+        "../ebay-icon",
+        "require: marko-widgets",
+        "require: ./index.js"
+    ]
+}

--- a/src/components/ebay-filter-menu/examples/01-basic/template.marko
+++ b/src/components/ebay-filter-menu/examples/01-basic/template.marko
@@ -1,4 +1,4 @@
-<ebay-filter-menu text="Filter Menu Button">
+<ebay-filter-menu>
     <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>

--- a/src/components/ebay-filter-menu/examples/01-basic/template.marko
+++ b/src/components/ebay-filter-menu/examples/01-basic/template.marko
@@ -1,0 +1,5 @@
+<ebay-filter-menu text="Filter Menu Button">
+    <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>
+</ebay-filter-menu>

--- a/src/components/ebay-filter-menu/examples/02-selected/template.marko
+++ b/src/components/ebay-filter-menu/examples/02-selected/template.marko
@@ -1,0 +1,5 @@
+<ebay-filter-menu text="Filter Selected">
+    <ebay-filter-menu-item value="item 1" checked>item 1</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>
+</ebay-filter-menu>

--- a/src/components/ebay-filter-menu/examples/02-selected/template.marko
+++ b/src/components/ebay-filter-menu/examples/02-selected/template.marko
@@ -1,4 +1,4 @@
-<ebay-filter-menu text="Filter Selected">
+<ebay-filter-menu>
     <ebay-filter-menu-item value="item 1" checked>item 1</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>

--- a/src/components/ebay-filter-menu/examples/03-many-options/template.marko
+++ b/src/components/ebay-filter-menu/examples/03-many-options/template.marko
@@ -1,4 +1,4 @@
-<ebay-filter-menu text="Lots of Options">
+<ebay-filter-menu>
     <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>

--- a/src/components/ebay-filter-menu/examples/03-many-options/template.marko
+++ b/src/components/ebay-filter-menu/examples/03-many-options/template.marko
@@ -1,0 +1,22 @@
+<ebay-filter-menu text="Lots of Options">
+    <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 4">item 4</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 5">item 5</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 6">item 6</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 7">item 7</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 8">item 8</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 9">item 9</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 10">item 10</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 11">item 11</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 12">item 12</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 13">item 13</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 14">item 14</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 15">item 15</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 16">item 16</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 17">item 17</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 18">item 18</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 19">item 19</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 20">item 20</ebay-filter-menu-item>
+</ebay-filter-menu>

--- a/src/components/ebay-filter-menu/examples/04-with-footer-button/template.marko
+++ b/src/components/ebay-filter-menu/examples/04-with-footer-button/template.marko
@@ -1,0 +1,5 @@
+<ebay-filter-menu text="Filter Menu Footer" footer-text="Apply">
+    <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>
+</ebay-filter-menu>

--- a/src/components/ebay-filter-menu/examples/04-with-footer-button/template.marko
+++ b/src/components/ebay-filter-menu/examples/04-with-footer-button/template.marko
@@ -1,4 +1,4 @@
-<ebay-filter-menu text="Filter Menu Footer" footer-text="Apply">
+<ebay-filter-menu footer-text="Apply">
     <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>

--- a/src/components/ebay-filter-menu/examples/05-form-variant/template.marko
+++ b/src/components/ebay-filter-menu/examples/05-form-variant/template.marko
@@ -1,4 +1,4 @@
-<ebay-filter-menu text="Filter Menu Footer" footer-text="Apply" variant="form" form-name="filter-menu-form" form-action="http://www.ebay.com/">
+<ebay-filter-menu footer-text="Apply" variant="form" form-name="filter-menu-form" form-action="http://www.ebay.com/">
     <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
     <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>

--- a/src/components/ebay-filter-menu/examples/05-form-variant/template.marko
+++ b/src/components/ebay-filter-menu/examples/05-form-variant/template.marko
@@ -1,0 +1,5 @@
+<ebay-filter-menu text="Filter Menu Footer" footer-text="Apply" variant="form" form-name="filter-menu-form" form-action="http://www.ebay.com/">
+    <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>
+</ebay-filter-menu>

--- a/src/components/ebay-filter-menu/index.js
+++ b/src/components/ebay-filter-menu/index.js
@@ -16,7 +16,7 @@ module.exports = require('marko-widgets').defineComponent({
         const { firstRender } = e;
         this.contentEl = this.el.querySelector('.filter-menu__menu, .filter-menu-button__menu');
 
-        if (this.state.withButton) {
+        if (this.state.classPrefix) {
             this.contentEl = this.el;
         }
 

--- a/src/components/ebay-filter-menu/index.js
+++ b/src/components/ebay-filter-menu/index.js
@@ -1,0 +1,80 @@
+const assign = require('core-js-pure/features/object/assign');
+const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
+const rovingTabindex = require('makeup-roving-tabindex');
+const eventUtils = require('../../common/event-utils');
+const template = require('./template.marko');
+
+module.exports = require('marko-widgets').defineComponent({
+    template,
+    getInitialState(input) {
+        return assign({}, input, {
+            items: (input.items || []).map(item => assign({}, item))
+        });
+    },
+    onRender(event) {
+        this.contentEl = this.el.querySelector('.filter-menu__menu, .filter-menu-button__menu');
+
+        if (this.state.withButton) {
+            this.contentEl = this.el;
+        }
+
+        if (event.firstRender) {
+            if (this.state.variant !== 'form') {
+                // FIXME: should be outside of firstRender, but only when itemEls changes
+                this.rovingTabindex = rovingTabindex.createLinear(
+                    this.contentEl.querySelector('[role="menu"]'), 'div',
+                    { index: 0, autoReset: 0 }
+                );
+
+                scrollKeyPreventer.add(this.contentEl);
+            }
+        }
+    },
+    onDestroy() {
+        scrollKeyPreventer.remove(this.contentEl);
+    },
+    setCheckedItem(itemIndex, itemEl) {
+        const item = this.state.items[itemIndex];
+
+        if (item) {
+            this.state.items[itemIndex].checked = !item.checked;
+            this.setStateDirty('items');
+            this.emitComponentEvent('change', itemEl);
+        }
+    },
+    getCheckedItems() {
+        return this.state.items
+            .filter(item => item.checked)
+            .map(item => item.value);
+    },
+    handleItemClick(e, itemEl) {
+        this.setCheckedItem(this.getItemElementIndex(itemEl), itemEl);
+    },
+    handleItemKeydown(e, itemEl) {
+        eventUtils.handleEscapeKeydown(e, () => {
+            this.emitComponentEvent('keydown', null, e);
+        });
+
+        if (this.state.variant !== 'form') {
+            eventUtils.handleActionKeydown(e, () => {
+                this.setCheckedItem(this.getItemElementIndex(itemEl), itemEl);
+            });
+        }
+    },
+    handleFooterButtonClick(originalEvent) {
+        this.emitComponentEvent('footer-click', null, originalEvent);
+    },
+    handleFormSubmit(originalEvent) {
+        this.emitComponentEvent('form-submit', null, originalEvent);
+    },
+    getItemElementIndex(itemEl) {
+        return Array.prototype.slice.call(itemEl.parentNode.children).indexOf(itemEl);
+    },
+    emitComponentEvent(eventType, itemEl, originalEvent) {
+        this.emit(`filter-menu-${eventType}`, {
+            el: itemEl,
+            checked: this.getCheckedItems(),
+            originalEvent
+        });
+    }
+});

--- a/src/components/ebay-filter-menu/index.js
+++ b/src/components/ebay-filter-menu/index.js
@@ -1,4 +1,5 @@
 const assign = require('core-js-pure/features/object/assign');
+const findIndex = require('core-js-pure/features/array/find-index');
 const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 const rovingTabindex = require('makeup-roving-tabindex');
 const eventUtils = require('../../common/event-utils');
@@ -11,17 +12,22 @@ module.exports = require('marko-widgets').defineComponent({
             items: (input.items || []).map(item => assign({}, item))
         });
     },
-    onRender() {
+    onRender(e) {
+        const { firstRender } = e;
         this.contentEl = this.el.querySelector('.filter-menu__menu, .filter-menu-button__menu');
 
         if (this.state.withButton) {
             this.contentEl = this.el;
         }
 
+        if (firstRender) {
+            this.tabindexPosition = 0;
+        }
+
         if (this.state.variant !== 'form') {
             this.rovingTabindex = rovingTabindex.createLinear(
                 this.contentEl.querySelector('[role="menu"]'), 'div',
-                { index: 0, autoReset: null }
+                { index: this.tabindexPosition, autoReset: null }
             );
 
             scrollKeyPreventer.add(this.contentEl);
@@ -36,6 +42,9 @@ module.exports = require('marko-widgets').defineComponent({
         scrollKeyPreventer.remove(this.contentEl);
     },
     setCheckedItem(itemIndex, itemEl) {
+        const currentTabindex = findIndex(this.rovingTabindex.filteredItems, (el) => el.tabIndex === 0);
+        this.tabindexPosition = currentTabindex;
+
         const item = this.state.items[itemIndex];
 
         if (item) {

--- a/src/components/ebay-filter-menu/index.js
+++ b/src/components/ebay-filter-menu/index.js
@@ -11,26 +11,28 @@ module.exports = require('marko-widgets').defineComponent({
             items: (input.items || []).map(item => assign({}, item))
         });
     },
-    onRender(event) {
+    onRender() {
         this.contentEl = this.el.querySelector('.filter-menu__menu, .filter-menu-button__menu');
 
         if (this.state.withButton) {
             this.contentEl = this.el;
         }
 
-        if (event.firstRender) {
-            if (this.state.variant !== 'form') {
-                // FIXME: should be outside of firstRender, but only when itemEls changes
-                this.rovingTabindex = rovingTabindex.createLinear(
-                    this.contentEl.querySelector('[role="menu"]'), 'div',
-                    { index: 0, autoReset: 0 }
-                );
+        if (this.state.variant !== 'form') {
+            this.rovingTabindex = rovingTabindex.createLinear(
+                this.contentEl.querySelector('[role="menu"]'), 'div',
+                { index: 0, autoReset: null }
+            );
 
-                scrollKeyPreventer.add(this.contentEl);
-            }
+            scrollKeyPreventer.add(this.contentEl);
         }
     },
+    onBeforeUpdate() {
+        this.rovingTabindex.destroy();
+        scrollKeyPreventer.remove(this.contentEl);
+    },
     onDestroy() {
+        this.rovingTabindex.destroy();
         scrollKeyPreventer.remove(this.contentEl);
     },
     setCheckedItem(itemIndex, itemEl) {

--- a/src/components/ebay-filter-menu/index.js
+++ b/src/components/ebay-filter-menu/index.js
@@ -14,7 +14,8 @@ module.exports = require('marko-widgets').defineComponent({
     },
     onRender(e) {
         const { firstRender } = e;
-        this.contentEl = this.el.querySelector('.filter-menu__menu, .filter-menu-button__menu');
+        const baseClass = this.state.classPrefix || 'filter-menu';
+        this.contentEl = this.el.querySelector(`.${baseClass}__menu`);
 
         if (this.state.classPrefix) {
             this.contentEl = this.el;

--- a/src/components/ebay-filter-menu/template.marko
+++ b/src/components/ebay-filter-menu/template.marko
@@ -1,0 +1,55 @@
+<script marko-init>
+    var processHtmlAttributes = require("../../common/html-attributes");
+</script>
+
+<var baseClass = data.withButton ? 'filter-menu-button': 'filter-menu'/>
+<var outerClass = data.withButton ? `${baseClass}__menu`: 'filter-menu'/>
+<var isForm = data.variant === 'form'/>
+<var checkedItems = (data.items && data.items.filter(function(item){ return item.checked })) || []/>
+
+<span
+    w-bind
+    class=[(data.withButton ? "${baseClass}__menu": baseClass), data.class]
+    style=data.style
+    ${processHtmlAttributes(data)}>
+    <div class="${baseClass}__menu" body-only-if(data.withButton)>
+        <form body-only-if(!isForm) name=data.formName action=data.formAction w-on-submit="handleFormSubmit">
+            <div class="${baseClass}__items" role=(!isForm && "menu")>
+                <for(item in data.items)>
+                    <${isForm ? "label" : "div"}
+                        class=["${baseClass}__item", item.class]
+                        style=item.style
+                        role="menuitemcheckbox"
+                        aria-checked=(item.checked ? "true" : "false" )
+                        data-value=item.value
+                        for=(isForm && widget.elId("checkbox"))
+                        w-onclick="handleItemClick"
+                        w-onkeydown="handleItemKeydown"
+                        ${processHtmlAttributes(item)}>
+                        <if(isForm)>
+                            <ebay-checkbox w-id="checkbox" checked=item.checked/>
+                        </if>
+                        <else>
+                            <span class="${baseClass}__status">
+                                <if(item.checked)>
+                                    <ebay-icon type="inline" name="checkbox-checked" />
+                                </if>
+                                <else>
+                                    <ebay-icon type="inline" name="checkbox-unchecked" />
+                                </else>
+                            </span>
+                        </else>
+                        <span class="${baseClass}__text" w-body=item.renderBody />
+                    </>
+                </for>
+            </div>
+            <button
+                if(data.footerText)
+                type=(data.variant === 'form'? "submit": "button")
+                aria-label=data.a11yFooterText
+                class="${baseClass}__footer"
+                w-onclick=(isForm ? null : "handleFooterButtonClick")
+            >${data.footerText}</button>
+        </form>
+    </div>
+</span>

--- a/src/components/ebay-filter-menu/template.marko
+++ b/src/components/ebay-filter-menu/template.marko
@@ -2,17 +2,17 @@
     var processHtmlAttributes = require("../../common/html-attributes");
 </script>
 
-<var baseClass = data.withButton ? 'filter-menu-button': 'filter-menu'/>
-<var outerClass = data.withButton ? `${baseClass}__menu`: 'filter-menu'/>
+<var baseClass = data.classPrefix ? data.classPrefix : 'filter-menu'/>
+<var outerClass = data.classPrefix ? `${baseClass}__menu`: 'filter-menu'/>
 <var isForm = data.variant === 'form'/>
 <var checkedItems = (data.items && data.items.filter(function(item){ return item.checked })) || []/>
 
 <span
     w-bind
-    class=[(data.withButton ? "${baseClass}__menu": baseClass), data.class]
+    class=[(data.classPrefix ? "${baseClass}__menu": baseClass), data.class]
     style=data.style
     ${processHtmlAttributes(data)}>
-    <div class="${baseClass}__menu" body-only-if(data.withButton)>
+    <div class="${baseClass}__menu" body-only-if(data.classPrefix)>
         <form
             body-only-if(!isForm)
             name=data.formName

--- a/src/components/ebay-filter-menu/template.marko
+++ b/src/components/ebay-filter-menu/template.marko
@@ -13,7 +13,12 @@
     style=data.style
     ${processHtmlAttributes(data)}>
     <div class="${baseClass}__menu" body-only-if(data.withButton)>
-        <form body-only-if(!isForm) name=data.formName action=data.formAction w-on-submit="handleFormSubmit">
+        <form
+            body-only-if(!isForm)
+            name=data.formName
+            action=data.formAction
+            method=data.formMethod
+            w-on-submit="handleFormSubmit">
             <div class="${baseClass}__items" role=(!isForm && "menu")>
                 <for(item in data.items)>
                     <${isForm ? "label" : "div"}

--- a/src/components/ebay-filter-menu/template.marko
+++ b/src/components/ebay-filter-menu/template.marko
@@ -2,7 +2,7 @@
     var processHtmlAttributes = require("../../common/html-attributes");
 </script>
 
-<var baseClass = data.classPrefix ? data.classPrefix : 'filter-menu'/>
+<var baseClass = (data.classPrefix || 'filter-menu')/>
 <var outerClass = data.classPrefix ? `${baseClass}__menu`: 'filter-menu'/>
 <var isForm = data.variant === 'form'/>
 <var checkedItems = (data.items && data.items.filter(function(item){ return item.checked })) || []/>

--- a/src/components/ebay-filter-menu/test/mock/index.js
+++ b/src/components/ebay-filter-menu/test/mock/index.js
@@ -1,0 +1,19 @@
+const assign = require('core-js-pure/features/object/assign');
+const { createRenderBody, getNItems } = require('../../../../common/test-utils/shared');
+
+exports.Basic_2Items = {
+    text: 'Basic Filter Menu Button',
+    footerText: 'Apply',
+    a11yText: 'Filter Menu Button A11y Text',
+    items: getNItems(2, i => ({
+        value: `item ${i}`,
+        renderBody: createRenderBody(`Item text ${i}`)
+    }))
+};
+
+exports.Basic_3Items = assign({}, exports.Basic_2Items, {
+    items: getNItems(3, i => ({
+        value: `item ${i}`,
+        renderBody: createRenderBody(`Item text ${i}`)
+    }))
+});

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -1,0 +1,132 @@
+const { expect, use } = require('chai');
+const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const { pressKey } = require('../../../common/test-utils/browser');
+const mock = require('./mock');
+const template = require('..');
+
+use(require('chai-dom'));
+afterEach(cleanup);
+
+/** @type import("@marko/testing-library").RenderResult */
+let component;
+
+describe('given the menu is in the default state', () => {
+    const input = mock.Basic_2Items;
+    const firstItemText = input.items[0].renderBody.text;
+    let footerButton, firstItem, secondItem;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+        footerButton = component.getAllByRole('button')[0];
+        firstItem = component.getAllByRole('menuitemcheckbox')[0];
+        secondItem = component.getAllByRole('menuitemcheckbox')[1];
+    });
+
+    describe('when an item is clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(component.getByText(firstItemText));
+        });
+
+        it('then it emits the filter-menu-change event with correct data', () => {
+            const selectEvents = component.emitted('filter-menu-change');
+            expect(selectEvents).to.length(1);
+
+            const [[eventArg]] = selectEvents;
+            expect(eventArg).has.property('el').with.text(firstItemText);
+            expect(eventArg).has.property('checked').to.deep.equal(['item 0']);
+        });
+    });
+
+    describe('when two items are clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(firstItem);
+            await fireEvent.click(secondItem);
+        });
+
+        it('then it emits two menu-change events with correct data', () => {
+            const changeEvents = component.emitted('filter-menu-change');
+            expect(changeEvents).to.have.length(2);
+
+            const firstEventData = changeEvents[0][0];
+            const secondEventData = changeEvents[1][0];
+            expect(firstEventData).has.property('el', firstItem);
+            expect(secondEventData).has.property('el', secondItem);
+        });
+
+        it('then both items are selected', () => {
+            expect(firstItem).to.have.attr('aria-checked', 'true');
+            expect(secondItem).to.have.attr('aria-checked', 'true');
+        });
+    });
+
+    describe('when an item is checked and then unchecked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(firstItem);
+            await fireEvent.click(firstItem);
+        });
+
+        it('then it emits the filter-menu-change events with correct data', () => {
+            const changeEvents = component.emitted('filter-menu-change');
+            expect(changeEvents).to.have.length(2);
+
+            const firstEventData = changeEvents[0][0];
+            const secondEventData = changeEvents[1][0];
+            expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
+            expect(secondEventData).has.property('checked').to.deep.equal([]);
+        });
+
+        it('then the item is unchecked', () => {
+            expect(firstItem).to.have.attr('aria-checked', 'false');
+        });
+    });
+
+    describe('when an item is checked via the keyboard', () => {
+        beforeEach(async() => {
+            await pressKey(firstItem, {
+                key: '(Space character)',
+                keyCode: 32
+            });
+        });
+
+        it('then it emits the filter-menu-change events with correct data', () => {
+            const changeEvents = component.emitted('filter-menu-change');
+            expect(changeEvents).to.have.length(1);
+
+            const firstEventData = changeEvents[0][0];
+            expect(firstEventData).has.property('el').with.text(firstItemText);
+            expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
+        });
+    });
+
+    describe('when the footer button is clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(footerButton);
+        });
+
+        it('then it emits the filter-menu-footer-click event', () => {
+            const changeEvents = component.emitted('filter-menu-footer-click');
+            expect(changeEvents).to.have.length(1);
+        });
+    });
+
+    describe('when an item is added via input from its parent and the new item is clicked', () => {
+        const newInput = mock.Basic_3Items;
+        const thirdItemText = newInput.items[2].renderBody.text;
+        beforeEach(async() => {
+            await component.rerender(newInput);
+            await fireEvent.click(component.getByText(thirdItemText));
+        });
+
+        it('then the new item is selected or something');
+
+        it('then it uses the new input in event data', () => {
+            const selectEvents = component.emitted('filter-menu-change');
+            expect(selectEvents).has.length(1);
+
+            const [[eventArg]] = selectEvents;
+            expect(eventArg)
+                .has.property('el')
+                .with.text(thirdItemText);
+        });
+    });
+});

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -117,8 +117,6 @@ describe('given the menu is in the default state', () => {
             await fireEvent.click(component.getByText(thirdItemText));
         });
 
-        it('then the new item is selected or something');
-
         it('then it uses the new input in event data', () => {
             const selectEvents = component.emitted('filter-menu-change');
             expect(selectEvents).has.length(1);

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -47,8 +47,7 @@ describe('given the menu is in the default state', () => {
             const changeEvents = component.emitted('filter-menu-change');
             expect(changeEvents).to.have.length(2);
 
-            const firstEventData = changeEvents[0][0];
-            const secondEventData = changeEvents[1][0];
+            const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el', firstItem);
             expect(secondEventData).has.property('el', secondItem);
         });
@@ -69,8 +68,7 @@ describe('given the menu is in the default state', () => {
             const changeEvents = component.emitted('filter-menu-change');
             expect(changeEvents).to.have.length(2);
 
-            const firstEventData = changeEvents[0][0];
-            const secondEventData = changeEvents[1][0];
+            const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
             expect(secondEventData).has.property('checked').to.deep.equal([]);
         });
@@ -92,7 +90,7 @@ describe('given the menu is in the default state', () => {
             const changeEvents = component.emitted('filter-menu-change');
             expect(changeEvents).to.have.length(1);
 
-            const firstEventData = changeEvents[0][0];
+            const [firstEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el').with.text(firstItemText);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
         });

--- a/src/components/ebay-filter-menu/test/test.server.js
+++ b/src/components/ebay-filter-menu/test/test.server.js
@@ -6,34 +6,22 @@ const template = require('..');
 
 use(require('chai-dom'));
 
-describe('filter-menu-button', () => {
+describe('filter-menu', () => {
     it('renders basic version', async() => {
         const input = mock.Basic_2Items;
         const { getByRole, getAllByRole, getByText } = await render(template, input);
-        const btnEl = getAllByRole('button')[0];
-        expect(btnEl).contains(getByText(input.text));
-        expect(btnEl).has.attr('aria-label', input.a11yText);
-        expect(btnEl).has.class('filter-menu-button__button');
-        expect(btnEl).has.attr('aria-haspopup', 'true');
-        expect(btnEl).has.attr('aria-expanded', 'false');
-        expect(btnEl).has.property('parentElement').with.class('filter-menu-button');
-        expect(btnEl.querySelector('.icon--chevron-down')).has.property('tagName', 'svg');
-        expect(getByRole('menu')).has.property('parentElement').with.class('filter-menu-button__menu');
+        const menuEl = getByRole('menu');
+        expect(menuEl).has.class('filter-menu__items');
+        expect(menuEl).has.property('parentElement').with.class('filter-menu__menu');
 
         const menuItemEls = getAllByRole('menuitemcheckbox');
         input.items.forEach((item, i) => {
             const menuItemEl = menuItemEls[i];
             const textEl = getByText(item.renderBody.text);
-            expect(menuItemEl).has.class('filter-menu-button__item');
+            expect(menuItemEl).has.class('filter-menu__item');
             expect(menuItemEl).has.attr('data-value', menuItemEl.value);
             expect(menuItemEl).contains(textEl);
         });
-    });
-
-    it('renders with disabled state', async() => {
-        const input = mock.Disabled;
-        const { getAllByRole } = await render(template, input);
-        expect(getAllByRole('button')[0]).has.attr('disabled');
     });
 
     it(`renders checked item`, async() => {
@@ -46,4 +34,10 @@ describe('filter-menu-button', () => {
     });
 
     testUtils.testPassThroughAttributes(template);
+    testUtils.testPassThroughAttributes(template, {
+        child: {
+            name: 'items',
+            multiple: true
+        }
+    });
 });


### PR DESCRIPTION
## Description
- Adds the `ebay-filter-menu`
- Modifies the `ebay-filter-menu-button` to use the new `ebay-filter-menu`

## Context
The `ebay-filter-menu` can now be used as a standalone component, specifically for mobile-first apps. The API is similar to the `ebay-filter-menu-button`, for obvious reasons, but with some less attributes.

With regards to the `ebay-filter-menu-button` changes, many of the attributes now pass through, in order to power the `ebay-filter-menu`.

## References
Closes #770 

## Screenshots
![image](https://user-images.githubusercontent.com/105656/63960007-b388fa00-ca4a-11e9-8a68-8a63289b64fa.png)
![image](https://user-images.githubusercontent.com/105656/63960028-bf74bc00-ca4a-11e9-9882-d48c8bd7ec4e.png)
![image](https://user-images.githubusercontent.com/105656/63960069-da473080-ca4a-11e9-9232-12758788270c.png)
