### PR TITLE
Filter menu fixes for marko 3

### DIFF
--- a/src/components/ebay-filter-menu-button/template.marko
+++ b/src/components/ebay-filter-menu-button/template.marko
@@ -43,8 +43,9 @@
                 class=item.class
                 value=item.value
                 checked=item.checked
-                variant=data.variant
-                w-body=item.renderBody/>
+                variant=data.variant>
+                <span body-only-if(true) w-body=item.renderBody/>
+            </ebay-filter-menu-item>
         </for>
     </ebay-filter-menu>
 </span>

--- a/src/components/ebay-filter-menu/template.marko
+++ b/src/components/ebay-filter-menu/template.marko
@@ -22,6 +22,7 @@
             <div class="${baseClass}__items" role=(!isForm && "menu")>
                 <for(item in data.items)>
                     <${isForm ? "label" : "div"}
+                        w-id="item[]"
                         class=["${baseClass}__item", item.class]
                         style=item.style
                         role="menuitemcheckbox"


### PR DESCRIPTION
This PR includes just the fixes that were causing Marko 3 tests to fail from #848.
## Description

1. Fixes an issue where the events were not forwarded between ebay-filter-menu and ebay-filter-menu-button. This issue was because w-body on a nested tag is broken in Marko 3. Fixed by switching it to use <span body-only-if(true) w-body=item.renderBody/> 😞.
2. Item els were being thrown away in Marko 3 causing issues with the tests. Fixed by adding w-id="item[]" to each item in the ebay-filter-menu.
