### PR TITLE
Removed synthetic click and just use browser click

### DIFF
--- a/src/components/ebay-pagination/index.js
+++ b/src/components/ebay-pagination/index.js
@@ -159,17 +159,15 @@ function refresh() {
  * @param {MouseEvent} originalEvent
  */
 function handlePageNumber(originalEvent, el) {
-    if (!isSyntheticClick(originalEvent)) {
-        this.emit('pagination-select', {
-            el,
-            originalEvent,
-            value: el.innerText
-        });
-    }
+    this.emit('pagination-select', {
+        el,
+        originalEvent,
+        value: el.innerText
+    });
 }
 
 function handleNextPage(originalEvent, el) {
-    if (!this.state.nextItem.disabled && !isSyntheticClick(originalEvent)) {
+    if (!this.state.nextItem.disabled) {
         this.emit('pagination-next', {
             el,
             originalEvent
@@ -178,41 +176,12 @@ function handleNextPage(originalEvent, el) {
 }
 
 function handlePreviousPage(originalEvent, el) {
-    if (!this.state.prevItem.disabled && !isSyntheticClick(originalEvent)) {
+    if (!this.state.prevItem.disabled) {
         this.emit('pagination-previous', {
             el,
             originalEvent
         });
     }
-}
-
-/**
- * Handle a11y for item, next page and previous page respectively.
- * @param {KeyboardEvent} originalEvent
- */
-function handlePageNumberKeyDown(originalEvent, el) {
-    eventUtils.handleActionKeydown(originalEvent, () => {
-        this.handlePageNumber(originalEvent, el);
-    });
-}
-
-function handleNextPageKeyDown(originalEvent, el) {
-    eventUtils.handleActionKeydown(originalEvent, () => {
-        this.handleNextPage(originalEvent, el);
-    });
-}
-
-function handlePreviousPageKeyDown(originalEvent, el) {
-    eventUtils.handleActionKeydown(originalEvent, () => {
-        this.handlePreviousPage(originalEvent, el);
-    });
-}
-
-function isSyntheticClick(event) {
-    // Keydown events can fire a click event on buttons, which caused this component
-    // to emit two events. Here we use the event.detail property to check that there was
-    // actually a click. https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
-    return event.type === 'click' && event.detail === 0;
 }
 
 module.exports = require('marko-widgets').defineComponent({
@@ -225,9 +194,6 @@ module.exports = require('marko-widgets').defineComponent({
     handlePageNumber,
     handleNextPage,
     handlePreviousPage,
-    handlePageNumberKeyDown,
-    handleNextPageKeyDown,
-    handlePreviousPageKeyDown,
     getInitialState,
     getTemplateData
 });

--- a/src/components/ebay-pagination/template.marko
+++ b/src/components/ebay-pagination/template.marko
@@ -17,7 +17,6 @@
         class=data.prevItem.class
         style=data.prevItem.style
         href=data.prevItem.href
-        w-onkeydown="handlePreviousPageKeyDown"
         w-onclick="handlePreviousPage"
         ${data.prevItem.htmlAttributes}
         if(data.prevItem)>
@@ -31,7 +30,6 @@
                 class=item.class
                 style=item.style
                 ${item.htmlAttributes}
-                w-onkeydown="handlePageNumberKeyDown"
                 w-onclick="handlePageNumber"
                 w-body=item.renderBody>
             </>
@@ -43,7 +41,6 @@
         class=data.nextItem.class
         style=data.nextItem.style
         href=data.nextItem.href
-        w-onkeydown="handleNextPageKeyDown"
         w-onclick="handleNextPage"
         ${data.nextItem.htmlAttributes}
         if(data.nextItem)>

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -1,6 +1,5 @@
 const { expect, use } = require('chai');
 const { render, fireEvent, cleanup } = require('@marko/testing-library');
-const { pressKey } = require('../../../common/test-utils/browser');
 const mock = require('./mock');
 const template = require('..');
 
@@ -43,17 +42,6 @@ describe('given the pagination is rendered', () => {
                 thenItEmittedThePaginationPreviousEvent();
             });
 
-            describe('via keyDown', () => {
-                beforeEach(async() => {
-                    await pressKey(component.getByLabelText(input.a11yPreviousText), {
-                        key: '(Space character)',
-                        keyCode: 32
-                    });
-                });
-
-                thenItEmittedThePaginationPreviousEvent();
-            });
-
             function thenItEmittedThePaginationPreviousEvent() {
                 it('then it emits the pagination-previous event', () => {
                     const previousEvents = component.emitted('pagination-previous');
@@ -77,17 +65,6 @@ describe('given the pagination is rendered', () => {
                 thenItEmittedThePaginationNextEvent();
             });
 
-            describe('via keyDown', () => {
-                beforeEach(async() => {
-                    await pressKey(component.getByLabelText(input.a11yNextText), {
-                        key: '(Space character)',
-                        keyCode: 32
-                    });
-                });
-
-                thenItEmittedThePaginationNextEvent();
-            });
-
             function thenItEmittedThePaginationNextEvent() {
                 it('then it emits the pagination-next event', () => {
                     const nextEvents = component.emitted('pagination-next');
@@ -105,17 +82,6 @@ describe('given the pagination is rendered', () => {
                 beforeEach(async() => {
                     await fireEvent.click(component.getByText(input.items[1].renderBody.text), {
                         detail: 1
-                    });
-                });
-
-                thenItEmittedThePaginationSelectEvent();
-            });
-
-            describe('via keyDown', () => {
-                beforeEach(async() => {
-                    await pressKey(component.getByText(input.items[1].renderBody.text), {
-                        key: '(Space character)',
-                        keyCode: 32
                     });
                 });
 
@@ -155,17 +121,6 @@ describe('given the pagination is rendered with disabled controls', () => {
             thenItDidNotEmitThePaginationPreviousEvent();
         });
 
-        describe('via keyDown', () => {
-            beforeEach(async() => {
-                await pressKey(component.getByLabelText(input.a11yPreviousText), {
-                    key: '(Space character)',
-                    keyCode: 32
-                });
-            });
-
-            thenItDidNotEmitThePaginationPreviousEvent();
-        });
-
         function thenItDidNotEmitThePaginationPreviousEvent() {
             it('then it does not emit the pagination-previous event', () => {
                 expect(component.emitted('pagination-previous')).has.length(0);
@@ -178,17 +133,6 @@ describe('given the pagination is rendered with disabled controls', () => {
             beforeEach(async() => {
                 await fireEvent.click(component.getByLabelText(input.a11yNextText), {
                     detail: 1
-                });
-            });
-
-            thenItDidNotEmitThePaginationNextEvent();
-        });
-
-        describe('via keyDown', () => {
-            beforeEach(async() => {
-                await pressKey(component.getByLabelText(input.a11yNextText), {
-                    key: '(Space character)',
-                    keyCode: 32
                 });
             });
 


### PR DESCRIPTION

## Description
* Removed keyup events since they are being duplicated in click events and not needed
* Removed the isSyntheticClick method
* Removed all tests for keyup as well
This is in line with `5.x` branch which also has the same refactor


## References
For #1077 

## Screenshots
<!-- Upload screenshots if appropriate. -->
