### PR TITLE
Updated carousel to use small icons for paddles

### DIFF
--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -27,7 +27,7 @@
             aria-describedby=statusId
             aria-label=data.a11yPreviousText
             aria-disabled=(data.prevControlDisabled && 'true')>
-            <ebay-icon type="inline" name="chevron-left"/>
+            <ebay-icon type="inline" name="chevron-left-small"/>
         </button>
 
         <ul w-id="list"
@@ -55,7 +55,7 @@
             aria-describedby=statusId
             aria-label=data.a11yNextText
             aria-disabled=(data.nextControlDisabled && 'true')>
-            <ebay-icon type="inline" name="chevron-right"/>
+            <ebay-icon type="inline" name="chevron-right-small"/>
         </button>
 
         <if(data.autoplayInterval && !data.bothControlsDisabled)>

--- a/src/components/ebay-icon/symbols/chevron-left-small/index.marko
+++ b/src/components/ebay-icon/symbols/chevron-left-small/index.marko
@@ -1,29 +1,5 @@
-<% if (typeof window !== 'undefined') console.error('ds4 icon not found: chevron-left-small') %>
-<symbol id="icon-chevron-left-small" viewBox="0 0 16 16">
-  <g fill="#111820" fill-rule="nonzero">
-    <g transform="translate(5.5 4.5)">
-      <circle cx="2.3" cy="6.1" r="1" />
-      <path
-        d="M1.8 4.7c0-.6 0-1.1.3-1.4.4-.4.9-.5 1.1-.6.3-.2.6-.5.6-.8 0-.3-.2-.8-1.3-.8-1 0-1.4.6-1.4 1.2H.3c0-1.3.8-2 2.2-2C4.6.4 4.7 1.7 4.7 2c0 .4-.2.8-.7 1.1-.5.4-.9.4-1.1.7-.2.2-.2.5-.2 1h-.9z"
-      />
-    </g>
-    <g transform="translate(1 1)">
-      <circle cx="7" cy=".7" r="1" />
-      <circle cx="10.2" cy=".7" r="1" />
-      <circle cx="13.3" cy=".7" r="1" />
-      <circle cx=".7" cy=".7" r="1" />
-      <circle cx="3.8" cy=".7" r="1" transform="rotate(90 3.8 .7)" />
-      <circle cx="7" cy="13.3" r="1" transform="rotate(180 7 13.3)" />
-      <circle cx="3.8" cy="13.3" r="1" transform="rotate(180 3.8 13.3)" />
-      <circle cx=".7" cy="13.3" r="1" transform="rotate(180 .7 13.3)" />
-      <circle cx="13.3" cy="13.3" r="1" transform="rotate(180 13.4 13.3)" />
-      <circle cx="10.2" cy="13.3" r="1" transform="rotate(-90 10.2 13.3)" />
-      <circle cx="13.3" cy="7" r="1" transform="rotate(90 13.3 7)" />
-      <circle cx="13.3" cy="10.2" r="1" transform="rotate(90 13.3 10.2)" />
-      <circle cx="13.3" cy="3.8" r="1" transform="rotate(180 13.3 3.8)" />
-      <circle cx=".7" cy="7" r="1" transform="rotate(-90 .7 7)" />
-      <circle cx=".7" cy="3.8" r="1" transform="rotate(-90 .7 3.8)" />
-      <circle cx=".7" cy="10.2" r="1" />
-    </g>
-  </g>
+<symbol id="icon-chevron-left-small" viewBox="0 0 14 24">
+  <path
+    d="M13.993 2.45L2.449 13.992 0 11.544 11.545 0l2.449 2.45h-.001zM2.449 9.096l11.545 11.545-2.449 2.45L0 11.546l2.449-2.45z"
+  ></path>
 </symbol>

--- a/src/components/ebay-icon/symbols/chevron-right-small/index.marko
+++ b/src/components/ebay-icon/symbols/chevron-right-small/index.marko
@@ -1,29 +1,5 @@
-<% if (typeof window !== 'undefined') console.error('ds4 icon not found: chevron-right-small') %>
-<symbol id="icon-chevron-right-small" viewBox="0 0 16 16">
-  <g fill="#111820" fill-rule="nonzero">
-    <g transform="translate(5.5 4.5)">
-      <circle cx="2.3" cy="6.1" r="1" />
-      <path
-        d="M1.8 4.7c0-.6 0-1.1.3-1.4.4-.4.9-.5 1.1-.6.3-.2.6-.5.6-.8 0-.3-.2-.8-1.3-.8-1 0-1.4.6-1.4 1.2H.3c0-1.3.8-2 2.2-2C4.6.4 4.7 1.7 4.7 2c0 .4-.2.8-.7 1.1-.5.4-.9.4-1.1.7-.2.2-.2.5-.2 1h-.9z"
-      />
-    </g>
-    <g transform="translate(1 1)">
-      <circle cx="7" cy=".7" r="1" />
-      <circle cx="10.2" cy=".7" r="1" />
-      <circle cx="13.3" cy=".7" r="1" />
-      <circle cx=".7" cy=".7" r="1" />
-      <circle cx="3.8" cy=".7" r="1" transform="rotate(90 3.8 .7)" />
-      <circle cx="7" cy="13.3" r="1" transform="rotate(180 7 13.3)" />
-      <circle cx="3.8" cy="13.3" r="1" transform="rotate(180 3.8 13.3)" />
-      <circle cx=".7" cy="13.3" r="1" transform="rotate(180 .7 13.3)" />
-      <circle cx="13.3" cy="13.3" r="1" transform="rotate(180 13.4 13.3)" />
-      <circle cx="10.2" cy="13.3" r="1" transform="rotate(-90 10.2 13.3)" />
-      <circle cx="13.3" cy="7" r="1" transform="rotate(90 13.3 7)" />
-      <circle cx="13.3" cy="10.2" r="1" transform="rotate(90 13.3 10.2)" />
-      <circle cx="13.3" cy="3.8" r="1" transform="rotate(180 13.3 3.8)" />
-      <circle cx=".7" cy="7" r="1" transform="rotate(-90 .7 7)" />
-      <circle cx=".7" cy="3.8" r="1" transform="rotate(-90 .7 3.8)" />
-      <circle cx=".7" cy="10.2" r="1" />
-    </g>
-  </g>
+<symbol id="icon-chevron-right-small" viewBox="0 0 14 23">
+  <path
+    d="M0 20.502L11.469 9.036l2.433 2.432L2.433 22.936 0 20.502zm11.469-6.601L0 2.433 2.433 0l11.469 11.469-2.433 2.433v-.001z"
+  ></path>
 </symbol>


### PR DESCRIPTION
## Description
With the carousel changes to DS6.5, we switched to using small icons for the paddles. This change provides that change, as well as support for DS4 to use small icons in paddles (and imported the SVG for small chevron icons which are the same as the normal chevron)

## References
ebay/skin#818
Skin PR: https://github.com/eBay/skin/pull/828 

## Screenshots
DS4
![image](https://user-images.githubusercontent.com/1755269/64992138-276b3500-d888-11e9-87f3-fa9ab6d3804a.png)

DS6
![image](https://user-images.githubusercontent.com/1755269/64992155-2df9ac80-d888-11e9-87e7-939c6ff7b1ee.png)
