### PR TITLE
Added details component

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Each layer does its bit to enforce and enhance accessibility. We consider this l
 * [`ebay-checkbox`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-checkbox)
 * [`ebay-combobox`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-combobox)
 * [`ebay-cta-button`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-cta-button)
+* [`ebay-details`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-details)
 * [`ebay-dialog`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-dialog)
 * [`ebay-expand-button`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-expand-button)
 * [`ebay-filter`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-filter)

--- a/src/components/ebay-details/README.md
+++ b/src/components/ebay-details/README.md
@@ -20,4 +20,4 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`details-toggle` |  | details toggled
+`details-toggle` | `{ originalEvent, open }` | details toggled. Open is boolean if true then details was opened, otherwise false means details closed

--- a/src/components/ebay-details/README.md
+++ b/src/components/ebay-details/README.md
@@ -1,0 +1,24 @@
+# ebay-details
+
+```marko
+<ebay-details open text="Show me the details">
+    The details
+</ebay-details>
+```
+
+## Attributes
+
+Name | Type | Stateful | Required | Description
+--- | --- | --- | --- | ---
+`text` | String | No | No | The text to display in the details toggle
+`type` | String | No | No | Can be "regular" / "center". Default "regular"
+`size` | String | No | No | Can be "regular" / "small". Default "regular"
+`open` | Boolean | Yes | No | Whether details is open.
+`rtl` | Boolean | Yes | No | Display details on the right side for right to left languages.
+
+## Events
+
+Event | Data | Description
+--- | --- | ---
+`details-open` |  | details opened
+`details-close` |  | details closed

--- a/src/components/ebay-details/README.md
+++ b/src/components/ebay-details/README.md
@@ -13,12 +13,11 @@ Name | Type | Stateful | Required | Description
 `text` | String | No | No | The text to display in the details toggle
 `type` | String | No | No | Can be "regular" / "center". Default "regular"
 `size` | String | No | No | Can be "regular" / "small". Default "regular"
-`open` | Boolean | Yes | No | Whether details is open.
-`rtl` | Boolean | Yes | No | Display details on the right side for right to left languages.
+`open` | Boolean | No | No | Whether details is open.
+`rtl` | Boolean | No | No | Display details on the right side for right to left languages.
 
 ## Events
 
 Event | Data | Description
 --- | --- | ---
-`details-open` |  | details opened
-`details-close` |  | details closed
+`details-toggle` |  | details toggled

--- a/src/components/ebay-details/README.md
+++ b/src/components/ebay-details/README.md
@@ -21,3 +21,4 @@ Name | Type | Stateful | Required | Description
 Event | Data | Description
 --- | --- | ---
 `details-toggle` | `{ originalEvent, open }` | details toggled. Open is boolean if true then details was opened, otherwise false means details closed
+`details-click` | `{ originalEvent }` | details clicked

--- a/src/components/ebay-details/browser.json
+++ b/src/components/ebay-details/browser.json
@@ -1,0 +1,10 @@
+{
+    "dependencies": [
+        {
+            "if-not-flag": "ebayui-no-skin",
+            "dependencies": [
+                "@ebay/skin/details"
+            ]
+        }
+    ]
+}

--- a/src/components/ebay-details/component.js
+++ b/src/components/ebay-details/component.js
@@ -1,0 +1,14 @@
+module.exports = {
+    onInput(input) {
+        this.state = { open: input.open || false };
+    },
+
+    toggleDetails() {
+        if (!this.state.open) {
+            this.emit('details-open');
+        } else {
+            this.emit('details-close');
+        }
+        this.state.open = !this.state.open;
+    }
+};

--- a/src/components/ebay-details/component.js
+++ b/src/components/ebay-details/component.js
@@ -1,5 +1,8 @@
 module.exports = {
     toggleDetails(ev) {
         this.emit('details-toggle', { originalEvent: ev, open: this.getEl('root').open });
+    },
+    clickDetails(ev) {
+        this.emit('details-click', { originalEvent: ev });
     }
 };

