### PR TITLE
918 spread attrs

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -30,7 +30,10 @@
   },
   "<ebay-button>": {
     "renderer": "./src/components/ebay-button/index.js",
-    "@*": "expression",
+    "@*": {
+      "type": "expression",
+      "targetProperty": null
+    },
     "@html-attributes": "expression",
     "@id": "string",
     "@class": "string",

--- a/src/common/html-attributes/index.js
+++ b/src/common/html-attributes/index.js
@@ -1,5 +1,5 @@
 const assign = require('core-js-pure/features/object/assign');
-
+const skipAttributes = ['*', 'htmlAttributes', 'renderBody', 'widgetState', '__widgetProps', '___widgetProps'];
 /**
  * Convert camelCase to kebab-case
  * @param {String} s
@@ -12,21 +12,26 @@ function camelToKebab(s) {
  * Create object of HTML attributes for pass-through to the DOM
  * @param {Object} input
  */
-function processHtmlAttributes(input = {}) {
+function processHtmlAttributes(input = {}, ignore = []) {
     const attributes = {};
     const htmlAttributes = input.htmlAttributes;
     const wildcardAttributes = input['*'];
 
-    let obj = htmlAttributes || wildcardAttributes;
+    let obj = htmlAttributes || wildcardAttributes || {};
     if (htmlAttributes && wildcardAttributes) {
         obj = assign(wildcardAttributes, htmlAttributes);
     }
-
-    if (obj) {
-        Object.keys(obj).forEach((key) => {
-            attributes[camelToKebab(key)] = obj[key];
+    if (ignore.length) {
+        Object.keys(input).forEach((key) => {
+            if (ignore.indexOf(key) === -1 && skipAttributes.indexOf(key) === -1) {
+                obj[key] = input[key];
+            }
         });
     }
+
+    Object.keys(obj).forEach((key) => {
+        attributes[camelToKebab(key)] = obj[key];
+    });
 
     return attributes;
 }

--- a/src/common/html-attributes/test/test.server.js
+++ b/src/common/html-attributes/test/test.server.js
@@ -20,3 +20,10 @@ it('uses htmlAttributes over * in case of conflict', () => {
     const htmlAttributes = { 'aria-role': 'button' };
     expect(processHtmlAttributes(input)).to.deep.equal(htmlAttributes);
 });
+
+it('should use the ignore list', () => {
+    const input = { htmlAttributes: { b: 2 }, dataAttribute: 'something', style: 'some style', renderBody: () => {} };
+    const ignoreList = ['style'];
+    const htmlAttributes = { b: 2, 'data-attribute': 'something' };
+    expect(processHtmlAttributes(input, ignoreList)).to.deep.equal(htmlAttributes);
+});

--- a/src/components/ebay-button/template.marko
+++ b/src/components/ebay-button/template.marko
@@ -15,11 +15,12 @@
 <var truncateClass=(data.truncate && (sizeClass ? "${sizeClass}-truncated" : "${baseClass}--truncated"))/>
 <var transparentClass=(data.transparent ? "${baseClass}--transparent" : "")/>
 <var fixedHeightClass=(data.fixedHeight && (sizeClass ? "${sizeClass}-fixed-height" : "${baseClass}--fixed-height"))/>
-<var htmlAttributes=processHtmlAttributes(data)/>
 <var tag=(data.href ? "a" : "button")/>
+<var htmlAttributes=(processHtmlAttributes(input, [
+    "id", "class", "style", "type", "disabled", "partiallyDisabled", "href", "priority", "size", "noText", "fluid", "variant", "fixedHeight", "truncate", "transparent", "badgeNumber", "badgeAriaLabel"
+]))/>
 
 <${tag}
-    ${htmlAttributes}
     w-bind
     w-onclick="handleClick"
     w-onkeydown="handleKeydown"
@@ -40,7 +41,8 @@
     href=data.href
     type=(tag === "button" && data.type || "button")
     disabled=data.disabled
-    aria-disabled=(data.partiallyDisabled && "true")>
+    aria-disabled=(data.partiallyDisabled && "true")
+    ${htmlAttributes}>
 
     <var hasAriaLabel=Boolean(htmlAttributes['aria-label'])/>
     <span body-only-if(!hasAriaLabel) w-body aria-hidden="true"/>

--- a/src/components/ebay-infotip/template.marko
+++ b/src/components/ebay-infotip/template.marko
@@ -27,7 +27,7 @@
                     <span body-only-if(true) w-body=data.iconTag.renderBody/>
                 </if>
                 <else>
-                    <ebay-icon type="inline" name="information-filled"/>
+                    <ebay-icon type="inline" name="information"/>
                 </else>
             </button>
             <ebay-tooltip-overlay


### PR DESCRIPTION
## Description
Changed ebay-button to support spread attributes

## Context
We discussed to add an ignore list in input, that way if that is passed then it will not use any attributes in that list. I also made it so that there are some (like renderBody which will not be added as attributes)

## References
#918 

This needs to be added to every component eventually but we only added button for this case since this was requested to fix (and I also as a proof of concept)