### PR TITLE
Add a guard for combobox blur/change event;

### DIFF
--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -149,6 +149,7 @@ module.exports = require('marko-widgets').defineComponent({
 
         if (this.valueChanged) {
             this.emitComboboxEvent('change');
+            this.valueChanged = false;
         }
     },
     handleOptionMouseDown() {

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -110,7 +110,7 @@ module.exports = require('marko-widgets').defineComponent({
                 this.setState('currentValue', newValue);
                 this.setSelectedIndex();
                 if (selectedEl) {
-                    this.emitChangeEvent('select');
+                    this.emitComboboxEvent('select');
                 }
                 this.expander.collapse();
             }
@@ -124,11 +124,13 @@ module.exports = require('marko-widgets').defineComponent({
         const newValue = this.getEl('input').value;
 
         eventUtils.handleTextInput(originalEvent, () => {
+            this.valueChanged = this.getEl('input').value !== newValue;
+
             this.activeDescendant.reset();
             this.getEl('input').value = newValue;
             this.setState('currentValue', newValue);
             this.setSelectedIndex();
-            this.emitChangeEvent();
+            this.emitComboboxEvent();
             if (this.expander) {
                 this.toggleListbox();
             }
@@ -145,7 +147,9 @@ module.exports = require('marko-widgets').defineComponent({
             this.expander.collapse();
         }
 
-        this.emitChangeEvent('change');
+        if (this.valueChanged) {
+            this.emitComboboxEvent('change');
+        }
     },
     handleOptionMouseDown() {
         this.optionClicked = true;
@@ -155,10 +159,12 @@ module.exports = require('marko-widgets').defineComponent({
         const selectedValue = selectedEl.textContent;
 
         this.optionClicked = false;
+        this.valueChanged = this.getEl('input').value !== selectedValue;
+
         this.getEl('input').value = selectedValue;
         this.setState('currentValue', selectedValue);
         this.setSelectedIndex();
-        this.emitChangeEvent('select');
+        this.emitComboboxEvent('select');
         this.expander.collapse();
     },
     setSelectedIndex(index = 0) {
@@ -169,7 +175,7 @@ module.exports = require('marko-widgets').defineComponent({
     getSelectedIndex(options, value) {
         return findIndex(options, option => option.text === value);
     },
-    emitChangeEvent(eventName = 'input') {
+    emitComboboxEvent(eventName = 'input') {
         this.emit(`combobox-${eventName}`, {
             currentInputValue: this.state.currentValue,
             selectedOption: this.state.options[this.state.selectedIndex],


### PR DESCRIPTION
## Description
- adds an `valueChanged` property to check when the value of the input changed
- guards the `change` event so that when it blurs we know that the option had changed
- minor method name change for better clarity

## Context
Presently, the `blur` of the combobox input field fires a `combobox-change` every time, without any concern for whether the input changed from the original value. This change will only fire the `combobox-change` event when the value is different from what was there before, whether typing or whether selecting from the menu.

Also, the generic method for emitting events for the combobox was updated for better clarity.

## References
Fixes #740 