--- a/src/components/ebay-details/component.js
+++ b/src/components/ebay-details/component.js
@@ -1,5 +1,8 @@
 module.exports = {
-    toggleDetails() {
-        this.emit('details-toggle');
+    onUpdate() {
+        this.getEl('root').open = this.input.open;
+    },
+    toggleDetails(ev) {
+        this.emit('details-toggle', { originalEvent: ev, open: this.getEl('root').open });
     }
 };

--- a/src/components/ebay-details/component.js
+++ b/src/components/ebay-details/component.js
@@ -1,14 +1,5 @@
 module.exports = {
-    onInput(input) {
-        this.state = { open: input.open || false };
-    },
-
     toggleDetails() {
-        if (!this.state.open) {
-            this.emit('details-open');
-        } else {
-            this.emit('details-close');
-        }
-        this.state.open = !this.state.open;
+        this.emit('details-toggle');
     }
 };

--- a/src/components/ebay-details/component.js
+++ b/src/components/ebay-details/component.js
@@ -1,7 +1,4 @@
 module.exports = {
-    onUpdate() {
-        this.getEl('root').open = this.input.open;
-    },
     toggleDetails(ev) {
         this.emit('details-toggle', { originalEvent: ev, open: this.getEl('root').open });
     }

--- a/src/components/ebay-details/component.js
+++ b/src/components/ebay-details/component.js
@@ -1,15 +1,6 @@
 module.exports = {
-    onInput(input) {
-        this.isOpen = input.open;
-    },
-    onUpdate() {
-        this.isOpen = this.getEl('root').open;
-    },
     toggleDetails(ev) {
-        if (this.isOpen !== this.getEl('root').open) {
-            this.isOpen = this.getEl('root').open;
-            this.emit('details-toggle', { originalEvent: ev, open: this.getEl('root').open });
-        }
+        this.emit('details-toggle', { originalEvent: ev, open: this.getEl('root').open });
     },
     clickDetails(ev) {
         this.emit('details-click', { originalEvent: ev });

--- a/src/components/ebay-details/examples/01-basic/template.marko
+++ b/src/components/ebay-details/examples/01-basic/template.marko
@@ -1,4 +1,4 @@
-<ebay-details text="detals">
+<ebay-details text="details">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.

--- a/src/components/ebay-details/examples/01-basic/template.marko
+++ b/src/components/ebay-details/examples/01-basic/template.marko
@@ -1,0 +1,6 @@
+<ebay-details text="detals">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+</ebay-details>

--- a/src/components/ebay-details/examples/02-opened/template.marko
+++ b/src/components/ebay-details/examples/02-opened/template.marko
@@ -1,3 +1,3 @@
-<ebay-details text="detals" open>
+<ebay-details text="details" open>
     Sample content inside of details
 </ebay-details>

--- a/src/components/ebay-details/examples/02-opened/template.marko
+++ b/src/components/ebay-details/examples/02-opened/template.marko
@@ -1,0 +1,3 @@
+<ebay-details text="detals" open>
+    Sample content inside of details
+</ebay-details>

--- a/src/components/ebay-details/examples/03-centered/template.marko
+++ b/src/components/ebay-details/examples/03-centered/template.marko
@@ -1,0 +1,3 @@
+<ebay-details text="detals" type="center">
+    Sample content inside of details
+</ebay-details>

--- a/src/components/ebay-details/examples/03-centered/template.marko
+++ b/src/components/ebay-details/examples/03-centered/template.marko
@@ -1,3 +1,3 @@
-<ebay-details text="detals" type="center">
+<ebay-details text="details" type="center">
     Sample content inside of details
 </ebay-details>

--- a/src/components/ebay-details/examples/04-small/template.marko
+++ b/src/components/ebay-details/examples/04-small/template.marko
@@ -1,3 +1,3 @@
-<ebay-details text="detals" size="small">
+<ebay-details text="details" size="small">
     Sample content inside of details
 </ebay-details>

--- a/src/components/ebay-details/examples/04-small/template.marko
+++ b/src/components/ebay-details/examples/04-small/template.marko
@@ -1,0 +1,3 @@
+<ebay-details text="detals" size="small">
+    Sample content inside of details
+</ebay-details>

--- a/src/components/ebay-details/examples/05-rtl/template.marko
+++ b/src/components/ebay-details/examples/05-rtl/template.marko
@@ -1,0 +1,6 @@
+<ebay-details text="detals" rtl>
+    lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+</ebay-details>

--- a/src/components/ebay-details/examples/05-rtl/template.marko
+++ b/src/components/ebay-details/examples/05-rtl/template.marko
@@ -1,4 +1,4 @@
-<ebay-details text="detals" rtl>
+<ebay-details text="details" rtl>
     lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.

--- a/src/components/ebay-details/examples/06-multiple-options/template.marko
+++ b/src/components/ebay-details/examples/06-multiple-options/template.marko
@@ -1,5 +1,5 @@
 class {}
 
-<ebay-details text="details" rtl size="small" type="center" open on-details-toggle(() => console.log('toggle')) >
+<ebay-details text="details" rtl size="small" type="center" open on-details-toggle((ev) => console.log('toggle', ev.open)) >
     Sample content inside of details
 </ebay-details>

--- a/src/components/ebay-details/examples/06-multiple-options/template.marko
+++ b/src/components/ebay-details/examples/06-multiple-options/template.marko
@@ -1,5 +1,5 @@
 class {}
 
-<ebay-details text="detals" rtl size="small" type="center" open on-details-open(() => console.log('open')) on-details-close(() => console.log('close'))>
+<ebay-details text="details" rtl size="small" type="center" open on-details-toggle(() => console.log('toggle')) >
     Sample content inside of details
 </ebay-details>

--- a/src/components/ebay-details/examples/06-multiple-options/template.marko
+++ b/src/components/ebay-details/examples/06-multiple-options/template.marko
@@ -1,0 +1,5 @@
+class {}
+
+<ebay-details text="detals" rtl size="small" type="center" open on-details-open(() => console.log('open')) on-details-close(() => console.log('close'))>
+    Sample content inside of details
+</ebay-details>

--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -2,7 +2,7 @@ import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = ["open", "type", "size", "rtl", "text"];
 
-<details class="details" open=input.open dir=(input.rtl && 'rtl') key="root" on-toggle('toggleDetails') ...processHtmlAttributes(input, ignoredAttributes)>
+<details class="details" open=input.open dir=(input.rtl && 'rtl') key="root" on-toggle('toggleDetails') on-click('clickDetails') ...processHtmlAttributes(input, ignoredAttributes)>
     <summary class=[
         "details__summary",
         input.size === "small" && "details__summary--small",

--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -2,7 +2,7 @@ import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = ["open", "type", "size", "rtl", "text"];
 
-<details class="details" open=input.open dir=(input.rtl && 'rtl') on-toggle('toggleDetails') ...processHtmlAttributes(input, ignoredAttributes)>
+<details class="details" open=input.open dir=(input.rtl && 'rtl') key="root" on-toggle('toggleDetails') ...processHtmlAttributes(input, ignoredAttributes)>
     <summary class=[
         "details__summary",
         input.size === "small" && "details__summary--small",

--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -2,7 +2,7 @@ import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = ["open", "type", "size", "rtl", "text"];
 
-<details class="details" open=state.open dir=(input.rtl && 'rtl') on-click("toggleDetails") ...processHtmlAttributes(input, ignoredAttributes)>
+<details class="details" open=input.open dir=(input.rtl && 'rtl') on-toggle('toggleDetails') ...processHtmlAttributes(input, ignoredAttributes)>
     <summary class=[
         "details__summary",
         input.size === "small" && "details__summary--small",

--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -1,0 +1,19 @@
+import processHtmlAttributes from "../../common/html-attributes"
+
+static var ignoredAttributes = ["open", "type", "size", "rtl", "text"];
+
+<details class="details" open=state.open dir=(input.rtl && 'rtl') on-click("toggleDetails") ...processHtmlAttributes(input, ignoredAttributes)>
+    <summary class=[
+        "details__summary",
+        input.size === "small" && "details__summary--small",
+        input.type === "center" && "details__summary--center"
+    ]>
+        <span class="details__label">${input.text}</span>
+        <span class="details__icon" hidden>
+            <ebay-icon name="dropdown" />
+        </span>
+    </summary>
+    <p>
+        <${input.renderBody}/>
+    </p>
+</details>

--- a/src/components/ebay-details/marko-tag.json
+++ b/src/components/ebay-details/marko-tag.json
@@ -1,0 +1,17 @@
+{
+  "attribute-groups": ["html-attributes"],
+  "@*": {
+    "targetProperty": null,
+    "type": "expression"
+  },
+  "@html-attributes": "expression",
+  "@type": {
+    "enum": ["regular", "center"]
+  },
+  "@size": {
+    "enum": ["regular", "small"]
+  },
+  "@text": "string",
+  "@open": "boolean",
+  "@rtl": "boolean"
+}

--- a/src/components/ebay-details/test/mock/index.js
+++ b/src/components/ebay-details/test/mock/index.js
@@ -1,0 +1,12 @@
+const assign = require('core-js-pure/features/object/assign');
+const { createRenderBody } = require('../../../../common/test-utils/shared');
+
+exports.Default_Details = {
+    text: 'open',
+    'data-testid': 'test',
+    renderBody: createRenderBody('body content')
+};
+
+exports.Open_Details = assign({}, exports.Default_Details, {
+    open: true
+});

--- a/src/components/ebay-details/test/mock/index.js
+++ b/src/components/ebay-details/test/mock/index.js
@@ -3,7 +3,6 @@ const { createRenderBody } = require('../../../../common/test-utils/shared');
 
 exports.Default_Details = {
     text: 'open',
-    'data-testid': 'test',
     renderBody: createRenderBody('body content')
 };
 

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -61,8 +61,6 @@ describe('given the details is in the default state and click is triggered', () 
         });
         describe('click after rerender', () => {
             beforeEach(async() => {
-                flushToggleEvent(true);
-
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
 
@@ -103,7 +101,6 @@ describe('given the details is in the open state and click is triggered', () => 
         });
         describe('click after rerender', () => {
             beforeEach(async() => {
-                flushToggleEvent(false);
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
             it('then it should be open', async() => {
@@ -114,22 +111,11 @@ describe('given the details is in the open state and click is triggered', () => 
     });
 });
 
-// In some older browsers, the toggleEvent is not fired consistently
-// On rerender, so adding a flush to make sure that it is synced up correctly
-function flushToggleEvent(isOpen) {
-    const toggleEvent = component.emitted('details-toggle');
-    if (toggleEvent.length > 0) {
-        const [[eventArg]] = toggleEvent;
-        expect(eventArg).has.property('open', isOpen);
-        expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
-    }
-}
-
 function verifyToggleEvent(isOpen) {
     const toggleEvent = component.emitted('details-toggle');
-    expect(toggleEvent).to.length(1);
+    expect(toggleEvent.length).to.be.greaterThan(0);
 
-    const [[eventArg]] = toggleEvent;
+    const [eventArg] = toggleEvent.pop();
     expect(eventArg).has.property('open', isOpen);
     expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
 }

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -16,7 +16,7 @@ describe('given the details is in the default state', () => {
     });
 
     it('should render with open false', () => {
-        expect(component.getByTestId('test').open).to.equal(false);
+        expect(component.getByText(input.text).closest('details').open).to.equal(false);
     });
 });
 
@@ -28,7 +28,7 @@ describe('given the details is in the open state', () => {
     });
 
     it('should render with open false', () => {
-        expect(component.getByTestId('test').open).to.equal(true);
+        expect(component.getByText(input.text).closest('details').open).to.equal(true);
     });
 });
 
@@ -55,7 +55,7 @@ describe('given the details is in the default state and click is triggered', () 
         });
 
         it('then it should have open true', () => {
-            expect(component.getByTestId('test').open).to.equal(true);
+            expect(component.getByText(detailsText).closest('details').open).to.equal(true);
         });
 
         describe('click after rerender', () => {
@@ -98,7 +98,7 @@ describe('given the details is in the open state and click is triggered', () => 
         });
 
         it('then it should have open true', () => {
-            expect(component.getByTestId('test').open).to.equal(false);
+            expect(component.getByText(detailsText).closest('details').open).to.equal(false);
         });
         describe('click after rerender', () => {
             beforeEach(async() => {

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -1,10 +1,13 @@
 const assign = require('core-js-pure/features/object/assign');
 const { expect, use } = require('chai');
 const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const { fastAnimations } = require('../../../common/test-utils/browser');
 const mock = require('./mock');
 const template = require('..');
 
 use(require('chai-dom'));
+before(fastAnimations.start);
+after(fastAnimations.stop);
 afterEach(cleanup);
 let component;
 

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -38,15 +38,16 @@ describe('given the details is in the default state and click is triggered', () 
 
     beforeEach(async() => {
         component = await render(template, input);
-        await fireEvent.click(component.getByText(detailsText));
     });
 
-    it('then it emits the details-toggle', () => {
-        const toggleEvent = component.emitted('details-toggle');
-        expect(toggleEvent).to.length(1);
-        const [[eventArg]] = toggleEvent;
-        expect(eventArg).has.property('open', true);
-        expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+    describe('click on details', () => {
+        beforeEach(async() => {
+            await fireEvent.click(component.getByText(detailsText));
+        });
+
+        it('then it emits the details-toggle', () => {
+            verifyToggleEvent(true);
+        });
     });
 
     describe('details should properly toggle open property', () => {
@@ -60,15 +61,13 @@ describe('given the details is in the default state and click is triggered', () 
 
         describe('click after rerender', () => {
             beforeEach(async() => {
+                verifyToggleEvent(true);
+
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
-            it('then it should be closed', () => {
-                const toggleEvent = component.emitted('details-toggle');
-                expect(toggleEvent).to.length(2);
 
-                const [eventArg] = toggleEvent[1];
-                expect(eventArg).has.property('open', false);
-                expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+            it('then it should be closed', () => {
+                verifyToggleEvent(false);
             });
         });
     });
@@ -80,20 +79,22 @@ describe('given the details is in the open state and click is triggered', () => 
 
     beforeEach(async() => {
         component = await render(template, input);
-        await fireEvent.click(component.getByText(detailsText));
     });
 
-    it('then it emits the details-toggle', () => {
-        const toggleEvent = component.emitted('details-toggle');
-        expect(toggleEvent).to.length(1);
+    describe('click on details', () => {
+        beforeEach(async() => {
+            verifyToggleEvent(true);
 
-        const [[eventArg]] = toggleEvent;
-        expect(eventArg).has.property('open', false);
-        expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+            await fireEvent.click(component.getByText(detailsText));
+        });
+
+        it('then it emits the details-toggle', () => {
+            verifyToggleEvent(false);
+        });
     });
-
     describe('details should properly toggle open property', () => {
         beforeEach(async() => {
+            verifyToggleEvent(true);
             await component.rerender(assign({}, input, { open: false }));
         });
 
@@ -102,16 +103,21 @@ describe('given the details is in the open state and click is triggered', () => 
         });
         describe('click after rerender', () => {
             beforeEach(async() => {
+                verifyToggleEvent(false);
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
             it('then it should be open', () => {
-                const toggleEvent = component.emitted('details-toggle');
-                expect(toggleEvent).to.length(2);
-
-                const [eventArg] = toggleEvent[1];
-                expect(eventArg).has.property('open', true);
-                expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+                verifyToggleEvent(true);
             });
         });
     });
 });
+
+function verifyToggleEvent(isOpen) {
+    const toggleEvent = component.emitted('details-toggle');
+    expect(toggleEvent).to.length(1);
+
+    const [[eventArg]] = toggleEvent;
+    expect(eventArg).has.property('open', isOpen);
+    expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+}

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -1,6 +1,6 @@
 const assign = require('core-js-pure/features/object/assign');
 const { expect, use } = require('chai');
-const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const { render, fireEvent, cleanup, wait } = require('@marko/testing-library');
 const mock = require('./mock');
 const template = require('..');
 
@@ -45,7 +45,7 @@ describe('given the details is in the default state and click is triggered', () 
             await fireEvent.click(component.getByText(detailsText));
         });
 
-        it('then it emits the details-toggle and click', () => {
+        it('then it emits the details-toggle and click', async() => {
             verifyToggleEvent(true);
             verifyClickEvent();
         });
@@ -62,13 +62,13 @@ describe('given the details is in the default state and click is triggered', () 
 
         describe('click after rerender', () => {
             beforeEach(async() => {
-                verifyToggleEvent(true);
+                await verifyToggleEvent(true);
 
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
 
-            it('then it should be closed', () => {
-                verifyToggleEvent(false);
+            it('then it should be closed', async() => {
+                await verifyToggleEvent(false);
                 verifyClickEvent();
             });
         });
@@ -90,9 +90,9 @@ describe('given the details is in the open state and click is triggered', () => 
             await fireEvent.click(component.getByText(detailsText));
         });
 
-        it('then it emits the details-toggle and click', () => {
+        it('then it emits the details-toggle and click', async() => {
             verifyToggleEvent(false);
-            verifyClickEvent();
+            await verifyClickEvent();
         });
     });
     describe('details should properly toggle open property', () => {
@@ -109,27 +109,28 @@ describe('given the details is in the open state and click is triggered', () => 
                 verifyToggleEvent(false);
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
-            it('then it should be open', () => {
+            it('then it should be open', async() => {
                 verifyToggleEvent(true);
-                verifyClickEvent();
+                await verifyClickEvent();
             });
         });
     });
 });
 
-function verifyToggleEvent(isOpen) {
-    const toggleEvent = component.emitted('details-toggle');
-    expect(toggleEvent).to.length(1);
+async function verifyToggleEvent(isOpen) {
+    return await wait(() => {
+        const toggleEvent = component.emitted('details-toggle');
+        expect(toggleEvent).to.length(1);
 
-    const [[eventArg]] = toggleEvent;
-    expect(eventArg).has.property('open', isOpen);
-    expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+        const [[eventArg]] = toggleEvent;
+        expect(eventArg).has.property('open', isOpen);
+        expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+    });
 }
 
 function verifyClickEvent() {
     const toggleEvent = component.emitted('details-click');
     expect(toggleEvent).to.length(1);
-
     const [[eventArg]] = toggleEvent;
     expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
 }

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -1,6 +1,6 @@
 const assign = require('core-js-pure/features/object/assign');
 const { expect, use } = require('chai');
-const { render, fireEvent, cleanup, wait } = require('@marko/testing-library');
+const { render, fireEvent, cleanup } = require('@marko/testing-library');
 const mock = require('./mock');
 const template = require('..');
 
@@ -46,7 +46,7 @@ describe('given the details is in the default state and click is triggered', () 
         });
 
         it('then it emits the details-toggle and click', async() => {
-            await verifyToggleEvent(true);
+            verifyToggleEvent(true);
             verifyClickEvent();
         });
     });
@@ -61,13 +61,13 @@ describe('given the details is in the default state and click is triggered', () 
         });
         describe('click after rerender', () => {
             beforeEach(async() => {
-                await verifyToggleEvent(true);
+                flushToggleEvent(true);
 
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
 
             it('then it should be closed', async() => {
-                await verifyToggleEvent(false);
+                verifyToggleEvent(false);
                 verifyClickEvent();
             });
         });
@@ -88,7 +88,7 @@ describe('given the details is in the open state and click is triggered', () => 
         });
 
         it('then it emits the details-toggle and click', async() => {
-            await verifyToggleEvent(false);
+            verifyToggleEvent(false);
             verifyClickEvent();
         });
     });
@@ -103,26 +103,35 @@ describe('given the details is in the open state and click is triggered', () => 
         });
         describe('click after rerender', () => {
             beforeEach(async() => {
-                await verifyToggleEvent(false);
+                flushToggleEvent(false);
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
             it('then it should be open', async() => {
-                await verifyToggleEvent(true);
+                verifyToggleEvent(true);
                 verifyClickEvent();
             });
         });
     });
 });
 
-async function verifyToggleEvent(isOpen) {
-    return await wait(() => {
-        const toggleEvent = component.emitted('details-toggle');
-        expect(toggleEvent).to.length(1);
-
+// In some older browsers, the toggleEvent is not fired consistently
+// On rerender, so adding a flush to make sure that it is synced up correctly
+function flushToggleEvent(isOpen) {
+    const toggleEvent = component.emitted('details-toggle');
+    if (toggleEvent.length > 0) {
         const [[eventArg]] = toggleEvent;
         expect(eventArg).has.property('open', isOpen);
         expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
-    });
+    }
+}
+
+function verifyToggleEvent(isOpen) {
+    const toggleEvent = component.emitted('details-toggle');
+    expect(toggleEvent).to.length(1);
+
+    const [[eventArg]] = toggleEvent;
+    expect(eventArg).has.property('open', isOpen);
+    expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
 }
 
 function verifyClickEvent() {

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -49,7 +49,7 @@ describe('given the details is in the default state and click is triggered', () 
         });
 
         it('then it emits the details-toggle and click', async() => {
-            verifyToggleEvent(true);
+            verifyToggleEvent();
             verifyClickEvent();
         });
     });
@@ -68,7 +68,7 @@ describe('given the details is in the default state and click is triggered', () 
             });
 
             it('then it should be closed', async() => {
-                verifyToggleEvent(false);
+                verifyToggleEvent();
                 verifyClickEvent();
             });
         });
@@ -89,7 +89,7 @@ describe('given the details is in the open state and click is triggered', () => 
         });
 
         it('then it emits the details-toggle and click', async() => {
-            verifyToggleEvent(false);
+            verifyToggleEvent();
             verifyClickEvent();
         });
     });
@@ -107,19 +107,19 @@ describe('given the details is in the open state and click is triggered', () => 
                 await fireEvent.click(component.getByText(detailsText).parentNode);
             });
             it('then it should be open', async() => {
-                verifyToggleEvent(true);
+                verifyToggleEvent();
                 verifyClickEvent();
             });
         });
     });
 });
 
-function verifyToggleEvent(isOpen) {
+function verifyToggleEvent() {
     const toggleEvent = component.emitted('details-toggle');
     expect(toggleEvent.length).to.be.greaterThan(0);
 
     const [eventArg] = toggleEvent.pop();
-    expect(eventArg).has.property('open', isOpen);
+    expect(eventArg).has.property('open');
     expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
 }
 

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -45,8 +45,9 @@ describe('given the details is in the default state and click is triggered', () 
             await fireEvent.click(component.getByText(detailsText));
         });
 
-        it('then it emits the details-toggle', () => {
+        it('then it emits the details-toggle and click', () => {
             verifyToggleEvent(true);
+            verifyClickEvent();
         });
     });
 
@@ -68,6 +69,7 @@ describe('given the details is in the default state and click is triggered', () 
 
             it('then it should be closed', () => {
                 verifyToggleEvent(false);
+                verifyClickEvent();
             });
         });
     });
@@ -88,8 +90,9 @@ describe('given the details is in the open state and click is triggered', () => 
             await fireEvent.click(component.getByText(detailsText));
         });
 
-        it('then it emits the details-toggle', () => {
+        it('then it emits the details-toggle and click', () => {
             verifyToggleEvent(false);
+            verifyClickEvent();
         });
     });
     describe('details should properly toggle open property', () => {
@@ -108,6 +111,7 @@ describe('given the details is in the open state and click is triggered', () => 
             });
             it('then it should be open', () => {
                 verifyToggleEvent(true);
+                verifyClickEvent();
             });
         });
     });
