### PR TITLE
Patch infotip browser.json to use ebay-icon;

### DIFF
--- a/src/components/ebay-infotip/browser.json
+++ b/src/components/ebay-infotip/browser.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
+        "../ebay-icon",
         "require: ./index.js"
     ]
 }


### PR DESCRIPTION
## Description
- add `ebay-icon` to the dependencies in the `ebay-infotip` browser.json

## Context
I'm not exactly sure how it was working before, but because `ebay-infotip` has a direct reference to `<ebay-icon/>` tag in the template, it should be in the dependencies.

## References
n/a

## Screenshots
n/a
