### PR TITLE
Refactored menu and menu button for marko v4

### DIFF
--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -21,9 +21,9 @@ static var ignoredAttributes = [
     "label"
 ];
 
-$ var isFake = state.type === "fake";
+$ var isFake = input.type === "fake";
 $ var baseClass = isFake ? "fake-menu-button" : "menu-button";
-$ var isOverflowVariant = state.variant === "overflow";
+$ var isOverflowVariant = input.variant === "overflow";
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
     class=[isFake ? "fake-menu-button" : "menu-button", input.class]
@@ -90,8 +90,8 @@ $ var isOverflowVariant = state.variant === "overflow";
         onMenu-change("handleMenuChange")
         onMenu-select("handleMenuSelect")
         key="content">
-        <for|item| of=state.items>
-            <ebay-menu-item(item)/>
+        <for|item,index| of=input.items>
+            <ebay-menu-item  ...item checked=state.checkedItems[index] />
         </for>
     </ebay-menu>
 </span>

--- a/src/components/ebay-menu/component.js
+++ b/src/components/ebay-menu/component.js
@@ -1,10 +1,8 @@
 const assign = require('core-js-pure/features/object/assign');
-const indexOf = require('core-js-pure/features/array/index-of');
 const findIndex = require('core-js-pure/features/array/find-index');
 const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 const rovingTabindex = require('makeup-roving-tabindex');
 const eventUtils = require('../../common/event-utils');
-const NodeListUtils = require('../../common/nodelist-utils');
 
 module.exports = {
     _handleDestroy() {
@@ -15,7 +13,6 @@ module.exports = {
     },
 
     toggleItemChecked(index, originalEvent, itemEl) {
-        const item = this.input.items[index];
         const currentIndex = this.state.checkedItems.findIndex(checked => checked);
 
         if (this.type === 'radio' && index !== currentIndex) {
@@ -49,7 +46,7 @@ module.exports = {
     },
 
     getCheckedIndexes() {
-       return this.input.items
+        return this.input.items
             .map((item, i) => this.state.checkedItems[i] && i)
             .filter(item => item !== false && typeof item !== 'undefined');
     },
@@ -82,6 +79,7 @@ module.exports = {
 
         if (isCheckbox && checkedIndexes.length > 1) {
             assign(eventObj, {
+                index,
                 indexes: this.getCheckedIndexes(), // DEPRECATED in v5
                 checked: this.getCheckedIndexes(), // DEPRECATED in v5 (keep but change from indexes to values)
                 checkedValues: this.getCheckedValues() // DEPRECATED in v5
@@ -107,7 +105,7 @@ module.exports = {
         this.state = {
             checkedItems: (input.items || []).map(item => item.checked || false)
 
-        }
+        };
     },
 
     onRender() {
@@ -118,9 +116,14 @@ module.exports = {
 
     onMount() {
         this.tabindexPosition = 0;
+        this.setContent();
     },
 
     onUpdate() {
+        this.setContent();
+    },
+
+    setContent() {
         this.contentEl = this.getEl('menu');
 
         if (this.type !== 'fake') {

--- a/src/components/ebay-menu/index.marko
+++ b/src/components/ebay-menu/index.marko
@@ -46,25 +46,26 @@ $ var baseClass = input.classPrefix || (isFake ? "fake-menu" : "menu");
         class=`${baseClass}__items`
         key="menu"
         id:scoped="menu">
-        <for|item| of=state.items>
+        <for|item, index| of=input.items>
             $ {
                 var itemRole = isRadio
                                 ? "menuitemradio"
                                 : isCheckbox
                                 ? "menuitemcheckbox"
                                 : !isFake && "menuitem";
+                var checked = state.checkedItems[index];
             }
             <${isFake ? (item.type === "button" ? "button" : "a") : "div"}
                 ...processHtmlAttributes(item, itemIgnoredAttributes)
                 class=[`${baseClass}__item`, item.class]
                 style=item.style
-                aria-checked=(!isNotCheckable && (item.checked ? "true" : "false"))
+                aria-checked=(!isNotCheckable && (checked ? "true" : "false"))
                 aria-current=(isNotCheckable && item.current ? "page" : false)
                 href=item.href
                 role=itemRole
-                onClick("handleItemClick")
-                onKeydown("handleItemKeydown")
-                onKeypress("handleItemKeypress")
+                onClick("handleItemClick", index)
+                onKeydown("handleItemKeydown", index)
+                onKeypress("handleItemKeypress", index)
                 key="item[]">
                 <span>
                     <${!item.badgeNumber ? null : "span"} aria-hidden="true">


### PR DESCRIPTION
## Description
Changed menu and menu button to no longer use state for everything, but input instead. Changed stated to be only the checked items

## Context
* I pass index through the events now, so we don't have to find the pressed item using fancy html manipulation
* I had to add the index on the ebay-menu change event because then the menu-button couldn't sync it's state based on it. A possible better solution (but might be a braking change), is to pass the state from `ebay-menu` in events and have the `ebay-menu-button` sync it's state based on that state


## References
#964