@@ -119,5 +123,13 @@ function verifyToggleEvent(isOpen) {
 
     const [[eventArg]] = toggleEvent;
     expect(eventArg).has.property('open', isOpen);
+    expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+}
+
+function verifyClickEvent() {
+    const toggleEvent = component.emitted('details-click');
+    expect(toggleEvent).to.length(1);
+
+    const [[eventArg]] = toggleEvent;
     expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
 }

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -1,0 +1,117 @@
+const assign = require('core-js-pure/features/object/assign');
+const { expect, use } = require('chai');
+const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const mock = require('./mock');
+const template = require('..');
+
+use(require('chai-dom'));
+afterEach(cleanup);
+let component;
+
+describe('given the details is in the default state', () => {
+    const input = mock.Default_Details;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+    });
+
+    it('should render with open false', () => {
+        expect(component.getByTestId('test').open).to.equal(false);
+    });
+});
+
+describe('given the details is in the open state', () => {
+    const input = mock.Open_Details;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+    });
+
+    it('should render with open false', () => {
+        expect(component.getByTestId('test').open).to.equal(true);
+    });
+});
+
+describe('given the details is in the default state and click is triggered', () => {
+    const input = mock.Default_Details;
+    const detailsText = input.text;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+        await fireEvent.click(component.getByText(detailsText));
+    });
+
+    it('then it emits the details-toggle', () => {
+        const toggleEvent = component.emitted('details-toggle');
+        expect(toggleEvent).to.length(1);
+        const [[eventArg]] = toggleEvent;
+        expect(eventArg).has.property('open', true);
+        expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+    });
+
+    describe('details should properly toggle open property', () => {
+        beforeEach(async() => {
+            await component.rerender(assign({}, input, { open: true }));
+        });
+
+        it('then it should have open true', () => {
+            expect(component.getByTestId('test').open).to.equal(true);
+        });
+
+        describe('click after rerender', () => {
+            beforeEach(async() => {
+                await fireEvent.click(component.getByText(detailsText).parentNode);
+            });
+            it('then it should be closed', () => {
+                const toggleEvent = component.emitted('details-toggle');
+                expect(toggleEvent).to.length(2);
+
+                const [eventArg] = toggleEvent[1];
+                expect(eventArg).has.property('open', false);
+                expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+            });
+        });
+    });
+});
+
+describe('given the details is in the open state and click is triggered', () => {
+    const input = mock.Open_Details;
+    const detailsText = input.text;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+        await fireEvent.click(component.getByText(detailsText));
+    });
+
+    it('then it emits the details-toggle', () => {
+        const toggleEvent = component.emitted('details-toggle');
+        expect(toggleEvent).to.length(1);
+
+        const [[eventArg]] = toggleEvent;
+        expect(eventArg).has.property('open', false);
+        expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+    });
+
+    describe('details should properly toggle open property', () => {
+        beforeEach(async() => {
+            await component.rerender(assign({}, input, { open: false }));
+        });
+
+        it('then it should have open true', () => {
+            expect(component.getByTestId('test').open).to.equal(false);
+        });
+        describe('click after rerender', () => {
+            beforeEach(async() => {
+                await fireEvent.click(component.getByText(detailsText).parentNode);
+            });
+            it('then it should be open', () => {
+                const toggleEvent = component.emitted('details-toggle');
+                expect(toggleEvent).to.length(2);
+
+                const [eventArg] = toggleEvent[1];
+                expect(eventArg).has.property('open', true);
+                expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+            });
+        });
+    });
+});

