### PR TITLE
Added migrator for icon type

### DIFF
--- a/src/components/ebay-badge/examples/03-icon/template.marko
+++ b/src/components/ebay-badge/examples/03-icon/template.marko
@@ -1,3 +1,3 @@
 <ebay-button aria-label="Menu (5 unread items)" variant="icon" badge-number="5">
-    <ebay-icon type="inline" name="menu"/>
+    <ebay-icon name="menu"/>
 </ebay-button>

--- a/src/components/ebay-button/examples/11-icon-button/template.marko
+++ b/src/components/ebay-button/examples/11-icon-button/template.marko
@@ -1,3 +1,3 @@
 <ebay-button aria-label="Menu" variant="icon">
-    <ebay-icon type="inline" name="menu"/>
+    <ebay-icon name="menu"/>
 </ebay-button>

--- a/src/components/ebay-checkbox/index.marko
+++ b/src/components/ebay-checkbox/index.marko
@@ -1,4 +1,4 @@
-import processHtmlAttributes from "../../common/html-attributes";
+import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = ["class", "style"];
 
@@ -12,13 +12,11 @@ static var ignoredAttributes = ["class", "style"];
         onFocus("handleFocus")/>
     <span class="checkbox__icon" hidden>
         <ebay-icon
-            type="inline"
             name="checkbox-unchecked"
             class="checkbox__unchecked"
             focusable="false"
             no-skin-classes/>
         <ebay-icon
-            type="inline"
             name="checkbox-checked"
             class="checkbox__checked"
             focusable="false"

--- a/src/components/ebay-dialog/index.marko
+++ b/src/components/ebay-dialog/index.marko
@@ -1,11 +1,6 @@
-import processHtmlAttributes from "../../common/html-attributes";
+import processHtmlAttributes from "../../common/html-attributes"
 
-static var ignoredAttributes = [
-    "open",
-    "type",
-    "focus",
-    "a11yCloseText"
-];
+static var ignoredAttributes = ["open", "type", "focus", "a11yCloseText"];
 
 $ var isFull = input.type === "full";
 $ var isCenter = !input.type || input.type === "fill";
@@ -38,7 +33,7 @@ $ var isDocked = input.type === "left" || input.type === "right";
             type="button"
             aria-label=input.a11yCloseText
             onClick("handleCloseButtonClick")>
-            <ebay-icon type="inline" name="close"/>
+            <ebay-icon name="close"/>
         </button>
         <div key="body" class="dialog__body">
             <${input.renderBody}/>

