### PR TITLE
987 - Catch race condition in carousel rerender

### DIFF
--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -110,10 +110,10 @@ function onRender() {
                     // Animate to the new scrolling position and emit update events afterward.
                     config.scrollTransitioning = true;
                     this.cancelScrollTransition = scrollTransition(listEl, offset, this.emitUpdate);
-                } else if (offset !== 0) {
+                } else {
                     // Race condition where user clicks the paddles quickly and by the time the offset is calculated
                     // its equal to the element position, so emitUpdate is never called
-                    this.emitUpdate();
+                    this.isMoving = false;
                 }
             }
         }

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -110,10 +110,10 @@ function onRender() {
                     // Animate to the new scrolling position and emit update events afterward.
                     config.scrollTransitioning = true;
                     this.cancelScrollTransition = scrollTransition(listEl, offset, this.emitUpdate);
-                } else {
-                    // Race condition where user clicks the paddles quickly and by the time the offset is calculated
-                    // its equal to the element position, so emitUpdate is never called
-                    this.isMoving = false;
+                } else if (this.isMoving) {
+                    // Animate to the new scrolling position and emit update events afterward.
+                    config.scrollTransitioning = true;
+                    this.cancelScrollTransition = scrollTransition(listEl, getOffset(state), this.emitUpdate);
                 }
             }
         }

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -110,6 +110,10 @@ function onRender() {
                     // Animate to the new scrolling position and emit update events afterward.
                     config.scrollTransitioning = true;
                     this.cancelScrollTransition = scrollTransition(listEl, offset, this.emitUpdate);
+                } else if (offset !== 0) {
+                    // Race condition where user clicks the paddles quickly and by the time the offset is calculated
+                    // its equal to the element position, so emitUpdate is never called
+                    this.emitUpdate();
                 }
             }
         }


### PR DESCRIPTION
## Description
Add a code branch for the carousel onRender to call emitUpdate so that the paddle click events are re-attached.

## Context
There is a race condition where the user could trigger a rerender by clicking a nav paddle, but the component calculates that the item position is correct by the time `getOffset` is called.  In this case it never calls `emitUpdate` so the click events on the paddles never get re-attached.  This fix handles that scenario.  

I check for `offset !== 0` because this change causes some of the unit tests to fail. In all these cases, the initial offset is 0. I'm not thrilled with this change to address the unit tests, but I couldn't figure out a way to skip this code branch during the unit tests, or why the tests were failing when `emitUpdate` was called.  But manual testing seems to work fine with this change.

## References
Fixes https://github.com/eBay/ebayui-core/issues/987

## Screenshots
no UI change
