### PR TITLE
Combobox: allow custom ID

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -96,7 +96,6 @@
     "renderer": "./src/components/ebay-combobox/index.js",
     "@*": "expression",
     "@html-attributes": "expression",
-    "@input-id": "string",
     "@class": "string",
     "@style": "string",
     "@name": "string",

--- a/marko.json
+++ b/marko.json
@@ -96,6 +96,7 @@
     "renderer": "./src/components/ebay-combobox/index.js",
     "@*": "expression",
     "@html-attributes": "expression",
+    "@input-id": "string",
     "@class": "string",
     "@style": "string",
     "@name": "string",

--- a/src/components/ebay-combobox/examples/07-custom-input-id/template.marko
+++ b/src/components/ebay-combobox/examples/07-custom-input-id/template.marko
@@ -1,0 +1,7 @@
+<ebay-combobox name="example2text" input-id="custom-id-1">
+    <ebay-combobox-option text="August Campaign"/>
+    <ebay-combobox-option text="4th of July Sale (paused)"/>
+    <ebay-combobox-option text="Basic Offer"/>
+    <ebay-combobox-option text="Basic Offer 1"/>
+    <ebay-combobox-option text="Basic Offer 3"/>
+</ebay-combobox>

--- a/src/components/ebay-combobox/examples/07-custom-input-id/template.marko
+++ b/src/components/ebay-combobox/examples/07-custom-input-id/template.marko
@@ -1,4 +1,4 @@
-<ebay-combobox name="example2text" input-id="custom-id-1">
+<ebay-combobox name="example2text" id="custom-id-1">
     <ebay-combobox-option text="August Campaign"/>
     <ebay-combobox-option text="4th of July Sale (paused)"/>
     <ebay-combobox-option text="Basic Offer"/>

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -29,10 +29,12 @@ module.exports = require('marko-widgets').defineComponent({
         const isExpanded = this.expanded = this.state.expanded;
         const wasToggled = isExpanded !== wasExpanded;
 
+        this.inputEl = this.el.querySelector('input');
+
         if (!this.state.disabled && this.state.options.length > 0) {
             this.activeDescendant = ActiveDescendant.createLinear(
                 this.el,
-                this.getEl('input'),
+                this.inputEl,
                 this.getEl('options'),
                 '.combobox__option[role=option]', {
                     activeDescendantClassName: 'combobox__option--active',
@@ -91,7 +93,7 @@ module.exports = require('marko-widgets').defineComponent({
     handleComboboxKeyDown(originalEvent) {
         const optionsEl = this.getEl('options');
         const selectedEl = optionsEl && optionsEl.querySelector('.combobox__option--active');
-        let newValue = this.getEl('input').value;
+        let newValue = this.inputEl.value;
 
         eventUtils.handleUpDownArrowsKeydown(originalEvent, () => {
             originalEvent.preventDefault();
@@ -106,7 +108,7 @@ module.exports = require('marko-widgets').defineComponent({
             if (this.expander.isExpanded()) {
                 newValue = selectedEl && selectedEl.textContent || newValue;
 
-                this.getEl('input').value = newValue;
+                this.inputEl.value = newValue;
                 this.setState('currentValue', newValue);
                 this.setSelectedIndex();
                 if (selectedEl) {
@@ -121,13 +123,13 @@ module.exports = require('marko-widgets').defineComponent({
         });
     },
     handleComboboxKeyUp(originalEvent) {
-        const newValue = this.getEl('input').value;
+        const newValue = this.inputEl.value;
 
         eventUtils.handleTextInput(originalEvent, () => {
-            this.valueChanged = this.getEl('input').value !== newValue;
+            this.valueChanged = this.inputEl.value !== newValue;
 
             this.activeDescendant.reset();
-            this.getEl('input').value = newValue;
+            this.inputEl.value = newValue;
             this.setState('currentValue', newValue);
             this.setSelectedIndex();
             this.emitComboboxEvent();
@@ -140,7 +142,7 @@ module.exports = require('marko-widgets').defineComponent({
         const wasClickedOption = this.optionClicked;
 
         if (wasClickedOption) {
-            this.getEl('input').focus();
+            this.inputEl.focus();
         }
 
         if (this.expander && this.expander.isExpanded() && !wasClickedOption) {
@@ -160,9 +162,9 @@ module.exports = require('marko-widgets').defineComponent({
         const selectedValue = selectedEl.textContent;
 
         this.optionClicked = false;
-        this.valueChanged = this.getEl('input').value !== selectedValue;
+        this.valueChanged = this.inputEl.value !== selectedValue;
 
-        this.getEl('input').value = selectedValue;
+        this.inputEl.value = selectedValue;
         this.setState('currentValue', selectedValue);
         this.setSelectedIndex();
         this.emitComboboxEvent('select');
@@ -184,7 +186,7 @@ module.exports = require('marko-widgets').defineComponent({
         });
     },
     toggleListbox() {
-        const query = this.getEl('input').value;
+        const query = this.inputEl.value;
         const queryReg = safeRegex(query);
 
         const showListbox =

--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -14,14 +14,21 @@ module.exports = require('marko-widgets').defineComponent({
         }, input);
     },
     getInitialState(input) {
+        let currentValue;
+        let inputId;
         const autocomplete = input.autocomplete === 'list' ? 'list' : 'none';
-        const currentValue = input['*'] && input['*'].value;
         const index = findIndex(input.options, option => option.text === currentValue);
+
+        if (input['*']) {
+            currentValue = input['*'].value;
+            inputId = input['*'].id;
+        }
 
         return assign({}, input, {
             autocomplete,
             selectedIndex: index === -1 ? null : index,
-            currentValue
+            currentValue,
+            id: inputId
         });
     },
     onRender() {

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -20,7 +20,7 @@
         respect the "off" key. Tested and works in all other browsers properly as well.
         -->
         <input
-            w-id="input"
+            id=(data.inputId || component.id + "-input")
             type='text'
             name=data.name
             role="combobox"

--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -20,7 +20,7 @@
         respect the "off" key. Tested and works in all other browsers properly as well.
         -->
         <input
-            id=(data.inputId || component.id + "-input")
+            id=(data.id || widget.id + "-input")
             type='text'
             name=data.name
             role="combobox"


### PR DESCRIPTION
### Note: for Core pre-v5
This will require a little bit of a change in Core@v5 to eliminate the DOM query. This presently is pointed to master, and I can create another PR for Core@v5 as needed.

## Description
- allows a custom `id` to be passed through to the `input`

## Context
Because a combobox input needs to have a label, the developer needs to add a `for` to the label, and therefore needs to be able to specify the ID.

## References
Fixes #968 