--- a/src/components/ebay-details/test/test.server.js
+++ b/src/components/ebay-details/test/test.server.js
@@ -1,0 +1,44 @@
+const { expect, use } = require('chai');
+const { render } = require('@marko/testing-library');
+const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const mock = require('./mock');
+const template = require('..');
+
+use(require('chai-dom'));
+
+describe('details', () => {
+    it('renders basic version', async() => {
+        const input = mock.Default_Details;
+        const { getByText } = await render(template, input);
+        expect(getByText(input.text)).has.class('details__label');
+        expect(getByText(input.renderBody.text)).has.property('tagName', 'P');
+    });
+
+    it('renders in open state', async() => {
+        const input = mock.Open_Details;
+        const { getByText, getByTestId } = await render(template, input);
+        expect(getByText(input.text)).has.class('details__label');
+        expect(getByText(input.renderBody.text)).has.property('tagName', 'P');
+        expect(getByTestId('test')).has.property('open', true);
+    });
+
+    it('renders left-to-right', async() => {
+        const input = Object.assign({}, mock.Default_Details, { rtl: true });
+        const { getByTestId } = await render(template, input);
+        expect(getByTestId('test')).has.property('dir', 'rtl');
+    });
+
+    it('renders small version', async() => {
+        const input = Object.assign({}, mock.Default_Details, { size: 'small' });
+        const { getByTestId } = await render(template, input);
+        expect(getByTestId('test').firstChild).has.class('details__summary--small');
+    });
+
+    it('renders center version', async() => {
+        const input = Object.assign({}, mock.Default_Details, { type: 'center' });
+        const { getByTestId } = await render(template, input);
+        expect(getByTestId('test').firstChild).has.class('details__summary--center');
+    });
+
+    testPassThroughAttributes(template);
+});

