### PR TITLE
Carousel: remove unneeded deps

### DIFF
--- a/src/components/ebay-carousel/browser.json
+++ b/src/components/ebay-carousel/browser.json
@@ -6,8 +6,6 @@
         {
             "if-not-flag": "ebayui-no-skin",
             "dependencies": [
-                "@ebay/skin/utility",
-                "@ebay/skin/less",
                 "@ebay/skin/icon/foreground",
                 "@ebay/skin/carousel"
             ]


### PR DESCRIPTION
## Description
The carousel has two `browser.json` dependencies left over from when the styles where included within the component directly. Now the skin utilities are not required by the carousel.
