### PR TITLE
Add information about fake tabs and preventDefault;

### DIFF
--- a/src/components/ebay-tab/README.md
+++ b/src/components/ebay-tab/README.md
@@ -21,6 +21,8 @@ Name | Type | Stateful | Description
 `fake` | Boolean | No | Whether to use link behavior for tab headings
 `activation` | String | Yes | whether to use automatic or manual activation when navigating by keyboard, "auto" (default) / "manual"
 
+> *Note:* When using fake tabs there is no `preventDefault` applied, and therefore the link in the tab heading will work as a normal and navigate to the URL provided in the `href`.
+
 ## ebay-tab Events
 
 Event | Data | Description


### PR DESCRIPTION
## Description
- simple documentation addition explaining that `preventDefault` is not used on fake tabs

## Context
To help developers realize when their fake tab doesn't change.

## References
Fixes #402