### PR TITLE
Add special handling for aria-invalid;

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -291,6 +291,7 @@
     "@grow": "boolean",
     "@borderless": "boolean",
     "@disabled": "boolean",
+    "@aria-invalid": "string",
     "@options <option>[]": {
       "@*": "expression",
       "@html-attributes": "expression",

--- a/marko.json
+++ b/marko.json
@@ -291,7 +291,7 @@
     "@grow": "boolean",
     "@borderless": "boolean",
     "@disabled": "boolean",
-    "@aria-invalid": "string",
+    "@invalid": "boolean",
     "@options <option>[]": {
       "@*": "expression",
       "@html-attributes": "expression",

--- a/src/components/ebay-listbox-button/examples/07-aria-invalid/template.marko
+++ b/src/components/ebay-listbox-button/examples/07-aria-invalid/template.marko
@@ -1,0 +1,5 @@
+<ebay-listbox-button name="formFieldName" aria-invalid="true">
+    <ebay-listbox-button-option value="1" text="Option 1"/>
+    <ebay-listbox-button-option value="2" text="Option 2"/>
+    <ebay-listbox-button-option value="3" text="Option 3"/>
+</ebay-listbox-button>

--- a/src/components/ebay-listbox-button/examples/07-aria-invalid/template.marko
+++ b/src/components/ebay-listbox-button/examples/07-aria-invalid/template.marko
@@ -1,4 +1,4 @@
-<ebay-listbox-button name="formFieldName" aria-invalid="true">
+<ebay-listbox-button name="formFieldName" invalid>
     <ebay-listbox-button-option value="1" text="Option 1"/>
     <ebay-listbox-button-option value="2" text="Option 2"/>
     <ebay-listbox-button-option value="3" text="Option 3"/>

--- a/src/components/ebay-listbox-button/template.marko
+++ b/src/components/ebay-listbox-button/template.marko
@@ -26,6 +26,7 @@
         type="button"
         disabled=data.disabled
         aria-haspopup="listbox"
+        aria-invalid=data.ariaInvalid
         w-preserve-attrs="aria-expanded,aria-controls">
         <span class="expand-btn__cell">
             <span>${selectedText}</span>

--- a/src/components/ebay-listbox-button/template.marko
+++ b/src/components/ebay-listbox-button/template.marko
@@ -26,7 +26,7 @@
         type="button"
         disabled=data.disabled
         aria-haspopup="listbox"
-        aria-invalid=data.ariaInvalid
+        aria-invalid=(data.invalid && 'true')
         w-preserve-attrs="aria-expanded,aria-controls">
         <span class="expand-btn__cell">
             <span>${selectedText}</span>


### PR DESCRIPTION
## Description
- adds `aria-invalid` capability to the button

## References
Companion PR to https://github.com/eBay/skin/pull/884, as part of the fix for https://github.com/eBay/skin/issues/741

## Screenshots
![image](https://user-images.githubusercontent.com/105656/66858914-7f5c9080-ef47-11e9-84cd-bca6a687b927.png)

