### PR TITLE
 Fixed menu button to not lose focus on firefox and safari

### DIFF
--- a/src/components/ebay-menu-button/component.js
+++ b/src/components/ebay-menu-button/component.js
@@ -163,10 +163,16 @@ module.exports = {
     },
 
     _setupMakeup() {
+        // In expander we set focusManagement to interactive for fake menu
+        // This is related to setting the tabindex=-1 on menu-button div container for fake menu
+        // In Safari and Firefox when clicking on a button/anchor focus is triggered on
+        // the closest element with tabindex=-1 if there are any above it.
+        // This would cause the menu to close before events are fired
+
         this.expander = new Expander(this.el, {
             hostSelector: '.menu-button__button, .fake-menu-button__button',
             contentSelector: '.menu-button__menu, .fake-menu-button__menu',
-            focusManagement: 'focusable',
+            focusManagement: this.input.type === 'fake' ? 'interactive' : 'focusable',
             expandOnClick: true,
             autoCollapse: true,
             alwaysDoFocusManagement: true

--- a/src/components/ebay-menu/index.marko
+++ b/src/components/ebay-menu/index.marko
@@ -44,6 +44,7 @@ $ var baseClass = input.classPrefix || (isFake ? "fake-menu" : "menu");
         role=(!isFake && "menu")
         class=`${baseClass}__items`
         key="menu"
+        tabindex=(isFake && "-1")
         id:scoped="menu">
         <for|item, index| of=input.items>
             $ {


### PR DESCRIPTION
Fix ported to `5.x` branch from `4.5.x`

Issue #1075
Original pr #1076 