### PR TITLE
fixing pagination on small screens

### DIFF
--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -4,7 +4,7 @@ const template = require('./template.marko');
 
 const constants = {
     indexForNavigation: 2,
-    minPagesRequired: 5,
+    minPagesRequired: 3,
     maxPagesAllowed: 9,
     margin: 8
 };
@@ -88,6 +88,7 @@ function onUpdate() {
 
 function refresh() {
     let current = 0;
+    this.pageContainerEl.style.overflow = 'hidden';
     for (let i = 0; i < this.state.items.length; i++) {
         if (this.state.items[i].current) {
             current = i;
@@ -134,6 +135,7 @@ function refresh() {
             this.pageEls[i].removeAttribute('hidden');
         }
     }
+    this.pageContainerEl.style.overflow = 'visible';
 }
 
 /**


### PR DESCRIPTION
## Description
Reduced the "minimum page" limit.
Removed "overflow:hidden" after calculating the items that are visible.

## Context
The primary problem was that small screens couldn't show 5 items, which was set as a minimum.  I removed that restriction because I didn't see it anywhere in the design system patterns.

With that change it looked better, but the border on some items were cut off due to `overflow: hidden`.  I think might be due to the browser not accounting for padding and margin when applying the flex.

![Screen Shot 2019-09-09 at 3 52 32 PM](https://user-images.githubusercontent.com/1562843/64571800-db654100-d319-11e9-961e-8923193cb510.png)

The overflow control is needed in the Skin version, but in ebayUI we use JS to calculate the hidden items and hide them individually.  So I remove `overflow:hidden` after calculating the hidden elements.  I add it back in before recalculating so the page UI doesn't jump.

## References
Fixes: https://github.com/eBay/ebayui-core/issues/858

## Screenshots
![Screen Shot 2019-09-09 at 3 33 36 PM](https://user-images.githubusercontent.com/1562843/64571742-ace76600-d319-11e9-8abb-80b8a372acb4.png)

