### PR TITLE
Carousel: Hide paddles if not enough items;

### DIFF
--- a/src/components/ebay-carousel/examples/12-items-per-slide-equal-total-items/template.marko
+++ b/src/components/ebay-carousel/examples/12-items-per-slide-equal-total-items/template.marko
@@ -1,0 +1,16 @@
+<style>
+    .demo11-card {
+        color: #cdf4fd;
+        background: #a1208b;
+        font-size: 24px;
+        font-weight: bold;
+        height: 150px;
+        line-height: 150px;
+        text-align: center;
+    }
+</style>
+<ebay-carousel items-per-slide="3">
+    <ebay-carousel-item class="demo11-card">Card 1</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 2</ebay-carousel-item>
+    <ebay-carousel-item class="demo11-card">Card 3</ebay-carousel-item>
+</ebay-carousel>

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -115,6 +115,7 @@ function getTemplateData(state) {
         slide,
         offset: hasOverride ? config.offsetOverride : offset,
         disableTransition: hasOverride,
+        showPaddles: itemsPerSlide ? items.length > itemsPerSlide : true,
         totalSlides,
         a11yStatusText,
         prevControlDisabled,

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -20,6 +20,7 @@
             </>
         </if>
         <button
+            if(data.showPaddles)
             class="carousel__control carousel__control--prev"
             type="button"
             w-onclick=(!data.prevControlDisabled && "handleMove")
@@ -47,6 +48,7 @@
         </ul>
 
         <button
+            if(data.showPaddles)
             w-id="next"
             class="carousel__control carousel__control--next"
             type="button"

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -238,8 +238,8 @@ describe('given a discrete carousel', () => {
         });
 
         it('then prev and next controls are disabled', () => {
-            expect(component.getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
-            expect(component.getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
+            expect(component.queryByLabelText(input.a11yPreviousText)).to.equal(null);
+            expect(component.queryByLabelText(input.a11yNextText)).to.equal(null);
         });
     });
 
@@ -251,8 +251,8 @@ describe('given a discrete carousel', () => {
         });
 
         it('then prev and next controls are disabled', () => {
-            expect(component.getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
-            expect(component.getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
+            expect(component.queryByLabelText(input.a11yPreviousText)).to.equal(null);
+            expect(component.queryByLabelText(input.a11yNextText)).to.equal(null);
         });
 
         it('then has the appropriate heading', () => {

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -33,6 +33,15 @@ describe('carousel', () => {
             expect(getAllByLabelText(/go to slide/)).has.length(2);
         });
 
+        it('renders without paddles', async() => {
+            const input = assign({}, mock.Discrete_1PerSlide_3Items, { itemsPerSlide: '3' });
+            const { queryByLabelText } = await render(template, input);
+
+            expect(queryByLabelText(input.a11yPreviousText)).to.equal(null);
+            expect(queryByLabelText(input.a11yNextText)).to.equal(null);
+            expect(queryByLabelText(/go to slide/)).to.equal(null);
+        });
+
         it('renders no-dots enabled', async() => {
             const input = assign({}, mock.Discrete_1PerSlide_3Items, { noDots: true });
             const { queryByLabelText } = await render(template, input);
@@ -44,10 +53,10 @@ describe('carousel', () => {
 
         it('renders without any provided items', async() => {
             const input = mock.Discrete_1PerSlide_0Items;
-            const { getByLabelText, queryByLabelText } = await render(template, input);
+            const { queryByLabelText } = await render(template, input);
 
-            expect(getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
-            expect(getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
+            expect(queryByLabelText(input.a11yPreviousText)).to.equal(null);
+            expect(queryByLabelText(input.a11yNextText)).to.equal(null);
             expect(queryByLabelText(/go to slide/)).to.equal(null);
         });
 


### PR DESCRIPTION
## Description
- makes paddles viewable only if using the `items-per-slide` and the number of items is larger than the items per slide

## References
Fixes #875 