### PR TITLE
Notice: changed background icons to foreground icons

### DIFF
--- a/src/components/ebay-notice/README.md
+++ b/src/components/ebay-notice/README.md
@@ -48,6 +48,12 @@ Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
 `a11y-heading-tag` | String | No | Yes | used to specify the heading tag according to the notice's placement (default: `"h2"`)
 
+### Additional attributes when type="window"
+
+Name | Type | Stateful | Required | Description
+--- | --- | --- | --- | ---
+`fill-window` | Boolean | No | No | used to specify whether the notice should fill the full height of it's window/container (default: `false`)
+
 ### ebay-notice Events
 
 Event | Description

--- a/src/components/ebay-notice/browser.json
+++ b/src/components/ebay-notice/browser.json
@@ -3,9 +3,11 @@
         {
             "if-not-flag": "ebayui-no-skin",
             "dependencies": [
-                "@ebay/skin/notice"
+                "@ebay/skin/notice",
+                "@ebay/skin/icon/foreground"
             ]
         },
+        "../ebay-icon",
         "require: marko-widgets",
         "require: ./index.js"
     ]

--- a/src/components/ebay-notice/examples/11-window-notice/template.marko
+++ b/src/components/ebay-notice/examples/11-window-notice/template.marko
@@ -8,12 +8,11 @@
 <div class="demo1-container">
     <ebay-notice
         type="window"
-        a11y-heading-text="information">
-        <ebay-notice-title>Congrats</ebay-notice-title>
+        a11y-heading-text="Success!">
+        <ebay-notice-title>Your first order has been placed!</ebay-notice-title>
         <ebay-notice-content>
-            <p><strong>Congrats!</strong> You just listed <a href="#">"Spam and Eggs From the Cow's Perspective</a> (paperback)."</p>
-            <p>You can check <a href="#">your listing</a> or <a href="#">sell another item</a></p>
+            <p>You'll get a confirmation email soon. The rest of your items are now ready to checkout.</p>
         </ebay-notice-content>
-        <ebay-button priority="none" size="large">Action Button</ebay-button>
+        <ebay-button priority="none" size="large">Continue</ebay-button>
     </ebay-notice>
 </div>

--- a/src/components/ebay-notice/examples/12-window-notice-fill/template.marko
+++ b/src/components/ebay-notice/examples/12-window-notice-fill/template.marko
@@ -9,12 +9,11 @@
 </style>
 
 <div class="demo2-container">
-    <ebay-notice type="window" fill>
-        <ebay-notice-title>Congrats</ebay-notice-title>
+    <ebay-notice type="window" a11y-heading-text="Success!" fill-window>
+        <ebay-notice-title>Your first order has been placed!</ebay-notice-title>
         <ebay-notice-content>
-            <p><strong>Congrats!</strong> You just listed <a href="#">"Spam and Eggs From the Cow's Perspective</a> (paperback)."</p>
-            <p>You can check <a href="#">your listing</a> or <a href="#">sell another item</a></p>
+            <p>You'll get a confirmation email soon. The rest of your items are now ready to checkout.</p>
         </ebay-notice-content>
-        <ebay-button priority="none" size="large">Action Button</ebay-button>
+        <ebay-button priority="none" size="large">Continue</ebay-button>
     </ebay-notice>
 </div>

--- a/src/components/ebay-notice/template.marko
+++ b/src/components/ebay-notice/template.marko
@@ -1,6 +1,6 @@
 <script marko-init>
     var processHtmlAttributes = require("../../common/html-attributes");
-    var ignoredAttributes = ["class",  "style",  "type",  "fill", "status",  "hidden",  "a11yHeadingText",  "a11yHeadingTag",  "a11yCloseText",  "dismissible",  "content", "title"];
+    var ignoredAttributes = ["class",  "style",  "type",  "fillWindow", "status",  "hidden",  "a11yHeadingText",  "a11yHeadingTag",  "a11yCloseText",  "dismissible",  "content", "title"];
     var itemIgnoredAttributes = ["class", "style"];
 </script>
 <var type=(data.type || "page")/>
@@ -27,7 +27,7 @@
         class=[
             "${type}-notice",
             !isLightGuidance && !isWindow ? "${type}-notice--${status}" : "",
-            data.fill ? "${type}-notice--fill" : "",
+            data.fillWindow ? "${type}-notice--fill" : "",
             data.class
         ]>
         <if(!isLightGuidance)>
@@ -35,16 +35,23 @@
                 class="${type}-notice__status"
                 w-id="status">
                 <if(isWindow && title && title.renderBody)>
-                    <span class="${type}-notice__icon" aria-label=data.a11yHeadingText role="img"/>
+                    <ebay-icon class="window-notice__icon" type="inline" name="confirmation-filled" aria-label=data.a11yHeadingText/>
                     <span class=["${type}-notice__title", title.class]
                         style=title.style
                         ${processHtmlAttributes(title, itemIgnoredAttributes)}
                         w-body=title.renderBody/>
                 </if>
                 <else>
-                    <span aria-label=data.a11yHeadingText role="img"/>
+                    <if(status==="confirmation" || status==="celebration")>
+                        <ebay-icon type="inline" name="confirmation-filled" aria-label=data.a11yHeadingText/>
+                    </if>
+                    <if(status==="attention")>
+                        <ebay-icon type="inline" name="attention-filled" aria-label=data.a11yHeadingText/>
+                    </if>
+                    <if(status==="information")>
+                        <ebay-icon type="inline" name="information-filled" aria-label=data.a11yHeadingText/>
+                    </if>
                 </else>
-
             </>
         </if>
        <if(content && content.renderBody)>

--- a/src/components/ebay-notice/test/test.server.js
+++ b/src/components/ebay-notice/test/test.server.js
@@ -168,7 +168,7 @@ describe('notice', () => {
         });
 
         it('renders fill window', async() => {
-            const input = assign({}, mock.Window_Notice, { fill: true });
+            const input = assign({}, mock.Window_Notice, { fillWindow: true });
             const { getByText } = await render(template, input);
             const container = getByText(input.content.renderBody.text).parentElement;
             expect(container).has.class('window-notice');


### PR DESCRIPTION
Similar to the recent pagination update, this PR swaps out all instances of background icons with foreground icons.

I made a couple of other changes:

* Renamed `fill` to `fillWindow`. Added to docs.
* Updated the examples to better match use case

## Screenshots

![Screen Shot 2019-11-06 at 11 56 34 AM](https://user-images.githubusercontent.com/38065/68332980-8ed58200-008c-11ea-86c5-ce2330854a9c.png)
![Screen Shot 2019-11-06 at 11 56 27 AM](https://user-images.githubusercontent.com/38065/68332981-8ed58200-008c-11ea-8e67-8f26d7c71fdc.png)
![Screen Shot 2019-11-06 at 11 56 20 AM](https://user-images.githubusercontent.com/38065/68332982-8f6e1880-008c-11ea-94c6-ecd5459e48cb.png)
![Screen Shot 2019-11-06 at 11 56 03 AM](https://user-images.githubusercontent.com/38065/68332983-8f6e1880-008c-11ea-89e6-b9fc31ce9303.png)
![Screen Shot 2019-11-06 at 11 55 54 AM](https://user-images.githubusercontent.com/38065/68332984-8f6e1880-008c-11ea-94b5-3b4c6a7a7533.png)
