### PR TITLE
Changed attributes to passthough to ebay-menu-item

### DIFF
--- a/src/components/ebay-menu-button/template.marko
+++ b/src/components/ebay-menu-button/template.marko
@@ -60,18 +60,7 @@
         w-on-menu-change="handleMenuChange"
         w-on-menu-select="handleMenuSelect">
         <for(item in data.items)>
-            <ebay-menu-item
-                style=item.style
-                class=item.class
-                href=item.href
-                checked=item.checked
-                current=item.current
-                value=item.value
-                badge-number=item.badgeNumber
-                badge-aria-label=item.badgeAriaLabel
-                ${processHtmlAttributes(item)}>
-                <span body-only-if(true) w-body=item.renderBody/>
-            </ebay-menu-item>
+            <ebay-menu-item ${item} />
         </for>
     </ebay-menu>
 </span>

--- a/src/components/ebay-menu-button/test/test.server.js
+++ b/src/components/ebay-menu-button/test/test.server.js
@@ -151,6 +151,12 @@ describe('menu-button', () => {
     });
 
     testUtils.testPassThroughAttributes(template);
+    testUtils.testPassThroughAttributes(template, {
+        child: {
+            name: 'items',
+            multiple: true
+        }
+    });
 });
 
 describe('transformer', () => {


### PR DESCRIPTION
## Description
By doing `${item}` this passes through and attributes defined. That way we don't have to define any attributes and then menu-item will process all html attributes. 

## Context
We should change other components to do the same, but this will solve this given issue. 
I also tested the badge-number if it was working as badgeNumber and it worked fine. Also render body is not needed since it will be passes in the $(item)

## References
#939 
