### PR TITLE
Infotip: remove aria-describedby #1080

### DIFF
--- a/src/components/components/ebay-tooltip-base/component.js
+++ b/src/components/components/ebay-tooltip-base/component.js
@@ -66,7 +66,7 @@ module.exports = {
                 autoCollapse: isTooltip
             });
 
-            if (!host.hasAttribute('aria-describedby')) {
+            if (isTooltip && !host.hasAttribute('aria-describedby')) {
                 host.setAttribute('aria-describedby', input.overlayId);
             }
         }


### PR DESCRIPTION
Fixes #1080

Infotip should not have `aria-describedby`. 