### PR TITLE
Fixed menu button to not lose focus on firefox and safari

### DIFF
--- a/src/components/ebay-menu-button/index.js
+++ b/src/components/ebay-menu-button/index.js
@@ -16,7 +16,7 @@ module.exports = require('marko-widgets').defineComponent({
         this.expander = new Expander(this.el, {
             hostSelector: '.menu-button__button, .fake-menu-button__button',
             contentSelector: '.menu-button__menu, .fake-menu-button__menu',
-            focusManagement: 'focusable',
+            focusManagement: this.state.type === 'fake' ? 'interactive' : 'focusable',
             expandOnClick: true,
             autoCollapse: true,
             alwaysDoFocusManagement: true

--- a/src/components/ebay-menu-button/index.js
+++ b/src/components/ebay-menu-button/index.js
@@ -13,6 +13,12 @@ module.exports = require('marko-widgets').defineComponent({
         });
     },
     onRender() {
+        // In expander we set focusManagement to interactive for fake menu
+        // This is related to setting the tabindex=-1 on menu-button div container for fake menu
+        // In Safari and Firefox when clicking on a button/anchor focus is triggered on
+        // the closest element with tabindex=-1 if there are any above it.
+        // This would cause the menu to close before events are fired
+
         this.expander = new Expander(this.el, {
             hostSelector: '.menu-button__button, .fake-menu-button__button',
             contentSelector: '.menu-button__menu, .fake-menu-button__menu',

--- a/src/components/ebay-menu/template.marko
+++ b/src/components/ebay-menu/template.marko
@@ -22,6 +22,7 @@
     ${processHtmlAttributes(data, ignoredAttributes)}>
     <div
         w-id="menu"
+        tabindex=(isFake ? "-1" : null)
         role=(!isFake && 'menu')
         class="${baseClass}__items">
         <for(item in data.items)>


### PR DESCRIPTION
## Description
By adding a tabindex to the container above where the buttons/anchor tags are, this will take focus and trigger focus on the element forcing it to not close. 
This is only needed for fake menu.

~~However this introduces another bug which basically will trigger focus on the container instead of the first element. We can fix this in makeup~~
Changed focusManagement on expander to `interactive` for fake menu in order to fix focus on first element. 

## References
#1075 
