### PR TITLE
Changed events of order so blur gets fired after keyup/down

### DIFF
--- a/src/components/ebay-combobox/template.marko
+++ b/src/components/ebay-combobox/template.marko
@@ -31,9 +31,9 @@
             disabled=data.disabled
             aria-autocomplete=data.autocomplete
             aria-haspopup='listbox'
-            w-on-blur='handleComboboxBlur'
             w-on-keydown='handleComboboxKeyDown'
             w-on-keyup='handleComboboxKeyUp'
+            w-on-blur='handleComboboxBlur'
             autocomplete="new-password"
             w-preserve-attrs="aria-controls,aria-activedescendant,aria-owns,aria-expanded"
             ${processHtmlAttributes(data, ignoredAttributes)}/>


### PR DESCRIPTION
## Description
Since blur happened before keyup, there was a chance that it would complete before keyup did. So I changed the order so that blur came after keyup in the template
Also I tested it locally and saw that the change event was getting fired properly with the right text.

## References
#1026 