### PR TITLE
Expand-Button: Add click and escape key event handling;

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -159,7 +159,7 @@
     "@a11y-close-text": "string"
   },
   "<ebay-expand-button>": {
-    "template": "./src/components/ebay-expand-button/index.marko",
+    "renderer": "./src/components/ebay-expand-button/index.js",
     "@*": "expression",
     "@html-attributes": "expression",
     "@id": "string",

--- a/src/components/ebay-expand-button/browser.json
+++ b/src/components/ebay-expand-button/browser.json
@@ -6,6 +6,7 @@
                 "@ebay/skin/expand-button"
             ]
         },
-        "../ebay-icon"
+        "../ebay-icon",
+        "require: ./index.js"
     ]
 }

--- a/src/components/ebay-expand-button/index.js
+++ b/src/components/ebay-expand-button/index.js
@@ -1,0 +1,23 @@
+const assign = require('core-js-pure/features/object/assign');
+const eventUtils = require('../../common/event-utils');
+
+module.exports = require('marko-widgets').defineComponent({
+    template: require('./template.marko'),
+    getInitialState(input) {
+        return assign({}, input, {
+            disabled: input.disabled
+        });
+    },
+    handleClick(originalEvent) {
+        if (!this.state.disabled) {
+            this.emit('button-click', { originalEvent });
+        }
+    },
+    handleKeydown(originalEvent) {
+        eventUtils.handleEscapeKeydown(originalEvent, () => {
+            if (!this.state.disabled) {
+                this.emit('button-escape', { originalEvent });
+            }
+        });
+    }
+});

--- a/src/components/ebay-expand-button/template.marko
+++ b/src/components/ebay-expand-button/template.marko
@@ -9,6 +9,7 @@
 <var sizeClass="${baseClass}--${size}"/>
 
 <button
+    w-bind
     ${processHtmlAttributes(data)}
     id=(data.id || getWidgetId(out))
     class=[
@@ -24,7 +25,9 @@
     href=data.href
     type="button"
     disabled=data.disabled
-    aria-disabled=(data.partiallyDisabled && "true")>
+    aria-disabled=(data.partiallyDisabled && "true")
+    w-onclick="handleClick"
+    w-onkeydown="handleKeydown">
     <span class="${baseClass}__cell">
         <span if(data.renderBody)><invoke data.renderBody(out) /></span>
         <ebay-icon type="inline" name="chevron-down-bold" class="expand-btn__icon" no-skin-classes/>

--- a/src/components/ebay-expand-button/test/test.browser.js
+++ b/src/components/ebay-expand-button/test/test.browser.js
@@ -1,0 +1,68 @@
+const { expect, use } = require('chai');
+const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const { pressKey } = require('../../../common/test-utils/browser');
+const template = require('..');
+
+use(require('chai-dom'));
+afterEach(cleanup);
+
+/** @type import("@marko/testing-library").RenderResult */
+let component;
+
+describe('given expand button is enabled', () => {
+    beforeEach(async() => {
+        component = await render(template);
+    });
+
+    describe('when expand button is clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(component.getByRole('button'));
+        });
+
+        it('then it emits the event with correct data', () => {
+            expect(component.emitted('button-click')).has.length(1);
+        });
+    });
+
+    describe('when escape key is pressed', () => {
+        beforeEach(async() => {
+            await pressKey(component.getByRole('button'), {
+                key: 'Escape',
+                keyCode: 27
+            });
+        });
+
+        it('then it emits the event with correct data', () => {
+            expect(component.emitted('button-escape')).has.length(1);
+        });
+    });
+});
+
+describe('given expand button is disabled', () => {
+    beforeEach(async() => {
+        component = await render(template, { disabled: true });
+    });
+
+    describe('when expand button is clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(component.getByRole('button'));
+        });
+
+        it('then it does not emit the event', () => {
+            expect(component.emitted('button-click')).has.length(0);
+        });
+    });
+
+    describe('when escape key is pressed', () => {
+        beforeEach(async() => {
+            await pressKey(component.getByRole('button'), {
+                key: 'Escape',
+                keyCode: 27
+            });
+        });
+
+        it('then it does not emit the event', () => {
+            expect(component.emitted('button-escape')).has.length(0);
+        });
+    });
+});


### PR DESCRIPTION
## Description
- add click event handler
- add escape key event handler
- add widget code
- update template to support being a widget
- add browser tests accordingly

## Context
The expand button component was not sending any click events or allowing the escape key to be captured (as is done in the plain button). These changes make the button capable of being interactive with other Marko components.

**_Note:_** the "expanded" state should be handled by the wrapping component using `aria-expanded="true"` to toggle the chevron. If it is being used to expose a popup (like a menu) the developer would also need to add `aria-haspopup="true"` and make sure that the expand button immediately precedes the menu (or other popup) in the DOM.

## References
Fixes #970 