### PR TITLE
Combobox: Added test for blur event

### DIFF
--- a/src/components/ebay-combobox/test/test.browser.js
+++ b/src/components/ebay-combobox/test/test.browser.js
@@ -56,6 +56,16 @@ describe('given the combobox with 3 items', () => {
                 it('then it should emit a input event', () => {
                     expect(component.emitted('combobox-input')).has.length(1);
                 });
+
+                describe('when blur happens on the combobox', () => {
+                    beforeEach(async() => {
+                        await fireEvent.blur(component.getByRole('combobox'));
+                    });
+
+                    it('then it should emit a change event', () => {
+                        expect(component.emitted('combobox-change')).has.length(1);
+                    });
+                });
             });
 
             describe('when the down arrow key is pressed', () => {
@@ -182,6 +192,16 @@ describe('given the combobox starts with zero options', () => {
 
                 it('then it should emit a input event', () => {
                     expect(component.emitted('combobox-input')).has.length(1);
+                });
+
+                describe('when blur happens on the combobox', () => {
+                    beforeEach(async() => {
+                        await fireEvent.blur(component.getByRole('combobox'));
+                    });
+
+                    it('then it should emit a change event', () => {
+                        expect(component.emitted('combobox-change')).has.length(1);
+                    });
                 });
             });
 


### PR DESCRIPTION
## Description
- add a test for text input and whether the change event fires on blur

## Context
Similar to #989, but this is the test for the v5 branch.

## References
Relates to #988 