### PR TITLE
Ported click/escape key event handling for expand-button

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -198,7 +198,7 @@
     "@a11y-close-text": "string"
   },
   "<ebay-expand-button>": {
-    "template": "./src/components/ebay-expand-button/index.marko",
+    "renderer": "./src/components/ebay-expand-button/index.js",
     "@*": {
       "targetProperty": null,
       "type": "expression"

--- a/src/components/ebay-expand-button/component.js
+++ b/src/components/ebay-expand-button/component.js
@@ -1,0 +1,16 @@
+const eventUtils = require('../../common/event-utils');
+
+module.exports = {
+    handleClick(originalEvent) {
+        if (!this.state.disabled) {
+            this.emit('button-click', { originalEvent });
+        }
+    },
+    handleKeydown(originalEvent) {
+        eventUtils.handleEscapeKeydown(originalEvent, () => {
+            if (!this.state.disabled) {
+                this.emit('button-escape', { originalEvent });
+            }
+        });
+    }
+};

--- a/src/components/ebay-expand-button/index.marko
+++ b/src/components/ebay-expand-button/index.marko
@@ -33,7 +33,9 @@ $ var sizeClass = baseClass + "--" + size;
     href=data.href
     type="button"
     disabled=data.disabled
-    aria-disabled=(data.partiallyDisabled && "true")>
+    aria-disabled=(data.partiallyDisabled && "true")
+    w-onclick="handleClick"
+    w-onkeydown="handleKeydown">
     <span class=`${baseClass}__cell`>
         <if(data.renderBody)>
             <span>

--- a/src/components/ebay-expand-button/test/test.browser.js
+++ b/src/components/ebay-expand-button/test/test.browser.js
@@ -1,0 +1,68 @@
+const { expect, use } = require('chai');
+const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const { pressKey } = require('../../../common/test-utils/browser');
+const template = require('..');
+
+use(require('chai-dom'));
+afterEach(cleanup);
+
+/** @type import("@marko/testing-library").RenderResult */
+let component;
+
+describe('given expand button is enabled', () => {
+    beforeEach(async() => {
+        component = await render(template);
+    });
+
+    describe('when expand button is clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(component.getByRole('button'));
+        });
+
+        it('then it emits the event with correct data', () => {
+            expect(component.emitted('button-click')).has.length(1);
+        });
+    });
+
+    describe('when escape key is pressed', () => {
+        beforeEach(async() => {
+            await pressKey(component.getByRole('button'), {
+                key: 'Escape',
+                keyCode: 27
+            });
+        });
+
+        it('then it emits the event with correct data', () => {
+            expect(component.emitted('button-escape')).has.length(1);
+        });
+    });
+});
+
+describe('given expand button is disabled', () => {
+    beforeEach(async() => {
+        component = await render(template, { disabled: true });
+    });
+
+    describe('when expand button is clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(component.getByRole('button'));
+        });
+
+        it('then it does not emit the event', () => {
+            expect(component.emitted('button-click')).has.length(0);
+        });
+    });
+
+    describe('when escape key is pressed', () => {
+        beforeEach(async() => {
+            await pressKey(component.getByRole('button'), {
+                key: 'Escape',
+                keyCode: 27
+            });
+        });
+
+        it('then it does not emit the event', () => {
+            expect(component.emitted('button-escape')).has.length(0);
+        });
+    });
+});


### PR DESCRIPTION
## Description
<!--- What are the changes? -->
Ported click/escape key event handling for expand-button (#970) upstream
## Context
<!--- Why did you make these changes, and why in this particular way? -->
Ported exact logic with the exception of using `marko-widgets`, keeping just escape key/click handler in the `component.js`.
## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
#956
