### PR TITLE
Fixed error when combobox has no options

### DIFF
--- a/src/components/ebay-combobox/index.js
+++ b/src/components/ebay-combobox/index.js
@@ -130,7 +130,9 @@ module.exports = require('marko-widgets').defineComponent({
         const newValue = this.inputEl.value;
 
         eventUtils.handleTextInput(originalEvent, () => {
-            this.activeDescendant.reset();
+            if (this.activeDescendant) {
+                this.activeDescendant.reset();
+            }
             this.inputEl.value = newValue;
             this.setState('currentValue', newValue);
             this.setSelectedIndex();

--- a/src/components/ebay-combobox/test/test.browser.js
+++ b/src/components/ebay-combobox/test/test.browser.js
@@ -166,6 +166,28 @@ describe('given the combobox starts with zero options', () => {
         });
     });
 
+    describe('when the input receives keyup with no options', () => {
+        beforeEach(async() => {
+            await pressKey(component.getByRole('combobox'), {
+                key: 'A',
+                keyCode: 65
+            });
+        });
+
+        it('then it should emit a input event', () => {
+            expect(component.emitted('combobox-input')).has.length(1);
+        });
+        describe('when blur happens on the combobox', () => {
+            beforeEach(async() => {
+                await fireEvent.blur(component.getByRole('combobox'));
+            });
+
+            it('then it should emit a change event', () => {
+                expect(component.emitted('combobox-change')).has.length(1);
+            });
+        });
+    });
+
     describe('when it is rerendered with 3 items', () => {
         const newInput = mock.Combobox_3Options;
 


### PR DESCRIPTION
## Description
Added a check to see if `this.activeDescendant`. Also added a test to verify that empty combobox events work. (Test failed without this change)

## References
#1059 

