### PR TITLE
Carousel: Add a11y heading text as needed;

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -68,6 +68,8 @@
     "@a11y-next-text": "string",
     "@a11y-status-text": "string",
     "@a11y-status-tag": "string",
+    "@a11y-heading-text": "string",
+    "@a11y-heading-tag": "string",
     "@a11y-current-text": "string",
     "@a11y-other-text": "string",
     "@a11y-play-text": "string",

--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -16,6 +16,8 @@ This component will bundle different resources depending on Lasso flags provided
 
 Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
+`a11y-heading-text` | String | No | No | a11y heading text used to describe the carousel (continuous only)
+`a11y-heading-tag` | String | No | No | use h1-h6 when there isn't a visible heading before the carousel (continuous only) (default: "h2")
 `a11y-previous-text` | String | No | Yes | a11y text for previous control (default: "Previous Slide")
 `a11y-next-text` | String | No | Yes | a11y text for next control (default: "Next Slide")
 `index` | String | Yes | No | 0-based index position

--- a/src/components/ebay-carousel/examples/13-a11y-text-continuous/template.marko
+++ b/src/components/ebay-carousel/examples/13-a11y-text-continuous/template.marko
@@ -1,0 +1,24 @@
+<style>
+    .demo1-card {
+        color: #0a1c6b;
+        background: #c2f5ff;
+        font-size: 24px;
+        font-weight: bold;
+        width: 200px;
+        height: 120px;
+        line-height: 120px;
+        text-align: center;
+    }
+</style>
+<ebay-carousel
+    a11y-heading-text="Top Products"
+    a11y-heading-tag="h2"
+    a11y-previous-text="Go to previous slide - Top Products"
+    a11y-next-text="Go to next slide - Top Products">
+    <ebay-carousel-item class="demo1-card">Card 1</ebay-carousel-item>
+    <ebay-carousel-item class="demo1-card">Card 2</ebay-carousel-item>
+    <ebay-carousel-item class="demo1-card">Card 3</ebay-carousel-item>
+    <ebay-carousel-item class="demo1-card">Card 4</ebay-carousel-item>
+    <ebay-carousel-item class="demo1-card">Card 5</ebay-carousel-item>
+    <ebay-carousel-item class="demo1-card">Card 6</ebay-carousel-item>
+</ebay-carousel>

--- a/src/components/ebay-carousel/index.js
+++ b/src/components/ebay-carousel/index.js
@@ -25,6 +25,8 @@ function getInitialState(input) {
         a11yNextText: input.a11yNextText || 'Next Slide',
         a11yStatusText: input.a11yStatusText || 'Showing Slide {currentSlide} of {totalSlides} - Carousel',
         a11yStatusTag: input.a11yStatusTag || 'span',
+        a11yHeadingText: input.a11yHeadingText,
+        a11yHeadingTag: input.a11yHeadingTag || 'h2',
         a11yCurrentText: input.a11yCurrentText || 'Current Slide {currentSlide} - Carousel',
         a11yOtherText: input.a11yOtherText || 'Slide {slide} - Carousel',
         a11yPauseText: input.a11yPauseText || 'Pause - Carousel',

--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -1,6 +1,7 @@
 <div class=data.classes style=data.style w-bind ${data.htmlAttributes}>
     <var config=data.config/>
-    <var statusId=null/>
+    <var discrete=(data.totalSlides >= 1)/>
+    <var statusId=(discrete && "carousel-status-" + widget.id)/>
     <div
         w-id="container"
         class=["carousel__container", data.bothControlsDisabled && "carousel__container--controls-disabled"]
@@ -10,15 +11,18 @@
         w-onfocusout=(data.autoplayInterval && "handleEndInteraction")
         w-onmouseout=(data.autoplayInterval && "handleEndInteraction")
         w-ontouchend=(data.autoplayInterval && "handleEndInteraction")>
-        <if(data.totalSlides >= 1)>
-            <assign statusId=("carousel-status-" + widget.id)/>
-            <${data.a11yStatusTag}
-                id=statusId
-                class="clipped"
-                aria-live=(data.autoplayInterval && !data.paused ? "off" : "polite")>
+        <${discrete ? data.a11yStatusTag : data.a11yHeadingTag}
+            id=statusId
+            class="clipped"
+            aria-live=(discrete ? (data.autoplayInterval && !data.paused ? "off" : "polite") : false)
+            if(data.a11yStatusText || data.a11yHeadingText)>
+            <if(discrete)>
                 <span>${data.a11yStatusText}</span>
-            </>
-        </if>
+            </if>
+            <else>
+                <span>${data.a11yHeadingText}</span>
+            </else>
+        </>
         <button
             if(data.showPaddles)
             class="carousel__control carousel__control--prev"


### PR DESCRIPTION
## Description
- add a new <strike>`a11yHeadingText`</strike> `a11yTitleText` attribute
- modify carousel `a11yStatusText` to include <strike>heading</strike> title
- new logic block for heading as `a11yStatusText` when `itemsPerSlide` is not provided

## References
Fixes #764 