### PR TITLE
Changed array findIndex to use core-js

### DIFF
--- a/src/components/ebay-menu-button/index.js
+++ b/src/components/ebay-menu-button/index.js
@@ -34,7 +34,7 @@ module.exports = require('marko-widgets').defineComponent({
     toggleItemChecked(itemEl) {
         const itemIndex = indexOf(itemEl.parentNode.children, itemEl);
         const item = this.state.items[itemIndex];
-        const currentIndex = this.state.items.findIndex(radioItem => radioItem.checked);
+        const currentIndex = findIndex(this.state.items, radioItem => radioItem.checked);
 
         if (this.state.type === 'radio' && itemIndex !== currentIndex) {
             this.state.items.forEach((eachItem, i) => {

--- a/src/components/ebay-menu/index.js
+++ b/src/components/ebay-menu/index.js
@@ -44,7 +44,7 @@ module.exports = require('marko-widgets').defineComponent({
     toggleItemChecked(originalEvent, itemEl) {
         const itemIndex = indexOf(itemEl.parentNode.children, itemEl);
         const item = this.state.items[itemIndex];
-        const currentIndex = this.state.items.findIndex(radioItem => radioItem.checked);
+        const currentIndex = findIndex(this.state.items, radioItem => radioItem.checked);
 
         if (this.state.type === 'radio' && itemIndex !== currentIndex) {
             this.state.items.forEach((eachItem, i) => {


### PR DESCRIPTION
Changed `findIndex` to use corejs instead of Array.prototype which is undefined in IE11

~~Does `forEach` also need to be changed? I see it's being used as well and not sure if it exists in IE11~~