### PR TITLE
Filter menu improvements

### DIFF
--- a/src/components/ebay-filter-menu-button/template.marko
+++ b/src/components/ebay-filter-menu-button/template.marko
@@ -2,7 +2,6 @@
     var processHtmlAttributes = require("../../common/html-attributes");
 </script>
 
-<var isForm = data.variant === 'form'/>
 <var checkedItems = (data.items && data.items.filter(function(item){ return item.checked })) || []/>
 
 <span
@@ -16,10 +15,11 @@
         type="button"
         class="filter-menu-button__button"
         disabled=data.disabled
-        aria-expanded=String(data.expanded)
+        aria-expanded="false"
         aria-haspopup="true"
         aria-label=data.a11yText
-        aria-pressed=(checkedItems.length > 0 && !data.footerButton && "true")>
+        aria-pressed=(checkedItems.length > 0 && !data.footerButton && "true")
+        w-preserve-attrs="aria-expanded">
         <span class="filter-menu-button__button-cell">
             <span class="filter-menu-button__button-text">${data.text}</span>
             <ebay-icon type="inline" name="chevron-down" />

--- a/src/components/ebay-filter-menu/index.js
+++ b/src/components/ebay-filter-menu/index.js
@@ -1,4 +1,5 @@
 const assign = require('core-js-pure/features/object/assign');
+const indexOf = require('core-js-pure/features/array/index-of');
 const findIndex = require('core-js-pure/features/array/find-index');
 const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 const rovingTabindex = require('makeup-roving-tabindex');
@@ -14,12 +15,7 @@ module.exports = require('marko-widgets').defineComponent({
     },
     onRender(e) {
         const { firstRender } = e;
-        const baseClass = this.state.classPrefix || 'filter-menu';
-        this.contentEl = this.el.querySelector(`.${baseClass}__menu`);
-
-        if (this.state.classPrefix) {
-            this.contentEl = this.el;
-        }
+        this.contentEl = this.getEl('content') || this.el;
 
         if (firstRender) {
             this.tabindexPosition = 0;
@@ -27,7 +23,7 @@ module.exports = require('marko-widgets').defineComponent({
 
         if (this.state.variant !== 'form') {
             this.rovingTabindex = rovingTabindex.createLinear(
-                this.contentEl.querySelector('[role="menu"]'), 'div',
+                this.getEl('menu'), 'div',
                 { index: this.tabindexPosition, autoReset: null }
             );
 
@@ -54,13 +50,21 @@ module.exports = require('marko-widgets').defineComponent({
             this.emitComponentEvent('change', itemEl);
         }
     },
-    getCheckedItems() {
+    toggleItemChecked(itemEl) {
+        const itemIndex = indexOf(itemEl.parentNode.children, itemEl);
+        const item = this.state.items[itemIndex];
+        item.checked = !item.checked;
+        this.setStateDirty('items');
+        this.emitComponentEvent('change', itemEl);
+        this.tabindexPosition = findIndex(this.rovingTabindex.filteredItems, el => el.tabIndex === 0);
+    },
+    getCheckedValues() {
         return this.state.items
             .filter(item => item.checked)
             .map(item => item.value);
     },
     handleItemClick(e, itemEl) {
-        this.setCheckedItem(this.getItemElementIndex(itemEl), itemEl);
+        this.toggleItemChecked(itemEl);
     },
     handleItemKeydown(e, itemEl) {
         eventUtils.handleEscapeKeydown(e, () => {
@@ -68,9 +72,7 @@ module.exports = require('marko-widgets').defineComponent({
         });
 
         if (this.state.variant !== 'form') {
-            eventUtils.handleActionKeydown(e, () => {
-                this.setCheckedItem(this.getItemElementIndex(itemEl), itemEl);
-            });
+            eventUtils.handleActionKeydown(e, () => this.toggleItemChecked(itemEl));
         }
     },
     handleFooterButtonClick(originalEvent) {
@@ -79,13 +81,10 @@ module.exports = require('marko-widgets').defineComponent({
     handleFormSubmit(originalEvent) {
         this.emitComponentEvent('form-submit', null, originalEvent);
     },
-    getItemElementIndex(itemEl) {
-        return Array.prototype.slice.call(itemEl.parentNode.children).indexOf(itemEl);
-    },
     emitComponentEvent(eventType, itemEl, originalEvent) {
         this.emit(`filter-menu-${eventType}`, {
             el: itemEl,
-            checked: this.getCheckedItems(),
+            checked: this.getCheckedValues(),
             originalEvent
         });
     }

--- a/src/components/ebay-filter-menu/template.marko
+++ b/src/components/ebay-filter-menu/template.marko
@@ -12,14 +12,14 @@
     class=[(data.classPrefix ? "${baseClass}__menu": baseClass), data.class]
     style=data.style
     ${processHtmlAttributes(data)}>
-    <div class="${baseClass}__menu" body-only-if(data.classPrefix)>
+    <div w-id="content" class="${baseClass}__menu" body-only-if(data.classPrefix)>
         <form
             body-only-if(!isForm)
             name=data.formName
             action=data.formAction
             method=data.formMethod
             w-on-submit="handleFormSubmit">
-            <div class="${baseClass}__items" role=(!isForm && "menu")>
+            <div w-id="menu" class="${baseClass}__items" role=(!isForm && "menu")>
                 <for(item in data.items)>
                     <${isForm ? "label" : "div"}
                         class=["${baseClass}__item", item.class]


### PR DESCRIPTION
✅ @DylanPiercey approved

## Description
- used destructuring better
- removed a couple of dead code items
- used the `getEl` selectors
- improved overall readability

## Context
These changes are patterns we should follow for future components and will help maintenance and readability.

**Note:** we should consider improving the event forwarding between the filter button and the filter menu. Changing events in any significant way would be a breaking change and should probably wait.

## References
Related to the #849 PR