--- a/src/components/ebay-filter-menu-button/index.marko
+++ b/src/components/ebay-filter-menu-button/index.marko
@@ -1,4 +1,4 @@
-import processHtmlAttributes from "../../common/html-attributes";
+import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = [
     "variant",
@@ -28,7 +28,7 @@ static var ignoredAttributes = [
         aria-pressed=(state.isChecked.some(Boolean) && "true")>
         <span class="filter-menu-button__button-cell">
             <span class="filter-menu-button__button-text">${input.text}</span>
-            <ebay-icon type="inline" name="chevron-down"/>
+            <ebay-icon name="chevron-down"/>
         </span>
     </button>
     <ebay-filter-menu

--- a/src/components/ebay-filter-menu/index.marko
+++ b/src/components/ebay-filter-menu/index.marko
@@ -16,7 +16,6 @@ static var itemIgnoredAttributes = ["checked", "value"];
 
 $ var baseClass = input.classPrefix || "filter-menu";
 $ var isForm = input.variant === "form";
-
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
     key="container"
@@ -27,17 +26,14 @@ $ var isForm = input.variant === "form";
         action=input.formAction
         method=input.formMethod
         onSubmit("handleFormSubmit")>
-        <div
-            key="menu"
-            class=`${baseClass}__items`
-            role=(!isForm && "menu")>
+        <div key="menu" class=`${baseClass}__items` role=(!isForm && "menu")>
             <for|item, i| of=input.items>
                 $ var isChecked = state.isChecked[i];
                 <${isForm ? "label" : "div"}
                     ...processHtmlAttributes(item, itemIgnoredAttributes)
                     class=[`${baseClass}__item`, item.class]
                     role="menuitemcheckbox"
-                    aria-checked=(String(isChecked))
+                    aria-checked=String(isChecked)
                     for=(isForm && component.elId(`checkbox-${i}`))
                     onClick("handleItemClick", i)
                     onKeydown("handleItemKeydown", i)>
@@ -47,21 +43,19 @@ $ var isForm = input.variant === "form";
                     <else>
                         <span class=`${baseClass}__status`>
                             <if(isChecked)>
-                                <ebay-icon type="inline" name="checkbox-checked"/>
+                                <ebay-icon name="checkbox-checked"/>
                             </if>
                             <else>
-                                <ebay-icon type="inline" name="checkbox-unchecked"/>
+                                <ebay-icon name="checkbox-unchecked"/>
                             </else>
                         </span>
                     </else>
-
                     <span class=`${baseClass}__text`>
                         <${item.renderBody}/>
                     </span>
                 </>
             </for>
         </div>
-
         <if(input.footerText)>
             <button
                 type=(isForm ? "submit" : "button")

--- a/src/components/ebay-icon/marko-tag.json
+++ b/src/components/ebay-icon/marko-tag.json
@@ -1,6 +1,7 @@
 {
   "template": "./index.marko",
   "transformer": "./transformer.js",
+  "migrator": "./migrator.js",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-icon/migrator.js
+++ b/src/components/ebay-icon/migrator.js
@@ -1,0 +1,13 @@
+/**
+ * @description
+ * Removes type attribute.
+ */
+
+function migrator(el, context) {
+    if (el.hasAttribute('type')) {
+        context.deprecate('type attribute is no longer supported for icon. All icons default to inline now');
+        el.removeAttribute('type');
+    }
+}
+
+module.exports = migrator;

--- a/src/components/ebay-icon/test/test.server.js
+++ b/src/components/ebay-icon/test/test.server.js
@@ -67,7 +67,6 @@ describe('transformer', () => {
     });
 });
 
-
 describe('migrator', () => {
     const componentPath = '../index.js';
     function getTagString() {

--- a/src/components/ebay-icon/test/test.server.js
+++ b/src/components/ebay-icon/test/test.server.js
@@ -2,6 +2,7 @@ const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
 const { runTransformer } = require('../../../common/test-utils/server');
 const transformer = require('../transformer');
+const migrator = require('../migrator');
 const template = require('..');
 
 const iconName = 'mic';
@@ -63,5 +64,20 @@ describe('transformer', () => {
         const { el } = runTransformer(transformer, tagString, componentPath);
         const attr = el.getAttribute('_themes');
         expect(attr).to.have.property('name', '_themes');
+    });
+});
+
+
+describe('migrator', () => {
+    const componentPath = '../index.js';
+    function getTagString() {
+        return `<ebay-icon type="inline" name="${iconName}" />`;
+    }
+
+    it('removes type attribute', () => {
+        const tagString = getTagString();
+        const { el } = runTransformer(migrator, tagString, componentPath);
+        const attr = el.hasAttribute('type');
+        expect(attr).to.equal(false);
     });
 });

--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -1,4 +1,4 @@
-import processHtmlAttributes from "../../common/html-attributes";
+import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = [
     "icon",
@@ -17,7 +17,6 @@ static var ignoredAttributes = [
 ];
 
 $ var pointer = input.pointer || "bottom";
-
 <span>
     <ebay-tooltip-base
         type="infotip"
@@ -38,7 +37,7 @@ $ var pointer = input.pointer || "bottom";
                     <${input.iconTag}/>
                 </if>
                 <else>
-                    <ebay-icon type="inline" name="information"/>
+                    <ebay-icon name="information"/>
                 </else>
             </button>
             <ebay-tooltip-overlay

--- a/src/components/ebay-menu/examples/05-icons/template.marko
+++ b/src/components/ebay-menu/examples/05-icons/template.marko
@@ -1,5 +1,11 @@
 <ebay-menu>
-    <ebay-menu-item><ebay-icon name="confirmation" type="inline" style="margin-right: 8px"></ebay-icon>Item 1</ebay-menu-item>
-    <ebay-menu-item><ebay-icon name="attention" type="inline" style="margin-right: 8px"></ebay-icon>Item 2</ebay-menu-item>
-    <ebay-menu-item><ebay-icon name="information" type="inline" style="margin-right: 8px"></ebay-icon>Item 3</ebay-menu-item>
+    <ebay-menu-item>
+        <ebay-icon name="confirmation" style="margin-right: 8px"/>Item 1
+    </ebay-menu-item>
+    <ebay-menu-item>
+        <ebay-icon name="attention" style="margin-right: 8px"/>Item 2
+    </ebay-menu-item>
+    <ebay-menu-item>
+        <ebay-icon name="information" style="margin-right: 8px"/>Item 3
+    </ebay-menu-item>
 </ebay-menu>

--- a/src/components/ebay-notice/index.marko
+++ b/src/components/ebay-notice/index.marko
@@ -17,7 +17,6 @@ $ var isWindow = type === "window";
 $ var isCelebration = status === "celebration";
 $ var isPage = type === "page" || isSection || isWindow;
 $ var isLightGuidance = isSection && !input.status;
-
 <if(!state.hidden)>
     <${isPage ? "section" : "div"}
         ...processHtmlAttributes(input, ignoredAttributes)
@@ -36,7 +35,6 @@ $ var isLightGuidance = isSection && !input.status;
                 <if(isWindow && input.title)>
                     <ebay-icon
                         class="window-notice__icon"
-                        type="inline"
                         name="confirmation-filled"
                         aria-label=input.a11yHeadingText/>
                     <span
@@ -47,27 +45,17 @@ $ var isLightGuidance = isSection && !input.status;
                 </if>
                 <else>
                     <if(status === "confirmation" || status === "celebration")>
-                        <ebay-icon
-                            type="inline"
-                            name="confirmation-filled"
-                            aria-label=input.a11yHeadingText/>
+                        <ebay-icon name="confirmation-filled" aria-label=input.a11yHeadingText/>
                     </if>
                     <else if(status === "attention")>
-                        <ebay-icon
-                            type="inline"
-                            name="attention-filled"
-                            aria-label=input.a11yHeadingText/>
+                        <ebay-icon name="attention-filled" aria-label=input.a11yHeadingText/>
                     </else>
                     <else if(status === "information")>
-                        <ebay-icon
-                            type="inline"
-                            name="information-filled"
-                            aria-label=input.a11yHeadingText/>
+                        <ebay-icon name="information-filled" aria-label=input.a11yHeadingText/>
                     </else>
                 </else>
             </>
         </if>
-
         <${isPage ? "div" : "span"}
             ...(input.content && processHtmlAttributes(input.content))
             class=[
@@ -81,14 +69,11 @@ $ var isLightGuidance = isSection && !input.status;
                     <${input.title.renderBody}/>
                 </span>
             </if>
-
             <${input.content || input.renderBody}/>
         </>
-
         <if(input.content)>
             <${input.renderBody}/>
         </if>
-
         <if(input.dismissible)>
             <button
                 class="page-notice__close"

--- a/src/components/ebay-radio/index.marko
+++ b/src/components/ebay-radio/index.marko
@@ -11,13 +11,11 @@ static var ignoredAttributes = ["class", "style"];
         onFocus("handleFocus")/>
     <span class="radio__icon" hidden>
         <ebay-icon
-            type="inline"
             name="radio-unchecked"
             class="radio__unchecked"
             focusable="false"
             no-skin-classes/>
         <ebay-icon
-            type="inline"
             name="radio-checked"
             class="radio__checked"
             focusable="false"

--- a/src/components/ebay-section-title/index.marko
+++ b/src/components/ebay-section-title/index.marko
@@ -1,4 +1,4 @@
-import processHtmlAttributes from "../../common/html-attributes";
+import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = [
     "ctaText",
@@ -49,12 +49,9 @@ static var ignoredAttributes = [
         ]>
             <a href=input.href tabindex="-1" aria-hidden="true">
                 <if(input.ctaText)>
-                    <span class="section-title__cta-text">
-                        ${input.ctaText}
-                    </span>
+                    <span class="section-title__cta-text">${input.ctaText}</span>
                 </if>
                 <ebay-icon
-                    type="inline"
                     name="arrow-right-bold"
                     class="section-title__cta-icon"
                     no-skin-classes/>


### PR DESCRIPTION
## Description
* Added migrator for removing type attribute from `<ebay-icon>`. Added test to support it
* Ran `marko  migrate` in order to remove all type attributes from all code in ebay-ui

## Context
`marko migrate` also seemed to change a bit of the formatting. I left it in there since that I assume that is the look going forward 

## References
#1010
