### PR TITLE
fix: added processHtmlAttributes to ebay menu button item

### DIFF
--- a/src/components/ebay-menu-button/template.marko
+++ b/src/components/ebay-menu-button/template.marko
@@ -68,7 +68,8 @@
                 current=item.current
                 value=item.value
                 badge-number=item.badgeNumber
-                badge-aria-label=item.badgeAriaLabel>
+                badge-aria-label=item.badgeAriaLabel
+                ${processHtmlAttributes(item)}>
                 <span body-only-if(true) w-body=item.renderBody/>
             </ebay-menu-item>
         </for>


### PR DESCRIPTION
## Description
Issue [928](https://github.com/eBay/ebayui-core/issues/928) `ebay-menu-button-item` is not honoring the custom attributes passed to it.

## Context
`ebay-menu-button` component menu item `ebay-menu-button-item` is not considering the custom attributes passed to it. Need to add processHtmlAttributes to menu item.

## References
https://github.com/eBay/ebayui-core/issues/928

