### PR TITLE
Misc cleanup and fixes for filter menu in Marko 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "lasso-marko": "^2.4.7",
     "lintspaces-cli": "^0.7.1",
     "marko": "^4",
-    "marko-cli": "^7.0.14",
+    "marko-cli": "^7.0.16",
     "marko-prettyprint": "^1.5.2",
     "marko-widgets": "^7",
     "mocha": "^6.1.4",

--- a/src/components/ebay-filter-menu-button/index.js
+++ b/src/components/ebay-filter-menu-button/index.js
@@ -1,4 +1,5 @@
 const assign = require('core-js-pure/features/object/assign');
+const indexOf = require('core-js-pure/features/array/index-of');
 const Expander = require('makeup-expander');
 const eventUtils = require('../../common/event-utils');
 const template = require('./template.marko');
@@ -7,17 +8,11 @@ module.exports = require('marko-widgets').defineComponent({
     template,
     getInitialState(input) {
         return assign({}, input, {
-            pressed: input.pressed || false,
-            expanded: false,
             items: (input.items || []).map(item => assign({}, item))
         });
     },
     onRender(event) {
-        this.contentEl = this.el.querySelector('.filter-menu-button__menu');
-        this.buttonEl = this.el.querySelector('button.filter-menu-button__button');
-
         if (event.firstRender) {
-            // FIX ME: this should be synced with the expanded state instead of using the `update_expanded` api below.
             this.expander = new Expander(this.el, {
                 hostSelector: '.filter-menu-button__button',
                 contentSelector: '.filter-menu-button__menu',
@@ -28,62 +23,39 @@ module.exports = require('marko-widgets').defineComponent({
             });
         }
     },
-    update_expanded(expanded) { // eslint-disable-line camelcase
-        if ((expanded && this.buttonEl.getAttribute('aria-expanded') === 'false') ||
-            (!expanded && this.buttonEl.getAttribute('aria-expanded') === 'true')) {
-            this.buttonEl.click();
-        }
+    toggleItemChecked(itemEl) {
+        const index = indexOf(itemEl.parentNode.children, itemEl);
+        const item = this.state.items[index];
+        item.checked = !item.checked;
+        this.setStateDirty('items');
+        this.emitComponentEvent('change', itemEl);
     },
-    setCheckedItem(itemIndex, itemEl) {
-        const item = this.state.items[itemIndex];
-
-        if (item) {
-            this.state.items[itemIndex].checked = !item.checked;
-            this.setStateDirty('items');
-            this.emitComponentEvent('change', itemEl);
-        }
-    },
-    getCheckedItems() {
+    getCheckedValues() {
         return this.state.items
             .filter(item => item.checked)
             .map(item => item.value);
     },
     handleButtonKeydown(e) {
-        eventUtils.handleEscapeKeydown(e.originalEvent, () => {
-            this.buttonEl.setAttribute('aria-expanded', false);
-        });
+        eventUtils.handleEscapeKeydown(e.originalEvent, () => this.expander.collapse());
     },
-    handleMenuChange(e) {
-        const { el } = e;
-        this.setCheckedItem(this.getItemElementIndex(el), el);
+    handleMenuChange({ el }) {
+        this.toggleItemChecked(el);
     },
-    handleItemKeydown(e) {
-        const { el, originalEvent } = e;
-        eventUtils.handleActionKeydown(originalEvent, () => {
-            this.setCheckedItem(this.getItemElementIndex(el), el);
-        });
+    handleItemKeydown({ el, originalEvent }) {
+        eventUtils.handleActionKeydown(originalEvent, () => this.toggleItemChecked(el));
     },
     handleFooterButtonClick() {
         this.emitComponentEvent('footer-click');
-        this.setState('expanded', false);
-        this.buttonEl.setAttribute('aria-expanded', false);
-        this.buttonEl.setAttribute('aria-pressed', (this.getCheckedItems().length > 0));
+        this.expander.collapse();
     },
-    handleFormSubmit(e) {
-        const { originalEvent } = e;
+    handleFormSubmit({ originalEvent }) {
         this.emitComponentEvent('form-submit', null, originalEvent);
     },
-    handleExpand(e) {
-        const { originalEvent } = e;
+    handleExpand({ originalEvent }) {
         this.emitComponentEvent('expand', null, originalEvent);
     },
-    handleCollapse(e) {
-        const { originalEvent } = e;
+    handleCollapse({ originalEvent }) {
         this.emitComponentEvent('collapse', null, originalEvent);
-    },
-    getItemElementIndex(itemEl) {
-        const parentNode = itemEl.parentNode || itemEl.el.parentNode;
-        return Array.prototype.slice.call(parentNode.children).indexOf(itemEl);
     },
     emitComponentEvent(eventType, itemEl, originalEvent) {
         switch (eventType) {
@@ -93,7 +65,7 @@ module.exports = require('marko-widgets').defineComponent({
             case 'form-submit':
             case 'collapse':
                 this.emit(`filter-menu-button-${eventType}`, {
-                    checked: this.getCheckedItems(),
+                    checked: this.getCheckedValues(),
                     originalEvent
                 });
                 break;
@@ -102,7 +74,7 @@ module.exports = require('marko-widgets').defineComponent({
             default:
                 this.emit(`filter-menu-button-${eventType}`, {
                     el: itemEl,
-                    checked: this.getCheckedItems(),
+                    checked: this.getCheckedValues(),
                     originalEvent
                 });
                 break;

--- a/src/components/ebay-filter-menu-button/template.marko
+++ b/src/components/ebay-filter-menu-button/template.marko
@@ -2,7 +2,6 @@
     var processHtmlAttributes = require("../../common/html-attributes");
 </script>
 
-<var isForm = data.variant === 'form'/>
 <var checkedItems = (data.items && data.items.filter(function(item){ return item.checked })) || []/>
 
 <span
@@ -16,10 +15,10 @@
         type="button"
         class="filter-menu-button__button"
         disabled=data.disabled
-        aria-expanded=String(data.expanded)
         aria-haspopup="true"
         aria-label=data.a11yText
-        aria-pressed=(checkedItems.length > 0 && !data.footerButton && "true")>
+        aria-pressed=(checkedItems.length > 0 && !data.footerButton && "true")
+        w-preserve-attrs="aria-expanded">
         <span class="filter-menu-button__button-cell">
             <span class="filter-menu-button__button-text">${data.text}</span>
             <ebay-icon type="inline" name="chevron-down" />
@@ -43,8 +42,9 @@
                 class=item.class
                 value=item.value
                 checked=item.checked
-                variant=data.variant
-                w-body=item.renderBody/>
+                variant=data.variant>
+                <span body-only-if(true) w-body=item.renderBody/>
+            </ebay-filter-menu-item>
         </for>
     </ebay-filter-menu>
 </span>

--- a/src/components/ebay-filter-menu-button/template.marko
+++ b/src/components/ebay-filter-menu-button/template.marko
@@ -15,6 +15,7 @@
         type="button"
         class="filter-menu-button__button"
         disabled=data.disabled
+        aria-expanded="false"
         aria-haspopup="true"
         aria-label=data.a11yText
         aria-pressed=(checkedItems.length > 0 && !data.footerButton && "true")

--- a/src/components/ebay-filter-menu-button/test/test.server.js
+++ b/src/components/ebay-filter-menu-button/test/test.server.js
@@ -15,6 +15,7 @@ describe('filter-menu-button', () => {
         expect(btnEl).has.attr('aria-label', input.a11yText);
         expect(btnEl).has.class('filter-menu-button__button');
         expect(btnEl).has.attr('aria-haspopup', 'true');
+        expect(btnEl).has.attr('aria-expanded', 'false');
         expect(btnEl).has.property('parentElement').with.class('filter-menu-button');
         expect(btnEl.querySelector('.icon--chevron-down')).has.property('tagName', 'svg');
         expect(getByRole('menu')).has.property('parentElement').with.class('filter-menu-button__menu');

--- a/src/components/ebay-filter-menu-button/test/test.server.js
+++ b/src/components/ebay-filter-menu-button/test/test.server.js
@@ -15,7 +15,6 @@ describe('filter-menu-button', () => {
         expect(btnEl).has.attr('aria-label', input.a11yText);
         expect(btnEl).has.class('filter-menu-button__button');
         expect(btnEl).has.attr('aria-haspopup', 'true');
-        expect(btnEl).has.attr('aria-expanded', 'false');
         expect(btnEl).has.property('parentElement').with.class('filter-menu-button');
         expect(btnEl.querySelector('.icon--chevron-down')).has.property('tagName', 'svg');
         expect(getByRole('menu')).has.property('parentElement').with.class('filter-menu-button__menu');

--- a/src/components/ebay-filter-menu/template.marko
+++ b/src/components/ebay-filter-menu/template.marko
@@ -12,16 +12,17 @@
     class=[(data.classPrefix ? "${baseClass}__menu": baseClass), data.class]
     style=data.style
     ${processHtmlAttributes(data)}>
-    <div class="${baseClass}__menu" body-only-if(data.classPrefix)>
+    <div w-id="content" class="${baseClass}__menu" body-only-if(data.classPrefix)>
         <form
             body-only-if(!isForm)
             name=data.formName
             action=data.formAction
             method=data.formMethod
             w-on-submit="handleFormSubmit">
-            <div class="${baseClass}__items" role=(!isForm && "menu")>
+            <div w-id="menu" class="${baseClass}__items" role=(!isForm && "menu")>
                 <for(item in data.items)>
                     <${isForm ? "label" : "div"}
+                        w-id="item[]"
                         class=["${baseClass}__item", item.class]
                         style=item.style
                         role="menuitemcheckbox"

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,10 +938,10 @@
     webpack-dev-server "^3.1.14"
     webpack-inject-plugin "^1.1.0"
 
-"@marko/test@^6.0.12":
-  version "6.0.12"
-  resolved "https://registry.npmjs.org/@marko/test/-/test-6.0.12.tgz#915034bceeb9554c02bf32204cee076310de73c5"
-  integrity sha512-ebNCph1eRcsbJmCofHxgtUKvC0bnbHZ9xEo8KcYdp1ugv8Qc+SWPiew/udGcNpn8skstG3aRBlZsinYAflo8tQ==
+"@marko/test@^6.0.14":
+  version "6.0.14"
+  resolved "https://registry.npmjs.org/@marko/test/-/test-6.0.14.tgz#0060cd6f04109c2b22615b2c4de0e1549a695264"
+  integrity sha512-y6YFO0OF7m1ICHhSVepP18KsaLfZOhENkGdjZrUura6ivjEd1akoZ+isJ0DAvQ7LGsxlCqCdic5mEm/47c3zsg==
   dependencies:
     "@lasso/marko-taglib" "^1.0.13"
     "@wdio/cli" "^5.8.4"
@@ -8937,10 +8937,10 @@ markdown-table@^1.1.0:
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
-marko-cli@^7.0.14:
-  version "7.0.14"
-  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-7.0.14.tgz#5d7cf16e4211e02f428174d4653536339bece136"
-  integrity sha512-OoUdy6ZfWBwwN8+XPbwCcdmK5aFRci4BhnIEQpkiF04o791vCEAdh3rKURoZ3J6xRfNTGdhbeK4q3xrDyAmjoA==
+marko-cli@^7.0.16:
+  version "7.0.16"
+  resolved "https://registry.npmjs.org/marko-cli/-/marko-cli-7.0.16.tgz#e62539040bfc3969194b2644132bc997d2f9b807"
+  integrity sha512-npT044OD9Q068sZCWqEtYhe8zv+sv4ibB8N+0vCyaGZVOa8uXwrshFAWgcWGDXuCUTR1t5rQhKa4nPKWFZi5sg==
   dependencies:
     "@babel/runtime" "^7.2.0"
     "@marko/build" "^1.0.3"
@@ -8949,7 +8949,7 @@ marko-cli@^7.0.14:
     "@marko/migrate" "^5.1.0"
     "@marko/prettyprint" "^2.1.2"
     "@marko/serve" "^1.0.3"
-    "@marko/test" "^6.0.12"
+    "@marko/test" "^6.0.14"
     app-root-dir "^1.0.2"
     argly "^1.2.0"
     complain "^1.3.0"
@@ -9018,7 +9018,45 @@ marko@4.14.21:
     try-require "^1.2.1"
     warp10 "^2.0.1"
 
-marko@^4, marko@^4.10.0, marko@^4.12.3, marko@^4.15.2:
+marko@^4:
+  version "4.18.13"
+  resolved "https://registry.npmjs.org/marko/-/marko-4.18.13.tgz#3c108e46bd33d0d3e01bfa79619abf4a13f7d814"
+  integrity sha512-1sFI4yfbOXxY/48lgunZgpoiOd86ZGuO42bshBiZqlkmcumlznnHknbBPKtq+CLq+LTXL2apW/XlUSWqAe09Rw==
+  dependencies:
+    app-module-path "^2.2.0"
+    argly "^1.0.0"
+    browser-refresh-client "^1.0.0"
+    camelcase "^5.0.0"
+    char-props "~0.1.5"
+    complain "^1.6.0"
+    deresolve "^1.1.2"
+    escodegen "^1.8.1"
+    esprima "^4.0.0"
+    estraverse "^4.2.0"
+    events "^1.0.2"
+    events-light "^1.0.0"
+    he "^1.1.0"
+    htmljs-parser "^2.6.7"
+    lasso-caching-fs "^1.0.1"
+    lasso-modules-client "^2.0.4"
+    lasso-package-root "^1.0.1"
+    listener-tracker "^2.0.0"
+    minimatch "^3.0.2"
+    object-assign "^4.1.0"
+    property-handlers "^1.0.0"
+    raptor-json "^1.0.1"
+    raptor-polyfill "^1.0.0"
+    raptor-promises "^1.0.1"
+    raptor-regexp "^1.0.0"
+    raptor-util "^3.2.0"
+    resolve-from "^2.0.0"
+    shorthash "0.0.2"
+    simple-sha1 "^2.1.0"
+    strip-json-comments "^2.0.1"
+    try-require "^1.2.1"
+    warp10 "^2.0.1"
+
+marko@^4.10.0, marko@^4.12.3, marko@^4.15.2:
   version "4.18.10"
   resolved "https://registry.npmjs.org/marko/-/marko-4.18.10.tgz#02889b00a9dd5d12e064db720080951a3bc0c148"
   integrity sha512-X2pmJIOBZ/39D2fCQZYtWprIjvrLF+cpEK0vjzMVwxBh13tRCyUhwoqlQO84d8Xif+RMEuR3/9fRDlwnURMSTw==


### PR DESCRIPTION
## Description
There are a few changes in here, and a little bit of refactoring.

## Fixes
1. Fixes an issue where the events were not forwarded between `ebay-filter-menu` and `ebay-filter-menu-button`. This issue was because `w-body` on a nested tag is broken in Marko 3. Fixed by switching it to use `<span body-only-if(true) w-body=item.renderBody/>` 😞.
2. Item els were being thrown away in Marko 3 causing issues with the tests. Fixed by adding `w-id="item[]"` to each item in the `ebay-filter-menu`.

## Improvements
1. `expand` and `pressed` states did not look to actually be used for the `ebay-filter-menu-button`. This allowed me to delete some code and just allow the expander to handle the `aria-expanded` attribute alone as we do in some other components.
2. Refactored some method names to be more clear (setX => toggleX in some cases).
3. Calculated item indexes in the toggle methods instead of doing that calculation every where the method was called.
4. in some places we were using `querySelector` which was not necessary and so I switched them to use the recommended `getEl`.
5. Updated `marko-cli` because I fixed an issue where the stack trace was not printing properly.