### PR TITLE
Icon: copied overflow ds6 icon to overflow ds4 icon

### DIFF
--- a/src/components/ebay-icon/symbols/overflow-small/index.marko
+++ b/src/components/ebay-icon/symbols/overflow-small/index.marko
@@ -1,29 +1,6 @@
-<% if (typeof window !== 'undefined') console.error('ds4 icon not found: overflow-small') %>
-<symbol id="icon-overflow-small" viewBox="0 0 16 16">
-  <g fill="#111820" fill-rule="nonzero">
-    <g transform="translate(5.5 4.5)">
-      <circle cx="2.3" cy="6.1" r="1" />
-      <path
-        d="M1.8 4.7c0-.6 0-1.1.3-1.4.4-.4.9-.5 1.1-.6.3-.2.6-.5.6-.8 0-.3-.2-.8-1.3-.8-1 0-1.4.6-1.4 1.2H.3c0-1.3.8-2 2.2-2C4.6.4 4.7 1.7 4.7 2c0 .4-.2.8-.7 1.1-.5.4-.9.4-1.1.7-.2.2-.2.5-.2 1h-.9z"
-      />
-    </g>
-    <g transform="translate(1 1)">
-      <circle cx="7" cy=".7" r="1" />
-      <circle cx="10.2" cy=".7" r="1" />
-      <circle cx="13.3" cy=".7" r="1" />
-      <circle cx=".7" cy=".7" r="1" />
-      <circle cx="3.8" cy=".7" r="1" transform="rotate(90 3.8 .7)" />
-      <circle cx="7" cy="13.3" r="1" transform="rotate(180 7 13.3)" />
-      <circle cx="3.8" cy="13.3" r="1" transform="rotate(180 3.8 13.3)" />
-      <circle cx=".7" cy="13.3" r="1" transform="rotate(180 .7 13.3)" />
-      <circle cx="13.3" cy="13.3" r="1" transform="rotate(180 13.4 13.3)" />
-      <circle cx="10.2" cy="13.3" r="1" transform="rotate(-90 10.2 13.3)" />
-      <circle cx="13.3" cy="7" r="1" transform="rotate(90 13.3 7)" />
-      <circle cx="13.3" cy="10.2" r="1" transform="rotate(90 13.3 10.2)" />
-      <circle cx="13.3" cy="3.8" r="1" transform="rotate(180 13.3 3.8)" />
-      <circle cx=".7" cy="7" r="1" transform="rotate(-90 .7 7)" />
-      <circle cx=".7" cy="3.8" r="1" transform="rotate(-90 .7 3.8)" />
-      <circle cx=".7" cy="10.2" r="1" />
-    </g>
-  </g>
+<symbol id="icon-overflow-small" viewBox="0 0 3 13">
+  <path
+    fill-rule="evenodd"
+    d="M1.5 10a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3zm0-5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3zm0-5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+  ></path>
 </symbol>

--- a/src/components/ebay-icon/symbols/overflow/index.marko
+++ b/src/components/ebay-icon/symbols/overflow/index.marko
@@ -1,29 +1,6 @@
-<% if (typeof window !== 'undefined') console.error('ds4 icon not found: overflow') %>
-<symbol id="icon-overflow" viewBox="0 0 16 16">
-  <g fill="#111820" fill-rule="nonzero">
-    <g transform="translate(5.5 4.5)">
-      <circle cx="2.3" cy="6.1" r="1" />
-      <path
-        d="M1.8 4.7c0-.6 0-1.1.3-1.4.4-.4.9-.5 1.1-.6.3-.2.6-.5.6-.8 0-.3-.2-.8-1.3-.8-1 0-1.4.6-1.4 1.2H.3c0-1.3.8-2 2.2-2C4.6.4 4.7 1.7 4.7 2c0 .4-.2.8-.7 1.1-.5.4-.9.4-1.1.7-.2.2-.2.5-.2 1h-.9z"
-      />
-    </g>
-    <g transform="translate(1 1)">
-      <circle cx="7" cy=".7" r="1" />
-      <circle cx="10.2" cy=".7" r="1" />
-      <circle cx="13.3" cy=".7" r="1" />
-      <circle cx=".7" cy=".7" r="1" />
-      <circle cx="3.8" cy=".7" r="1" transform="rotate(90 3.8 .7)" />
-      <circle cx="7" cy="13.3" r="1" transform="rotate(180 7 13.3)" />
-      <circle cx="3.8" cy="13.3" r="1" transform="rotate(180 3.8 13.3)" />
-      <circle cx=".7" cy="13.3" r="1" transform="rotate(180 .7 13.3)" />
-      <circle cx="13.3" cy="13.3" r="1" transform="rotate(180 13.4 13.3)" />
-      <circle cx="10.2" cy="13.3" r="1" transform="rotate(-90 10.2 13.3)" />
-      <circle cx="13.3" cy="7" r="1" transform="rotate(90 13.3 7)" />
-      <circle cx="13.3" cy="10.2" r="1" transform="rotate(90 13.3 10.2)" />
-      <circle cx="13.3" cy="3.8" r="1" transform="rotate(180 13.3 3.8)" />
-      <circle cx=".7" cy="7" r="1" transform="rotate(-90 .7 7)" />
-      <circle cx=".7" cy="3.8" r="1" transform="rotate(-90 .7 3.8)" />
-      <circle cx=".7" cy="10.2" r="1" />
-    </g>
-  </g>
+<symbol id="icon-overflow" viewBox="0 0 4 18">
+  <path
+    fill-rule="evenodd"
+    d="M2 4A2 2 0 1 0 2.001.001 2 2 0 0 0 2 4zm0 7a2 2 0 1 0 .001-3.999A2 2 0 0 0 2 11zm2 5a2 2 0 1 1-3.999.001A2 2 0 0 1 4 16z"
+  ></path>
 </symbol>


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
* copied `overflow` and `overflow-small` from DS6 to DS4

## Context
* `ebay-icon` doesn't work for `overflow` and `overflow-small` in DS4
* `overflow` is required for overflow variant in `ebay-menu-button` and `ebay-notice`
* this fix should go into 4.3.0 release

## References
https://github.com/eBay/ebayui-core/issues/904 Icon: ds4 overflow icon doesn't exist
https://github.com/eBay/ebayui-core/issues/912 menu-variant=overflow: icon not present in ds4

## Screenshots
<img width="1216" alt="overflow_fixed" src="https://user-images.githubusercontent.com/844822/66351251-13a87100-e912-11e9-8795-c3a7ff318171.png">

