### PR TITLE
Updated carousel mask class to viewport

### DIFF
--- a/src/components/ebay-carousel/index.marko
+++ b/src/components/ebay-carousel/index.marko
@@ -51,10 +51,11 @@ $ var data = component.getTemplateData(state, input);
             </button>
         </if>
         <div class=[
+            "carousel__viewport",
             !data.itemsPerSlide &&
             !data.nextControlDisabled &&
             !data.autoplayInterval &&
-                "carousel__mask"]>
+                "carousel__viewport--mask"]>
             <ul
                 class="carousel__list"
                 style=(


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
This is the ebayui change for the skin carousel cleanup PR (https://github.com/eBay/skin/pull/1017) in order to update the classes to match the new class names. 

## References
https://github.com/eBay/skin/pull/1017

## Screenshots
Just for fun
<img width="1586" alt="image" src="https://user-images.githubusercontent.com/1755269/73773882-d88b4280-4737-11ea-8140-bc06140f4ac9.png">
