### PR TITLE
Normalize to selected instead of pressed;

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -175,8 +175,8 @@
     "@disabled": "boolean",
     "@href": "string",
     "@priority": "string",
-    "@pressed": "boolean",
-    "@aria-selected-text": "string"
+    "@selected": "boolean",
+    "@a11y-selected-text": "string"
   },
   "<ebay-filter-menu>": {
     "renderer": "./src/components/ebay-filter-menu/index.js",
@@ -213,7 +213,7 @@
     "@class": "string",
     "@style": "string",
     "@disabled": "boolean",
-    "@pressed": "boolean",
+    "@selected": "boolean",
     "@form-name": "string",
     "@form-action": "string",
     "@form-method": "string",

--- a/src/components/ebay-filter/README.md
+++ b/src/components/ebay-filter/README.md
@@ -12,8 +12,8 @@ Name | Type | Stateful | Description
 --- | --- | --- | ---
 `href` | String | No | for link that looks like a button
 `disabled` | Boolean | No |
-`pressed` | Boolean | No |
-`a11y-active-text` | String | No | **Note:** only for fake filters; defaults to `"Selected"`, but should be changed based on L10N or I18N
+`selected` | Boolean | No |
+`a11y-selected-text` | String | No | **Note:** only for fake filters; defaults to `"Selected"`, but should be changed based on L10N or I18N
 
 ## ebay-filter Events
 

--- a/src/components/ebay-filter/index.js
+++ b/src/components/ebay-filter/index.js
@@ -5,7 +5,7 @@ module.exports = require('marko-widgets').defineComponent({
     template,
     getInitialState(input) {
         return assign({}, input, {
-            pressed: input.pressed || false
+            selected: input.selected || false
         });
     },
     onRender() {
@@ -16,7 +16,7 @@ module.exports = require('marko-widgets').defineComponent({
     },
     handleButtonClick(event) {
         if (!this.state.disabled) {
-            this.setState('pressed', !this.state.pressed);
+            this.setState('selected', !this.state.selected);
             this.emit('filter-click', event);
         }
     }

--- a/src/components/ebay-filter/template.marko
+++ b/src/components/ebay-filter/template.marko
@@ -9,19 +9,19 @@
     w-on-click="handleButtonClick"
     class=[
         classPrefix,
-        data.pressed ? classPrefix + "--selected" : classPrefix + "--unselected",
+        data.selected ? classPrefix + "--selected" : classPrefix + "--unselected",
         data.class
     ]
     style=data.style
     href=data.href
     disabled=data.disabled
     type=(!data.href && "button")
-    aria-pressed=(!data.href && data.pressed && "true")
+    aria-pressed=(!data.href && data.selected && "true")
     ${processHtmlAttributes(data)}>
     <span class="${classPrefix}__cell">
         <span w-body/>
-        <if(data.href && data.pressed)>
-            <span w-id="active-text" class="clipped"> - ${data.a11yActiveText || "Selected"}</span>
+        <if(data.href && data.selected)>
+            <span w-id="active-text" class="clipped"> - ${data.a11ySelectedText || "Selected"}</span>
         </if>
     </span>
 </>

--- a/src/components/ebay-filter/test/mock/index.js
+++ b/src/components/ebay-filter/test/mock/index.js
@@ -5,8 +5,8 @@ exports.Basic = {
     renderBody: createRenderBody('text')
 };
 
-exports.Pressed = assign({}, exports.Basic, {
-    pressed: true
+exports.Selected = assign({}, exports.Basic, {
+    selected: true
 });
 
 exports.Disabled = assign({}, exports.Basic, {
@@ -17,9 +17,9 @@ exports.Fake = assign({}, exports.Basic, {
     href: '#fake'
 });
 
-exports.Fake_Pressed = assign({}, exports.Fake, {
-    pressed: true,
-    a11yActiveText: 'Selected Filter'
+exports.Fake_Selected = assign({}, exports.Fake, {
+    selected: true,
+    a11ySelectedText: 'Selected Filter'
 });
 
 exports.Fake_Disabled = assign({}, exports.Fake, {

--- a/src/components/ebay-filter/test/test.browser.js
+++ b/src/components/ebay-filter/test/test.browser.js
@@ -15,7 +15,7 @@ describe('given filter is enabled', () => {
         component = await render(template, input);
     });
 
-    it('then it is not pressed', () => {
+    it('then it is not selected', () => {
         expect(component.getByRole('button')).does.not.have.attr('aria-pressed');
     });
 
@@ -28,7 +28,7 @@ describe('given filter is enabled', () => {
             expect(component.emitted('filter-click')).has.length(1);
         });
 
-        it('then it is pressed', () => {
+        it('then it is selected', () => {
             expect(component.getByRole('button')).has.attr('aria-pressed', 'true');
         });
 
@@ -37,7 +37,7 @@ describe('given filter is enabled', () => {
                 await fireEvent.click(component.getByRole('button'));
             });
 
-            it('then it is not pressed', () => {
+            it('then it is not selected', () => {
                 expect(component.getByRole('button')).does.not.have.attr('aria-pressed');
             });
         });

--- a/src/components/ebay-filter/test/test.server.js
+++ b/src/components/ebay-filter/test/test.server.js
@@ -17,7 +17,7 @@ describe('filter', () => {
     });
 
     it('renders with pressed attribute', async() => {
-        const input = mock.Pressed;
+        const input = mock.Selected;
         const { getByRole } = await render(template, input);
         expect(getByRole('button')).has.attr('aria-pressed', 'true');
     });
@@ -45,10 +45,10 @@ describe('filter', () => {
     });
 
     it('renders fake version with pressed attribute', async() => {
-        const input = mock.Fake_Pressed;
+        const input = mock.Fake_Selected;
         const { getByText } = await render(template, input);
         expect(getByText(input.renderBody.text).closest('a'))
-            .contains(getByText(input.a11yActiveText, { exact: false }));
+            .contains(getByText(input.a11ySelectedText, { exact: false }));
     });
 
     testPassThroughAttributes(template, {


### PR DESCRIPTION
## Description
- changes `pressed` to `selected`
- changes `a11y-active-text` to `a11y-selected-text`
- fixed an issue with `marko.json` where `aria-selected-text` was the attribute instead of `a11y-selected-text`

## Context
Because both `pressed` and `selected` were used in describing the active/selected/pressed state of the `<ebay-filter>`. Therefore, to help with developer experience, we updated the attribute and documentation to make things easier.

## References
Closes #859 
