### PR TITLE
Tabs: manual fix

### DIFF
--- a/src/common/event-utils/index.js
+++ b/src/common/event-utils/index.js
@@ -41,6 +41,10 @@ function handleLeftRightArrowsKeydown(e, callback) {
     handleKeydown([37, 39], e, callback);
 }
 
+function handleArrowsKeydown(e, callback) {
+    handleKeydown([37, 38, 39, 40], e, callback);
+}
+
 // only fire for character input, not modifier/meta keys (enter, escape, backspace, tab, etc.)
 function handleTextInput(e, callback) {
     const keys = [
@@ -95,6 +99,7 @@ module.exports = {
     handleEscapeKeydown,
     handleUpDownArrowsKeydown,
     handleLeftRightArrowsKeydown,
+    handleArrowsKeydown,
     handleTextInput,
     preventDefaultIfHijax,
     resizeUtil: {

--- a/src/components/ebay-tab/index.js
+++ b/src/components/ebay-tab/index.js
@@ -36,18 +36,15 @@ module.exports = require('marko-widgets').defineComponent({
     handleHeadingKeydown(event, el) {
         eventUtils.handleActionKeydown(event, () => {
             event.preventDefault();
-
-            if (this.state.activation === 'manual') {
-                this.setIndex(el.dataset.index);
-            }
+            this.setIndex(el.dataset.index);
         });
 
-        eventUtils.handleLeftRightArrowsKeydown(event, () => {
+        eventUtils.handleArrowsKeydown(event, () => {
             event.preventDefault();
 
             const len = this.state.headings.length;
             const keyCode = event.charCode || event.keyCode;
-            const direction = keyCode === 37 ? -1 : 1;
+            const direction = keyCode === 37 || keyCode === 38 ? -1 : 1;
             const index = (this.state.index + len + direction) % len;
             this.getEl(`tab-${index}`).focus();
 


### PR DESCRIPTION
## Description
- add a `handleArrowsKeydown` to event utils file
- fix the `direction` variable
- remove the `handleActionKeydown` guard for `manual` as it actually doesn't matter in the `auto` case

## Context
Issues found during testing the recent fix for the manual tabs.

## References
Found during #887 (#888) testing.