### PR TITLE
Fixed template to now rerender button but only content

### DIFF
--- a/src/components/ebay-carousel/template.marko
+++ b/src/components/ebay-carousel/template.marko
@@ -65,24 +65,18 @@
         </button>
 
         <if(data.autoplayInterval && !data.bothControlsDisabled)>
-            <if(data.paused)>
-                <button
-                    class="carousel__playback"
-                    type="button"
-                    aria-label=data.a11yPlayText
-                    w-onclick="togglePlay">
-                    <ebay-icon type="inline" name="play"/>
-                </button>
-            </if>
-            <else>
-                <button
-                    class="carousel__playback"
-                    type="button"
-                    aria-label=data.a11yPauseText
-                    w-onclick="togglePlay">
-                    <ebay-icon type="inline" name="pause"/>
-                </button>
-            </else>
+            <button
+                class="carousel__playback"
+                type="button"
+                aria-label=(data.paused ? data.a11yPlayText : data.a11yPauseText)
+                w-onclick="togglePlay">
+                <if (data.paused)>
+                    <ebay-icon type="inline" name="play" />
+                </if>
+                <else>
+                    <ebay-icon type="inline" name="pause" />
+                </else>
+            </button>
         </if>
     </div>
 


### PR DESCRIPTION

## Description
Changed template to not rerender button. This makes it so focus stays on it. Only change the attributes of the template. 
This change is also needed in 5.0 branch

## Context
I could add focus but this does it automatically. 

## References.
#1060 
