### PR TITLE
Infotip: fixed icon alignment issues

### DIFF
--- a/src/components/ebay-infotip/examples/01-infotip/template.marko
+++ b/src/components/ebay-infotip/examples/01-infotip/template.marko
@@ -1,4 +1,4 @@
-<ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information" pointer="left-top">
+<ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information">
     <ebay-infotip-heading>Important</ebay-infotip-heading>
     <ebay-infotip-content><p>This is some important info</p></ebay-infotip-content>
 </ebay-infotip>

--- a/src/components/ebay-infotip/examples/02-custom-icon/template.marko
+++ b/src/components/ebay-infotip/examples/02-custom-icon/template.marko
@@ -1,4 +1,4 @@
-<ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information" icon="settings" pointer="left-top">
+<ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information" icon="settings">
     <ebay-infotip-heading>Important</ebay-infotip-heading>
     <ebay-infotip-content><p>This is some important info</p></ebay-infotip-content>
 </ebay-infotip>

--- a/src/components/ebay-infotip/examples/03-disabled/template.marko
+++ b/src/components/ebay-infotip/examples/03-disabled/template.marko
@@ -1,4 +1,4 @@
-<ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information" pointer="left-top" disabled>
+<ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information" disabled>
     <ebay-infotip-heading>Important</ebay-infotip-heading>
     <ebay-infotip-content><p>This is some important info</p></ebay-infotip-content>
 </ebay-infotip>

--- a/src/components/ebay-infotip/examples/04-intotip-in-paragraph/template.marko
+++ b/src/components/ebay-infotip/examples/04-intotip-in-paragraph/template.marko
@@ -5,7 +5,7 @@
     </em>
     <p>
         Some paragraph content
-        <ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information" pointer="left-top">
+        <ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information">
             <ebay-infotip-heading>Important</ebay-infotip-heading>
             <ebay-infotip-content>This is some important info</ebay-infotip-content>
         </ebay-infotip>

--- a/src/components/ebay-infotip/template.marko
+++ b/src/components/ebay-infotip/template.marko
@@ -28,7 +28,7 @@
                     <span body-only-if(true) w-body=data.iconTag.renderBody/>
                 </if>
                 <else>
-                    <ebay-icon type="inline" name="information"/>
+                    <ebay-icon type="inline" name="information-small"/>
                 </else>
             </button>
             <ebay-tooltip-overlay

--- a/src/components/ebay-tooltip/examples/02-anchor-host/template.marko
+++ b/src/components/ebay-tooltip/examples/02-anchor-host/template.marko
@@ -1,4 +1,4 @@
-<ebay-tooltip pointer="top-left">
+<ebay-tooltip>
     <ebay-tooltip-host>
         <a href="https://www.ebay.com">View options</a>
     </ebay-tooltip-host>

--- a/src/components/ebay-tooltip/examples/04-pointer-with-custom-location/template.marko
+++ b/src/components/ebay-tooltip/examples/04-pointer-with-custom-location/template.marko
@@ -1,4 +1,4 @@
-<ebay-tooltip pointer="top-left" style-top="32px" style-left="-16px">
+<ebay-tooltip pointer="top-left" style-top="24px" style-left="-16px">
     <ebay-tooltip-host>
         <a href="https://www.ebay.com">View options</a>
     </ebay-tooltip-host>

--- a/src/components/ebay-tourtip/examples/01-tourtip/template.marko
+++ b/src/components/ebay-tourtip/examples/01-tourtip/template.marko
@@ -10,11 +10,3 @@
     <ebay-tourtip-heading>Important</ebay-tourtip-heading>
     <ebay-tourtip-content><p>This new feature was added.</p></ebay-tourtip-content>
 </ebay-tourtip>
-
-<ebay-tourtip pointer="bottom-left" a11y-close-text="Dismiss tourtip">
-    <ebay-tourtip-host>
-        <p>Ad anim do ea sint fugiat irure dolore. Cillum veniam pariatur elit sint aute dolor cillum reprehenderit exercitation.</p>
-    </ebay-tourtip-host>
-    <ebay-tourtip-heading>Important</ebay-tourtip-heading>
-    <ebay-tourtip-content><p>This new feature was added.</p></ebay-tourtip-content>
-</ebay-tourtip>


### PR DESCRIPTION
# Closes #965

Requires latest from skin branch 9.5.0

* Addresses issue with misaligned icon in info tips, and incorrect size for tooltips

Other:

* Sets all examples to default pointer location (this will make overlay hard to see in storybook, but I have an idea of how to fix this, by centering the example on the page)
* Sets `icon-information` to `icon-information-small`
* Removes the second tourtip from the example

<img width="962" alt="Screen Shot 2019-11-19 at 4 22 41 PM" src="https://user-images.githubusercontent.com/38065/69198947-4cc82980-0aeb-11ea-81b1-95abe67bf52a.png">
<img width="952" alt="Screen Shot 2019-11-19 at 4 32 24 PM" src="https://user-images.githubusercontent.com/38065/69198952-505bb080-0aeb-11ea-8c48-36dd68ed04f2.png">
<img width="375" alt="Screen Shot 2019-11-19 at 4 25 07 PM" src="https://user-images.githubusercontent.com/38065/69198962-623d5380-0aeb-11ea-8a47-51a0c67920c5.png">

