### PR TITLE
Migrated skin-ds6 flag to ds-4

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = async ({ config }) => {
   });
 
   config.plugins.push(new BrowserJSONPlugin({
-    flags: process.env.DS === "4" ? [] : ['skin-ds6']
+    flags: process.env.DS === "4" ? ['ds-4'] : []
   }));
 
   return config;

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Marko v3 requires [Marko Widgets v6](https://github.com/marko-js/marko-widgets)\
 Marko v4 requires [Marko Widgets v7](https://github.com/marko-js/marko-widgets/tree/v7)*
 
-*Note: eBayUI Core components utilize Marko flags and, therefore, require `<lasso-page/>` to be added to any page which will have core components. eBayUI Core presently relies on the `skin-ds6` flag to toggle designs to use the Design System 6 version of Skin.*
+*Note: eBayUI Core components utilize Marko flags and, therefore, require `<lasso-page/>` to be added to any page which will have core components.*
 
 *Note: In order for spread attributes to work properly, `marko@3.14.5` or `marko@4.18.22` at least is required*
 

--- a/demo/browser.json
+++ b/demo/browser.json
@@ -5,7 +5,7 @@
         "./atom-light-syntax.css",
         "./style.less",
         {
-            "if-flag": "skin-ds6",
+            "if-not-flag": "ds-4",
             "dependencies": [
                 "@ebay/skin/marketsans"
             ]

--- a/demo/index.js
+++ b/demo/index.js
@@ -58,7 +58,7 @@ app.get('/:designSystem/:component?', (req, res) => {
         components: demoUtils.getComponentsWithExamples('src')
     };
 
-    const dsFlag = req.params.designSystem === 'ds6' ? 'skin-ds6' : '';
+    const dsFlag = req.params.designSystem === 'ds6' ? '' : 'ds-4';
     const lassoFlags = ['ebayui-no-bg-icons'];
 
     // allow .only in example folder name

--- a/integration/base.marko
+++ b/integration/base.marko
@@ -1,4 +1,4 @@
-<lasso-page name="integration" package-path="./browser.json" flags=["skin-ds6"]/>
+<lasso-page name="integration" package-path="./browser.json" flags=[]/>
 <html>
     <head>
         <lasso-head/>

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,8 +1,8 @@
 {
   "flagSets": {
     "Theme": {
-      "DS6": ["skin-ds6"],
-      "DS4": []
+      "DS6": [],
+      "DS4": ["ds-4"]
     }
   }
 }

--- a/marko-cli.js
+++ b/marko-cli.js
@@ -6,7 +6,7 @@ const buildID = `${process.env.TRAVIS_BUILD_NUMBER}.${process.env.TRAVIS_JOB_NUM
 module.exports = ({ config }) => {
     config.mochaOptions = { timeout: 20000 };
     config.lassoOptions = {
-        flags: ['skin-ds6'],
+        flags: [],
         plugins: ['lasso-less'],
         require: isTravis && {
             transforms: [{

--- a/scripts/import-svg/index.js
+++ b/scripts/import-svg/index.js
@@ -19,11 +19,11 @@ const missingSVG = prettier.format(fs.readFileSync(path.join(__dirname, 'missing
 const icons = new Map();
 const THEMES = {
     ds4: {
-        flags: { 'if-not-flag': 'skin-ds6' },
+        flags: { 'if-flag': 'ds-4' },
         file: './index.marko'
     },
     ds6: {
-        flags: { 'if-flag': 'skin-ds6' },
+        flags: { 'if-not-flag': 'ds-4' },
         file: './index[skin-ds6].marko'
     }
 };

--- a/src/components/ebay-icon/index.marko
+++ b/src/components/ebay-icon/index.marko
@@ -36,7 +36,7 @@ $ var a11yAttributes = input.a11yText ? { role: "img" } : { "aria-hidden": "true
                     // Actual magic, please do not try to replicate.
                     var lassoContext = out.global["lasso/LassoRenderContext"];
                     var flags = lassoContext && lassoContext.data.config.flags;
-                    theme = themes[flags && flags.indexOf("skin-ds6") !== -1 ? 1 : 0];
+                    theme = themes[flags && flags.indexOf("ds-4") !== -1 ? 0 : 1];
                 }
             }
 

--- a/src/components/ebay-icon/symbols/add-small/browser.json
+++ b/src/components/ebay-icon/symbols/add-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/add/browser.json
+++ b/src/components/ebay-icon/symbols/add/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/alert/browser.json
+++ b/src/components/ebay-icon/symbols/alert/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-down/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-down/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-left-small/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-left-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-left/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-left/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-move-small/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-move-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-move/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-move/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-right-bold/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-right-bold/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-right-small/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-right-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-right/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-right/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/arrow-up/browser.json
+++ b/src/components/ebay-icon/symbols/arrow-up/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/attention-filled-small/browser.json
+++ b/src/components/ebay-icon/symbols/attention-filled-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/attention-filled/browser.json
+++ b/src/components/ebay-icon/symbols/attention-filled/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/attention-small/browser.json
+++ b/src/components/ebay-icon/symbols/attention-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/attention/browser.json
+++ b/src/components/ebay-icon/symbols/attention/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/auction/browser.json
+++ b/src/components/ebay-icon/symbols/auction/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/autocomplete/browser.json
+++ b/src/components/ebay-icon/symbols/autocomplete/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/back/browser.json
+++ b/src/components/ebay-icon/symbols/back/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/best-offer/browser.json
+++ b/src/components/ebay-icon/symbols/best-offer/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/bids/browser.json
+++ b/src/components/ebay-icon/symbols/bids/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/bold/browser.json
+++ b/src/components/ebay-icon/symbols/bold/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/box/browser.json
+++ b/src/components/ebay-icon/symbols/box/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/breadcrumb/browser.json
+++ b/src/components/ebay-icon/symbols/breadcrumb/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/bulleted-list/browser.json
+++ b/src/components/ebay-icon/symbols/bulleted-list/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/call/browser.json
+++ b/src/components/ebay-icon/symbols/call/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/camera-small/browser.json
+++ b/src/components/ebay-icon/symbols/camera-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/camera/browser.json
+++ b/src/components/ebay-icon/symbols/camera/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/carousel-next/browser.json
+++ b/src/components/ebay-icon/symbols/carousel-next/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/carousel-prev/browser.json
+++ b/src/components/ebay-icon/symbols/carousel-prev/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/cart-null/browser.json
+++ b/src/components/ebay-icon/symbols/cart-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/cart-small/browser.json
+++ b/src/components/ebay-icon/symbols/cart-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/cart/browser.json
+++ b/src/components/ebay-icon/symbols/cart/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/categories/browser.json
+++ b/src/components/ebay-icon/symbols/categories/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/caution-null/browser.json
+++ b/src/components/ebay-icon/symbols/caution-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/center-aligned/browser.json
+++ b/src/components/ebay-icon/symbols/center-aligned/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/center-justified/browser.json
+++ b/src/components/ebay-icon/symbols/center-justified/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chat/browser.json
+++ b/src/components/ebay-icon/symbols/chat/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/check/browser.json
+++ b/src/components/ebay-icon/symbols/check/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/checkbox-checked-small/browser.json
+++ b/src/components/ebay-icon/symbols/checkbox-checked-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/checkbox-checked/browser.json
+++ b/src/components/ebay-icon/symbols/checkbox-checked/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/checkbox-unchecked-small/browser.json
+++ b/src/components/ebay-icon/symbols/checkbox-unchecked-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/checkbox-unchecked/browser.json
+++ b/src/components/ebay-icon/symbols/checkbox-unchecked/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/checkout-complete/browser.json
+++ b/src/components/ebay-icon/symbols/checkout-complete/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-down-bold/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-down-bold/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-down-small/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-down-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-down/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-down/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-left-small/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-left-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-left/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-left/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-light-left/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-light-left/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-light-right/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-light-right/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-right-small/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-right-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-right/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-right/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-up-bold/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-up-bold/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-up-small/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-up-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/chevron-up/browser.json
+++ b/src/components/ebay-icon/symbols/chevron-up/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/classified-ad/browser.json
+++ b/src/components/ebay-icon/symbols/classified-ad/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/clear-small/browser.json
+++ b/src/components/ebay-icon/symbols/clear-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/clear/browser.json
+++ b/src/components/ebay-icon/symbols/clear/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/clock-small/browser.json
+++ b/src/components/ebay-icon/symbols/clock-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/clock/browser.json
+++ b/src/components/ebay-icon/symbols/clock/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/close-small/browser.json
+++ b/src/components/ebay-icon/symbols/close-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/close/browser.json
+++ b/src/components/ebay-icon/symbols/close/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/collections-null/browser.json
+++ b/src/components/ebay-icon/symbols/collections-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/comments/browser.json
+++ b/src/components/ebay-icon/symbols/comments/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/confirmation-filled-small/browser.json
+++ b/src/components/ebay-icon/symbols/confirmation-filled-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/confirmation-filled/browser.json
+++ b/src/components/ebay-icon/symbols/confirmation-filled/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/confirmation-small/browser.json
+++ b/src/components/ebay-icon/symbols/confirmation-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/confirmation/browser.json
+++ b/src/components/ebay-icon/symbols/confirmation/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/cta/browser.json
+++ b/src/components/ebay-icon/symbols/cta/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/deals/browser.json
+++ b/src/components/ebay-icon/symbols/deals/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/delete-small/browser.json
+++ b/src/components/ebay-icon/symbols/delete-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/delete/browser.json
+++ b/src/components/ebay-icon/symbols/delete/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/download/browser.json
+++ b/src/components/ebay-icon/symbols/download/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/dropdown/browser.json
+++ b/src/components/ebay-icon/symbols/dropdown/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/edit-small/browser.json
+++ b/src/components/ebay-icon/symbols/edit-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/edit/browser.json
+++ b/src/components/ebay-icon/symbols/edit/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/event/browser.json
+++ b/src/components/ebay-icon/symbols/event/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/fast-n-free-small/browser.json
+++ b/src/components/ebay-icon/symbols/fast-n-free-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/fast-n-free/browser.json
+++ b/src/components/ebay-icon/symbols/fast-n-free/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/feedback-negative/browser.json
+++ b/src/components/ebay-icon/symbols/feedback-negative/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/feedback-neutral/browser.json
+++ b/src/components/ebay-icon/symbols/feedback-neutral/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/feedback-null/browser.json
+++ b/src/components/ebay-icon/symbols/feedback-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/feedback-positive/browser.json
+++ b/src/components/ebay-icon/symbols/feedback-positive/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/filter-gallery-small/browser.json
+++ b/src/components/ebay-icon/symbols/filter-gallery-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/filter-gallery/browser.json
+++ b/src/components/ebay-icon/symbols/filter-gallery/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/filter-list-small/browser.json
+++ b/src/components/ebay-icon/symbols/filter-list-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/filter-list/browser.json
+++ b/src/components/ebay-icon/symbols/filter-list/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/filter-single-small/browser.json
+++ b/src/components/ebay-icon/symbols/filter-single-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/filter-single/browser.json
+++ b/src/components/ebay-icon/symbols/filter-single/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/fire/browser.json
+++ b/src/components/ebay-icon/symbols/fire/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/fixed-price/browser.json
+++ b/src/components/ebay-icon/symbols/fixed-price/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/flag/browser.json
+++ b/src/components/ebay-icon/symbols/flag/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/follow/browser.json
+++ b/src/components/ebay-icon/symbols/follow/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/following-small/browser.json
+++ b/src/components/ebay-icon/symbols/following-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/following/browser.json
+++ b/src/components/ebay-icon/symbols/following/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/glasses-null/browser.json
+++ b/src/components/ebay-icon/symbols/glasses-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/help/browser.json
+++ b/src/components/ebay-icon/symbols/help/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/home/browser.json
+++ b/src/components/ebay-icon/symbols/home/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/information-filled-small/browser.json
+++ b/src/components/ebay-icon/symbols/information-filled-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/information-filled/browser.json
+++ b/src/components/ebay-icon/symbols/information-filled/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/information-small/browser.json
+++ b/src/components/ebay-icon/symbols/information-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/information/browser.json
+++ b/src/components/ebay-icon/symbols/information/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/italic/browser.json
+++ b/src/components/ebay-icon/symbols/italic/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/item-feedback/browser.json
+++ b/src/components/ebay-icon/symbols/item-feedback/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/item-paid/browser.json
+++ b/src/components/ebay-icon/symbols/item-paid/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/item-shipped/browser.json
+++ b/src/components/ebay-icon/symbols/item-shipped/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/justified/browser.json
+++ b/src/components/ebay-icon/symbols/justified/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/left-aligned/browser.json
+++ b/src/components/ebay-icon/symbols/left-aligned/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/left-justified/browser.json
+++ b/src/components/ebay-icon/symbols/left-justified/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/link/browser.json
+++ b/src/components/ebay-icon/symbols/link/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/magnify/browser.json
+++ b/src/components/ebay-icon/symbols/magnify/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/mail-open/browser.json
+++ b/src/components/ebay-icon/symbols/mail-open/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/mail/browser.json
+++ b/src/components/ebay-icon/symbols/mail/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/menu/browser.json
+++ b/src/components/ebay-icon/symbols/menu/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/messages-open/browser.json
+++ b/src/components/ebay-icon/symbols/messages-open/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/messages/browser.json
+++ b/src/components/ebay-icon/symbols/messages/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/mic-small/browser.json
+++ b/src/components/ebay-icon/symbols/mic-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/mic/browser.json
+++ b/src/components/ebay-icon/symbols/mic/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/minus/browser.json
+++ b/src/components/ebay-icon/symbols/minus/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/notification-null/browser.json
+++ b/src/components/ebay-icon/symbols/notification-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/notification/browser.json
+++ b/src/components/ebay-icon/symbols/notification/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/notifications-null/browser.json
+++ b/src/components/ebay-icon/symbols/notifications-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/notifications/browser.json
+++ b/src/components/ebay-icon/symbols/notifications/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/null-cart/browser.json
+++ b/src/components/ebay-icon/symbols/null-cart/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/null-search/browser.json
+++ b/src/components/ebay-icon/symbols/null-search/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/null-wallet/browser.json
+++ b/src/components/ebay-icon/symbols/null-wallet/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/null-watch/browser.json
+++ b/src/components/ebay-icon/symbols/null-watch/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/numbered-list/browser.json
+++ b/src/components/ebay-icon/symbols/numbered-list/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/overflow-small/browser.json
+++ b/src/components/ebay-icon/symbols/overflow-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/overflow/browser.json
+++ b/src/components/ebay-icon/symbols/overflow/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/pagination-next/browser.json
+++ b/src/components/ebay-icon/symbols/pagination-next/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/pagination-prev/browser.json
+++ b/src/components/ebay-icon/symbols/pagination-prev/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/part-paid/browser.json
+++ b/src/components/ebay-icon/symbols/part-paid/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/pause/browser.json
+++ b/src/components/ebay-icon/symbols/pause/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/payment-refunded/browser.json
+++ b/src/components/ebay-icon/symbols/payment-refunded/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/pencil-null/browser.json
+++ b/src/components/ebay-icon/symbols/pencil-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/photo-brightness/browser.json
+++ b/src/components/ebay-icon/symbols/photo-brightness/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/photo-crop/browser.json
+++ b/src/components/ebay-icon/symbols/photo-crop/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/photo-gallery-more/browser.json
+++ b/src/components/ebay-icon/symbols/photo-gallery-more/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/photo-gallery/browser.json
+++ b/src/components/ebay-icon/symbols/photo-gallery/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/photo-rotate/browser.json
+++ b/src/components/ebay-icon/symbols/photo-rotate/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/photo-select-all/browser.json
+++ b/src/components/ebay-icon/symbols/photo-select-all/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/photo-select-none/browser.json
+++ b/src/components/ebay-icon/symbols/photo-select-none/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/pictures-null/browser.json
+++ b/src/components/ebay-icon/symbols/pictures-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/play/browser.json
+++ b/src/components/ebay-icon/symbols/play/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/priority/browser.json
+++ b/src/components/ebay-icon/symbols/priority/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/profile/browser.json
+++ b/src/components/ebay-icon/symbols/profile/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/purchases/browser.json
+++ b/src/components/ebay-icon/symbols/purchases/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/radio-checked-small/browser.json
+++ b/src/components/ebay-icon/symbols/radio-checked-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/radio-checked/browser.json
+++ b/src/components/ebay-icon/symbols/radio-checked/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/radio-unchecked-small/browser.json
+++ b/src/components/ebay-icon/symbols/radio-unchecked-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/radio-unchecked/browser.json
+++ b/src/components/ebay-icon/symbols/radio-unchecked/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/red-laser-small/browser.json
+++ b/src/components/ebay-icon/symbols/red-laser-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/red-laser/browser.json
+++ b/src/components/ebay-icon/symbols/red-laser/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/refresh/browser.json
+++ b/src/components/ebay-icon/symbols/refresh/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/relisted/browser.json
+++ b/src/components/ebay-icon/symbols/relisted/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/requested-total/browser.json
+++ b/src/components/ebay-icon/symbols/requested-total/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/right-aligned/browser.json
+++ b/src/components/ebay-icon/symbols/right-aligned/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/right-justified/browser.json
+++ b/src/components/ebay-icon/symbols/right-justified/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/save-bold/browser.json
+++ b/src/components/ebay-icon/symbols/save-bold/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/save-selected-small/browser.json
+++ b/src/components/ebay-icon/symbols/save-selected-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/save-selected/browser.json
+++ b/src/components/ebay-icon/symbols/save-selected/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/save-small/browser.json
+++ b/src/components/ebay-icon/symbols/save-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/save/browser.json
+++ b/src/components/ebay-icon/symbols/save/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/search-bold/browser.json
+++ b/src/components/ebay-icon/symbols/search-bold/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/search-null/browser.json
+++ b/src/components/ebay-icon/symbols/search-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/search-small/browser.json
+++ b/src/components/ebay-icon/symbols/search-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/search/browser.json
+++ b/src/components/ebay-icon/symbols/search/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/second-chance/browser.json
+++ b/src/components/ebay-icon/symbols/second-chance/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/sell-null/browser.json
+++ b/src/components/ebay-icon/symbols/sell-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/seller-feedback/browser.json
+++ b/src/components/ebay-icon/symbols/seller-feedback/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/selling-null/browser.json
+++ b/src/components/ebay-icon/symbols/selling-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/selling/browser.json
+++ b/src/components/ebay-icon/symbols/selling/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/send/browser.json
+++ b/src/components/ebay-icon/symbols/send/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/settings/browser.json
+++ b/src/components/ebay-icon/symbols/settings/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/shopping-null/browser.json
+++ b/src/components/ebay-icon/symbols/shopping-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/sign-out/browser.json
+++ b/src/components/ebay-icon/symbols/sign-out/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/sort/browser.json
+++ b/src/components/ebay-icon/symbols/sort/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-empty/browser.json
+++ b/src/components/ebay-icon/symbols/star-empty/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-filled-empty-small/browser.json
+++ b/src/components/ebay-icon/symbols/star-filled-empty-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-filled-grey/browser.json
+++ b/src/components/ebay-icon/symbols/star-filled-grey/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-filled-small/browser.json
+++ b/src/components/ebay-icon/symbols/star-filled-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-filled/browser.json
+++ b/src/components/ebay-icon/symbols/star-filled/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-half-small/browser.json
+++ b/src/components/ebay-icon/symbols/star-half-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-half/browser.json
+++ b/src/components/ebay-icon/symbols/star-half/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-small/browser.json
+++ b/src/components/ebay-icon/symbols/star-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star-undefined/browser.json
+++ b/src/components/ebay-icon/symbols/star-undefined/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/star/browser.json
+++ b/src/components/ebay-icon/symbols/star/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/strike-thru/browser.json
+++ b/src/components/ebay-icon/symbols/strike-thru/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/success/browser.json
+++ b/src/components/ebay-icon/symbols/success/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/tag/browser.json
+++ b/src/components/ebay-icon/symbols/tag/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/thumbs-down-selected-small/browser.json
+++ b/src/components/ebay-icon/symbols/thumbs-down-selected-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/thumbs-down-selected/browser.json
+++ b/src/components/ebay-icon/symbols/thumbs-down-selected/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/thumbs-down-small/browser.json
+++ b/src/components/ebay-icon/symbols/thumbs-down-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/thumbs-down/browser.json
+++ b/src/components/ebay-icon/symbols/thumbs-down/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/thumbs-up-selected-small/browser.json
+++ b/src/components/ebay-icon/symbols/thumbs-up-selected-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/thumbs-up-selected/browser.json
+++ b/src/components/ebay-icon/symbols/thumbs-up-selected/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/thumbs-up-small/browser.json
+++ b/src/components/ebay-icon/symbols/thumbs-up-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/thumbs-up/browser.json
+++ b/src/components/ebay-icon/symbols/thumbs-up/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/tick-small/browser.json
+++ b/src/components/ebay-icon/symbols/tick-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/tick/browser.json
+++ b/src/components/ebay-icon/symbols/tick/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/top-seller/browser.json
+++ b/src/components/ebay-icon/symbols/top-seller/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/trash/browser.json
+++ b/src/components/ebay-icon/symbols/trash/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/truck-small/browser.json
+++ b/src/components/ebay-icon/symbols/truck-small/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/truck/browser.json
+++ b/src/components/ebay-icon/symbols/truck/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/underline/browser.json
+++ b/src/components/ebay-icon/symbols/underline/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/user-profile/browser.json
+++ b/src/components/ebay-icon/symbols/user-profile/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/view-detail/browser.json
+++ b/src/components/ebay-icon/symbols/view-detail/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/view-grid/browser.json
+++ b/src/components/ebay-icon/symbols/view-grid/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/view-list/browser.json
+++ b/src/components/ebay-icon/symbols/view-list/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/watch/browser.json
+++ b/src/components/ebay-icon/symbols/watch/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/watching-null/browser.json
+++ b/src/components/ebay-icon/symbols/watching-null/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }

--- a/src/components/ebay-icon/symbols/window/browser.json
+++ b/src/components/ebay-icon/symbols/window/browser.json
@@ -3,12 +3,12 @@
     {
       "from": "./index[skin-ds6].marko",
       "to": "./index.marko",
-      "if-not-flag": "skin-ds6"
+      "if-flag": "ds-4"
     },
     {
       "from": "./index.marko",
       "to": "./index[skin-ds6].marko",
-      "if-flag": "skin-ds6"
+      "if-not-flag": "ds-4"
     }
   ]
 }


### PR DESCRIPTION
## Description
Switched flag of `skin-ds6` to `ds-4` flag. This is to support skin 10's switch to DS6. 