### PR TITLE
Notice docs fix;

### DIFF
--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -30,5 +30,4 @@ Name | Type | Stateful | Description
 
 Event | Description
 --- | ---
-`notice-show` | the page notice was shown
 `notice-close` | the page notice was closed


### PR DESCRIPTION
## Description
- removes `notice-show` event from the docs as it is no longer implemented

## References
Fixes #867 