--- a/src/components/ebay-details/test/test.server.js
+++ b/src/components/ebay-details/test/test.server.js
@@ -12,32 +12,35 @@ describe('details', () => {
         const { getByText } = await render(template, input);
         expect(getByText(input.text)).has.class('details__label');
         expect(getByText(input.renderBody.text)).has.property('tagName', 'P');
+        expect(getByText(input.text).closest('details')).has.property('open', false);
+        expect(getByText(input.renderBody.text).closest('details')).has.property('open', false);
     });
 
     it('renders in open state', async() => {
         const input = mock.Open_Details;
-        const { getByText, getByTestId } = await render(template, input);
+        const { getByText } = await render(template, input);
         expect(getByText(input.text)).has.class('details__label');
         expect(getByText(input.renderBody.text)).has.property('tagName', 'P');
-        expect(getByTestId('test')).has.property('open', true);
+        expect(getByText(input.text).closest('details')).has.property('open', true);
+        expect(getByText(input.renderBody.text).closest('details')).has.property('open', true);
     });
 
     it('renders left-to-right', async() => {
         const input = Object.assign({}, mock.Default_Details, { rtl: true });
-        const { getByTestId } = await render(template, input);
-        expect(getByTestId('test')).has.property('dir', 'rtl');
+        const { getByText } = await render(template, input);
+        expect(getByText(input.text).closest('details')).has.property('dir', 'rtl');
     });
 
     it('renders small version', async() => {
         const input = Object.assign({}, mock.Default_Details, { size: 'small' });
-        const { getByTestId } = await render(template, input);
-        expect(getByTestId('test').firstChild).has.class('details__summary--small');
+        const { getByText } = await render(template, input);
+        expect(getByText(input.text).closest('summary')).has.class('details__summary--small');
     });
 
     it('renders center version', async() => {
         const input = Object.assign({}, mock.Default_Details, { type: 'center' });
-        const { getByTestId } = await render(template, input);
-        expect(getByTestId('test').firstChild).has.class('details__summary--center');
+        const { getByText } = await render(template, input);
+        expect(getByText(input.text).closest('summary')).has.class('details__summary--center');
     });
 
     testPassThroughAttributes(template);


### PR DESCRIPTION
## Description
Added new details component based on skin markup

## Context
* Added two events for details open/close
* Added a size and type options. I could have done just  center=true and small=true, but who knows if we want to expand those at a later time and they go in line with other components
* Added open as a state variable, although the browser handles the open/close. 

## References
#660 

## Screenshots
![Screen Shot 2020-02-27 at 11 01 16 AM](https://user-images.githubusercontent.com/1755269/75477088-988f3800-5950-11ea-8239-7bd9f09cb9ec.png)
