### PR TITLE
Dialog: restore dialog focus on close

### DIFF
--- a/src/components/ebay-dialog/component.js
+++ b/src/components/ebay-dialog/component.js
@@ -53,6 +53,7 @@ module.exports = {
 
         // Ensure focus is set and body scroll prevented on initial render.
         if (isFirstRender && isTrapped) {
+            this._prevFocusEl = document.activeElement;
             focusEl.focus();
             bodyScroll.prevent();
         }
@@ -67,7 +68,17 @@ module.exports = {
                     this.emit('dialog-show');
                 } else {
                     bodyScroll.restore();
+                    const activeElement = document.activeElement;
                     this.emit('dialog-close');
+
+                    if (
+                        // Skip restoring focus if the focused element was changed via the dialog-close event
+                        activeElement === document.activeElement &&
+                        // Skip restoring focus if the previously focused element was removed from the DOM.
+                        document.documentElement.contains(this._prevFocusEl)
+                    ) {
+                        this._prevFocusEl.focus();
+                    }
 
                     // Reset dialog scroll position lazily to avoid jank.
                     // Note since the dialog is not in the dom at this point none of the scroll methods will work.
@@ -80,6 +91,7 @@ module.exports = {
 
             if (isTrapped) {
                 if (!isFirstRender) {
+                    this._prevFocusEl = document.activeElement;
                     bodyScroll.prevent();
                     this.cancelTransition = transition({
                         el: this.rootEl,

--- a/src/components/ebay-dialog/test/test.browser.js
+++ b/src/components/ebay-dialog/test/test.browser.js
@@ -88,7 +88,8 @@ describe('given an open dialog', () => {
     let sibling;
 
     beforeEach(async() => {
-        sibling = document.body.appendChild(document.createElement('div'));
+        sibling = document.body.appendChild(document.createElement('button'));
+        sibling.focus();
         component = await render(template, input);
     });
 
@@ -151,8 +152,9 @@ describe('given an open dialog', () => {
             expect(sibling).does.not.have.attr('aria-hidden');
         });
 
-        it('then it does not trap focus', () => {
+        it('then it restores the previous focus', async() => {
             expect(component.getByRole('document')).does.not.have.class('keyboard-trap--active');
+            await wait(() => expect(document.activeElement).to.equal(sibling));
         });
 
         if (wasToggled) {


### PR DESCRIPTION
## Description
This PR updates the `ebay-dialog` to track the focused element before trapping the focus within the dialog. When the dialog is closed it then restores focus to the previous element.

The user can still control restoring the focus manually by using the `on-close` event and setting the focus there since the focus is restored internally just before emitting that event.

## References
Fixes #941 

