### PR TITLE
Menu Button: Add scroll management attribute;

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -253,6 +253,7 @@
         "@priority": "string",
         "@iconTag <icon>": {},
         "@disabled": "boolean",
+        "@scroll-management": "string",
         "@items <item>[]": {
             "@*": "expression",
             "@html-attributes": "expression",

--- a/src/components/ebay-menu-button/README.md
+++ b/src/components/ebay-menu-button/README.md
@@ -31,6 +31,7 @@ Name | Type | Stateful | Description
 `priority` | String | No | button priority, "primary" / "secondary" (default) / "none"
 `checked` (radio) | Number | Yes | will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup
 `disabled` | Boolean | Yes | Will disable the entire dropdown (disables the ebay-button label) if set to true
+`scroll-management` | String | Yes | "checked" (default) / "none"
 
 ### ebay-menu-button Events
 

--- a/src/components/ebay-menu-button/examples/19-disable-scroll-management/template.marko
+++ b/src/components/ebay-menu-button/examples/19-disable-scroll-management/template.marko
@@ -1,0 +1,17 @@
+<ebay-menu-button text="eBay Menu" type="radio" scroll-management="none">
+    <ebay-menu-button-item>item 1</ebay-menu-button-item>
+    <ebay-menu-button-item>item 2</ebay-menu-button-item>
+    <ebay-menu-button-item>item 3</ebay-menu-button-item>
+    <ebay-menu-button-item>item 4</ebay-menu-button-item>
+    <ebay-menu-button-item>item 5</ebay-menu-button-item>
+    <ebay-menu-button-item>item 6</ebay-menu-button-item>
+    <ebay-menu-button-item>item 7</ebay-menu-button-item>
+    <ebay-menu-button-item>item 8</ebay-menu-button-item>
+    <ebay-menu-button-item>item 9</ebay-menu-button-item>
+    <ebay-menu-button-item>item 10</ebay-menu-button-item>
+    <ebay-menu-button-item>item 11</ebay-menu-button-item>
+    <ebay-menu-button-item>item 12</ebay-menu-button-item>
+    <ebay-menu-button-item>item 13</ebay-menu-button-item>
+    <ebay-menu-button-item>item 14</ebay-menu-button-item>
+    <ebay-menu-button-item checked>item 15</ebay-menu-button-item>
+</ebay-menu-button>

--- a/src/components/ebay-menu-button/index.js
+++ b/src/components/ebay-menu-button/index.js
@@ -97,7 +97,8 @@ function getInitialState(input) {
         items,
         checked: checkedItems,
         customLabel: input.label,
-        disabled: input.disabled || false
+        disabled: input.disabled || false,
+        scrollManagement: input.scrollManagement || 'checked'
     };
 }
 
@@ -147,7 +148,8 @@ function getTemplateData(state) {
         role: !state.isFake ? 'menu' : null,
         items: state.items,
         customLabel: state.customLabel,
-        disabled: state.disabled
+        disabled: state.disabled,
+        scrollManagement: state.scrollManagement
     };
 }
 
@@ -299,7 +301,9 @@ function handleButtonEscape() {
 }
 
 function handleExpand() {
-    elementScroll.scroll(this.el.querySelector(checkedItemSelector));
+    if (this.state.scrollManagement === 'checked') {
+        elementScroll.scroll(this.el.querySelector(checkedItemSelector));
+    }
     this.setState('expanded', true);
     emitAndFire(this, 'menu-expand');
     scrollKeyPreventer.add(this.contentEl);


### PR DESCRIPTION
## Description
- adds a `scroll-management` attribute to allow for limiting scroll behavior

## Context
When working with certain use cases the scroll behavior for radio or checkbox should be disabled. Specifically, when the label is changed by the developer they may also decide to limit the scroll behavior to surface the most relevant choices at the very top, even if the user has chosen something else.

**Note:** I made a mistaken push to 9.2.0 😞 and we can't force push changes there. Therefore, we'll have to live with two commits, unless you folks are really dead set on a clean history. (E.g. `focus-first` was the original attempt at a fix, but I went a different direction.)

## References
Fixes #906 