### PR TITLE
Expand button: fix when expand btn has both small and no text modifiers

### DIFF
--- a/src/components/ebay-expand-button/index.marko
+++ b/src/components/ebay-expand-button/index.marko
@@ -24,7 +24,9 @@
     href=data.href
     type="button"
     disabled=data.disabled
-aria-disabled=(data.partiallyDisabled && "true")>
-    <span if(data.renderBody)><invoke data.renderBody(out) /></span>
-    <ebay-icon type="inline" name="chevron-down-bold" class="expand-btn__icon" no-skin-classes/>
-</>
+    aria-disabled=(data.partiallyDisabled && "true")>
+    <span class="${baseClass}__cell">
+        <span if(data.renderBody)><invoke data.renderBody(out) /></span>
+        <ebay-icon type="inline" name="chevron-down-bold" class="expand-btn__icon" no-skin-classes/>
+    </span>
+</button>


### PR DESCRIPTION
## Description
- adds `expand-btn__cell` span within the expand button
- small whitespace fix
- small closing tag improvement for readability

## References
Issue reported in Skin https://github.com/eBay/skin/issues/448, but additional fix is needed in core to make sure alignments work properly within the button cell.

## Screenshots

>Please ignore color changes in the screen shots as the color system has changed since this issue was created.

#### before

![image](https://user-images.githubusercontent.com/105656/47684896-2a8b0300-db9a-11e8-9fb5-2a2ed9e0fb33.png)

#### after

![image](https://user-images.githubusercontent.com/105656/65086747-3200f980-d970-11e9-9046-ed2ac921a5c3.png)