### PR TITLE
Added an option collapseOnSelect to close menu on option selection

### DIFF
--- a/marko.json
+++ b/marko.json
@@ -443,6 +443,7 @@
     "@priority": "string",
     "@iconTag <icon>": {},
     "@disabled": "boolean",
+    "@collapseOnSelect": "boolean",
     "@variant": "string",
     "@items <item>[]": {
       "@*": {

--- a/src/components/ebay-menu-button/README.md
+++ b/src/components/ebay-menu-button/README.md
@@ -32,6 +32,7 @@ Name | Type | Stateful | Required | Description
 `checked` (radio) | Number | Yes | No | will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup
 `disabled` | Boolean | Yes | No | Will disable the entire dropdown (disables the ebay-button label) if set to true
 `variant` | String | No | No | will change the button style, "overflow" / "default"
+`collapseOnSelect` | Boolean | Yes | No | Will collapse whole menu when an item is selected in menu. Only works when `type="radio"`
 
 ### ebay-menu-button Events
 

--- a/src/components/ebay-menu-button/README.md
+++ b/src/components/ebay-menu-button/README.md
@@ -32,7 +32,7 @@ Name | Type | Stateful | Required | Description
 `checked` (radio) | Number | Yes | No | will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup
 `disabled` | Boolean | Yes | No | Will disable the entire dropdown (disables the ebay-button label) if set to true
 `variant` | String | No | No | will change the button style, "overflow" / "default"
-`collapseOnSelect` | Boolean | Yes | No | Will collapse whole menu when an item is selected in menu. Only works when `type="radio"`
+`collapseOnSelect` | Boolean | Yes | No | Will collapse whole menu when an item is selected in menu. Typically used in `type="radio"`
 
 ### ebay-menu-button Events
 

--- a/src/components/ebay-menu-button/index.js
+++ b/src/components/ebay-menu-button/index.js
@@ -46,6 +46,9 @@ module.exports = require('marko-widgets').defineComponent({
                 eventType: 'change',
                 el: itemEl
             });
+            if (this.state.collapseOnSelect) {
+                this.expander.collapse();
+            }
         } else if (this.state.type !== 'radio') {
             item.checked = !item.checked;
             this.setStateDirty('items');

--- a/src/components/ebay-menu-button/index.js
+++ b/src/components/ebay-menu-button/index.js
@@ -56,6 +56,9 @@ module.exports = require('marko-widgets').defineComponent({
                 eventType: this.state.type === 'fake' || !this.state.type ? 'select' : 'change',
                 el: itemEl
             });
+            if (this.state.collapseOnSelect) {
+                this.expander.collapse();
+            }
         }
 
         if (this.rovingTabindex) {


### PR DESCRIPTION
## Description
Added an option to auto collapse on click. I added an option because some teams might not want to automatically collapse since it does not always reflect your changes (and I think some teams update their content after the menu is closed)
This also does not make it a breaking change. 

## References
#1058 

## Screenshots
![menu-collapse](https://user-images.githubusercontent.com/1755269/74773591-00ee6300-5247-11ea-8bb6-5adb4ced1a2a.gif)

