### PR TITLE
Added notice transform to support marko v3

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -377,6 +377,7 @@
   },
   "<ebay-notice>": {
     "renderer": "./src/components/ebay-notice/index.js",
+    "transformer": "./src/components/ebay-notice/transformer.js",
     "@*": "expression",
     "@html-attributes": "expression",
     "@class": "string",
@@ -388,6 +389,9 @@
     "@a11y-heading-tag": "string",
     "@a11y-close-text": "string",
     "@dismissible": "boolean",
+    "@_default <_default>": {
+      "@*": "expression"
+    },
     "@content <content>": {
       "@*": "expression",
       "@html-attributes": "expression",

--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -9,6 +9,7 @@
 <var isLightGuidance=(isSection && !data.status)/>
 <var content=(data.content)/>
 <var cta=(data.cta)/>
+<var defRender=(data._default && data._default.renderBody) />
 <var contentTag=(isPage ? "div" : "span")/>
 
 <if(!data.hidden)>
@@ -36,10 +37,10 @@
                 class=[content.class, "${type}-notice__content"]
                 style=content.style
                 w-body=data.content.renderBody/>
-            <div body-only-if(true) w-body/>
+            <div body-only-if(true) w-body=defRender />
         </if>
         <else>
-            <${contentTag} class="${type}-notice__content" w-body/>
+            <${contentTag} class="${type}-notice__content" w-body=defRender />
         </else>
         <if(data.dismissible)>
             <button

--- a/src/components/ebay-notice/test/mock/index.js
+++ b/src/components/ebay-notice/test/mock/index.js
@@ -3,7 +3,7 @@ const { createRenderBody } = require('../../../../common/test-utils/shared');
 
 exports.Page = {
     a11yHeadingText: 'Heading Text',
-    renderBody: createRenderBody('Content')
+    _default: { renderBody: createRenderBody('Content') }
 };
 
 exports.Page_Custom_Heading_Tag = assign({}, exports.Page, {
@@ -40,16 +40,16 @@ exports.Section_Info = {
     a11yHeadingText: 'Heading Text',
     type: 'section',
     status: 'information',
-    renderBody: createRenderBody('Content')
+    _default: { renderBody: createRenderBody('Content') }
 };
 
 exports.Section_Light = {
     type: 'section',
-    renderBody: createRenderBody('Content')
+    _default: { renderBody: createRenderBody('Content') }
 };
 
 exports.Cta_Button = {
-    renderBody: createRenderBody('<button>Action</button>'),
+    _default: { renderBody: createRenderBody('<button>Action</button>') },
     content: {
         renderBody: createRenderBody('Body')
     }

--- a/src/components/ebay-notice/transformer.js
+++ b/src/components/ebay-notice/transformer.js
@@ -1,0 +1,24 @@
+/**
+ * Transform ebay* components' child tags for use as nested tags
+ * Example: <ebaycomboboxoption> to <ebaycombobox:option>
+ * Note: Used exclusively by Marko as a transform for the nested tags
+ * See: /src/components/ebaycombobox/marko.json
+ * @param {Object} el
+ * @param {Object} context
+ */
+function transform(el, context) {
+    const defaultRenderBody = context.createNodeForEl('ebay-notice:_default');
+
+    el.forEachChild(child => {
+        if (child.tagName === 'ebay-notice-content') {
+            return;
+        }
+
+        child.detach();
+        defaultRenderBody.appendChild(child);
+    });
+
+    el.prependChild(defaultRenderBody);
+}
+
+module.exports = transform;


### PR DESCRIPTION
## Description
There is a bug where the body of an `<ebay-notice>` tag gets rendered before the tag, causing the text to be outside of the tag.
In markoV3, if there is a sub component, then render body gets called beforehand (since it assumes to be rendered in a subcomponent). In order to get by that, I added a transformer to take the renderBody content and put it in a subcomponent called _default. Then, that is used as the body render.

## Context
I created a custom transformer with @DylanPiercey help. I only add the items that are not in the `<ebay-notice-content>` in order to transform it.
I also tested it in the page that it was failing and it is working properly.