### PR TITLE
Listbox Button: Adding name attribute to the button

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -295,6 +295,7 @@
     "@disabled": "boolean",
     "@fluid": "boolean",
     "@invalid": "boolean",
+    "@button-name": "string",
     "@options <option>[]": {
       "@*": "expression",
       "@html-attributes": "expression",

--- a/src/components/ebay-listbox-button/README.md
+++ b/src/components/ebay-listbox-button/README.md
@@ -34,6 +34,7 @@ Name | Type | Stateful | Required | Description
 `selected` | Number | Yes | n/a | allows you to set the selected index option to `selected`
 `borderless` | Boolean | No | No | whether button has borders
 `fluid` | Boolean | No | No | whether listbox width is 100%
+`buttonName` | String | No | Yes | used for the `name` attribute of the native `<button>`
 
 **Note:** For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 

--- a/src/components/ebay-listbox-button/template.marko
+++ b/src/components/ebay-listbox-button/template.marko
@@ -25,6 +25,7 @@
         value=selectedText
         type="button"
         disabled=data.disabled
+        name=data.buttonName
         aria-haspopup="listbox"
         aria-invalid=(data.invalid && 'true')
         w-preserve-attrs="aria-expanded,aria-controls">

--- a/src/components/ebay-listbox-button/test/mock/index.js
+++ b/src/components/ebay-listbox-button/test/mock/index.js
@@ -2,6 +2,7 @@ const { getNItems } = require('../../../../common/test-utils/shared');
 
 exports.Basic_0Options = {
     name: 'listbox-name',
+    buttonName: 'listbox-button-name',
     options: []
 };
 
@@ -16,6 +17,7 @@ exports.Basic_3Options_fluid = {
 
 exports.Basic_3Options = {
     name: 'listbox-name',
+    buttonName: 'listbox-button-name',
     options: getNItems(3, i => ({
         value: String(i),
         text: `option ${i}`

--- a/src/components/ebay-listbox-button/test/test.browser.js
+++ b/src/components/ebay-listbox-button/test/test.browser.js
@@ -26,6 +26,10 @@ describe('given the listbox with 3 items', () => {
         expect(component.getByRole('button')).has.attr('aria-expanded', 'false');
     });
 
+    it('then it should have button with name attribute', () => {
+        expect(component.getByRole('button')).has.attr('name', 'listbox-button-name');
+    });
+
     it('then the native select should be initialized to the first option value', () => {
         expect(form.elements)
             .has.property(input.name)

--- a/src/components/ebay-listbox-button/test/test.server.js
+++ b/src/components/ebay-listbox-button/test/test.server.js
@@ -16,6 +16,7 @@ describe('listbox', () => {
         const visibleOptionEls = getAllByRole('option').filter(isVisible);
 
         expect(btnEl).has.attr('aria-haspopup', 'listbox');
+        expect(btnEl).has.attr('name', input.buttonName);
         expect(btnEl).has.text(input.options[0].text);
         expect(btnEl).has.class('listbox-button__control');
 


### PR DESCRIPTION
## Description
Added name attribute to the button in `ebay-listbox-button`. The value should be provided as a part of the options as `buttonName`.

## References
Resolving #807 
