### PR TITLE
Fixed dialog focus and menu item badge layout

### DIFF
--- a/src/components/ebay-dialog/component.js
+++ b/src/components/ebay-dialog/component.js
@@ -82,7 +82,7 @@ module.exports = {
         const isTrapped = this.isTrapped = this.state.open;
         const isFirstRender = (opts && opts.firstRender);
         const wasToggled = isTrapped !== wasTrapped;
-        const focusEl = (this.state.focus && document.getElementById(this.state.focus)) || this.closeEl;
+        const focusEl = (this.input.focus && document.getElementById(this.input.focus)) || this.closeEl;
 
         if (restoreTrap || (isTrapped && !wasTrapped)) {
             screenReaderTrap.trap(this.windowEl);

--- a/src/components/ebay-menu/index.marko
+++ b/src/components/ebay-menu/index.marko
@@ -66,15 +66,12 @@ $ var baseClass = input.classPrefix || (isFake ? "fake-menu" : "menu");
                 onKeypress("handleItemKeypress")
                 key="item[]">
                 <span>
-                    <${!item.badgeNumber ? null : "span"} aria-hidden="true">
-                        <span>
-                            <${item.renderBody}/>
-                        </span>
-                        <if(item.badgeNumber)>
-                            <ebay-badge type="menu" number=item.badgeNumber/>
-                        </if>
-                    </>
+                    <${item.renderBody}/>
                 </span>
+                <if(item.badgeNumber)>
+                    <ebay-badge type="menu" number=item.badgeNumber/>
+                </if>
+
                 <ebay-icon name="tick-small" />
             </>
         </for>


### PR DESCRIPTION
## Description
* For dialog, fixed focus by changing dialog state to input. 
* For menu badge layout (see https://github.com/eBay/skin/pull/1016). Basically made badge to be an immediate child of menu item so it picks up flex styles. 

## References
#1039 
#1048 

## Screenshots
<img width="760" alt="image" src="https://user-images.githubusercontent.com/1755269/73711617-485be780-46bc-11ea-8a6d-f4e8f319acfa.png">

