### PR TITLE
Updated dialog for support with new skin changes

### DIFF
--- a/src/components/ebay-dialog/examples/01-basic/template.marko
+++ b/src/components/ebay-dialog/examples/01-basic/template.marko
@@ -1,5 +1,5 @@
 <ebay-dialog a11y-close-text="Close Dialog" aria-labelledby="dialog-title" open=state.open on-dialog-close('closeDialog')>
-    <h2 id="dialog-title">Heading</h2>
+    <@header><h2 id="dialog-title">Heading</h2></@header>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <p><a href="http://www.ebay.com">www.ebay.com</a></p>
 </ebay-dialog>

--- a/src/components/ebay-dialog/examples/02-scrolling/template.marko
+++ b/src/components/ebay-dialog/examples/02-scrolling/template.marko
@@ -3,7 +3,7 @@
     aria-labelledby="dialog-title"
     open=state.open
     on-dialog-close("closeDialog")>
-    <h2 id="dialog-title">Heading</h2>
+    <@header><h2 id="dialog-title">Heading</h2></@header>
     <for|i| from=0 to=100>
         <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/src/components/ebay-dialog/examples/03-fullscreen/template.marko
+++ b/src/components/ebay-dialog/examples/03-fullscreen/template.marko
@@ -1,5 +1,5 @@
 <ebay-dialog type="full" a11y-close-text="Close Dialog" aria-labelledby="dialog-title" open=state.open on-dialog-close('closeDialog')>
-    <h2 id="dialog-title">Heading</h2>
+    <@header><h2 id="dialog-title">Heading</h2></@header>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <p><a href="http://www.ebay.com">www.ebay.com</a></p>
 </ebay-dialog>

--- a/src/components/ebay-dialog/examples/05-panel-right/template.marko
+++ b/src/components/ebay-dialog/examples/05-panel-right/template.marko
@@ -1,5 +1,5 @@
 <ebay-dialog type="right" a11y-close-text="Close Dialog" aria-labelledby="dialog-title" open=state.open on-dialog-close('closeDialog')>
-    <h2 id="dialog-title">Heading</h2>
+    <@header><h2 id="dialog-title">Heading</h2></@header>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <p><a href="http://www.ebay.com">www.ebay.com</a></p>
 </ebay-dialog>

--- a/src/components/ebay-dialog/examples/07-focus/template.marko
+++ b/src/components/ebay-dialog/examples/07-focus/template.marko
@@ -1,5 +1,5 @@
 <ebay-dialog focus="my-input" a11y-close-text="Close Dialog" aria-labelledby="dialog-title" open=state.open on-dialog-close('closeDialog')>
-    <h2 id="dialog-title">Heading</h2>
+    <@header><h2 id="dialog-title">Heading</h2></@header>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <input id="my-input" placeholder="Enter a value"/>
     <p><a href="http://www.ebay.com">www.ebay.com</a></p>

--- a/src/components/ebay-dialog/examples/08-with-footer/template.marko
+++ b/src/components/ebay-dialog/examples/08-with-footer/template.marko
@@ -1,7 +1,10 @@
-<ebay-dialog type="left" a11y-close-text="Close Dialog" aria-labelledby="dialog-title" open=state.open on-dialog-close('closeDialog')>
+<ebay-dialog type="full" a11y-close-text="Close Dialog" aria-labelledby="dialog-title" open=state.open on-dialog-close('closeDialog')>
     <@header><h2 id="dialog-title">Heading</h2></@header>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+    <@footer>
+      <ebay-button on-button-click('closeDialog')>Close</ebay-button>
+    </@footer>
 </ebay-dialog>
 
 <ebay-button on-button-click('openDialog')>

--- a/src/components/ebay-dialog/index.marko
+++ b/src/components/ebay-dialog/index.marko
@@ -24,19 +24,25 @@ $ var isDocked = input.type === "left" || input.type === "right";
         class=[
             "dialog__window",
             input.type && `dialog__window--${input.type}`,
-            isDocked && "dialog__window--slide",
-            (isFull || isCenter) && "dialog__window--fade"
+            (isDocked ||isFull) && "dialog__window--slide",
+            isCenter && "dialog__window--fade"
         ]>
-        <button
-            key="close"
-            class="dialog__close"
-            type="button"
-            aria-label=input.a11yCloseText
-            onClick("handleCloseButtonClick")>
-            <ebay-icon name="close"/>
-        </button>
+        <${input.header && "div"} class="dialog__header">
+            <button
+                key="close"
+                class="dialog__close"
+                type="button"
+                aria-label=input.a11yCloseText
+                onClick("handleCloseButtonClick")>
+                <ebay-icon name="close"/>
+            </button>
+            <${input.header.renderBody} if(input.header) />
+        </>
         <div key="body" class="dialog__body">
             <${input.renderBody}/>
+        </div>
+        <div class="dialog__footer" if(input.footer)>
+            <${input.footer.renderBody} />
         </div>
     </div>
 </div>

--- a/src/components/ebay-dialog/marko-tag.json
+++ b/src/components/ebay-dialog/marko-tag.json
@@ -1,5 +1,7 @@
 {
-  "attribute-groups": ["html-attributes"],
+  "attribute-groups": [
+    "html-attributes"
+  ],
   "@*": {
     "targetProperty": null,
     "type": "expression"
@@ -7,10 +9,35 @@
   "@html-attributes": "expression",
   "@open": "boolean",
   "@type": {
-    "enum": ["full", "fill", "left", "right"]
+    "enum": [
+      "full",
+      "fill",
+      "left",
+      "right"
+    ]
   },
   "@focus": "string",
   "@a11y-close-text": "string",
   "@role": "never",
-  "@hidden": "never"
+  "@hidden": "never",
+  "@header <header>": {
+    "attribute-groups": [
+      "html-attributes"
+    ],
+    "@*": {
+      "targetProperty": null,
+      "type": "expression"
+    },
+    "@html-attributes": "expression"
+  },
+  "@footer <footer>": {
+    "attribute-groups": [
+      "html-attributes"
+    ],
+    "@*": {
+      "targetProperty": null,
+      "type": "expression"
+    },
+    "@html-attributes": "expression"
+  }
 }

--- a/src/components/ebay-dialog/test/mock/index.js
+++ b/src/components/ebay-dialog/test/mock/index.js
@@ -6,6 +6,17 @@ exports.Fill_Dialog = {
     renderBody: createRenderBody('body content')
 };
 
+exports.Header_Footer_Dialog = {
+    a11yCloseText: 'close',
+    footer: {
+        renderBody: createRenderBody('footer content')
+    },
+    header: {
+        renderBody: createRenderBody('title content')
+    },
+    renderBody: createRenderBody('body content')
+};
+
 exports.Fill_Dialog_Open = assign({}, exports.Fill_Dialog, {
     open: true
 });

--- a/src/components/ebay-dialog/test/test.server.js
+++ b/src/components/ebay-dialog/test/test.server.js
@@ -17,6 +17,18 @@ describe('dialog', () => {
         expect(getByText(input.renderBody.text)).has.class('dialog__body');
     });
 
+    it('renders with header and footer', async() => {
+        const input = mock.Header_Footer_Dialog;
+        const { getByRole, getByLabelText, getByText } = await render(template, input);
+
+        expect(getByRole('dialog')).has.attr('hidden');
+        expect(getByRole('dialog')).has.class('dialog');
+        expect(getByLabelText(input.a11yCloseText)).has.class('dialog__close');
+        expect(getByText(input.renderBody.text)).has.class('dialog__body');
+        expect(getByText(input.header.renderBody.text)).has.class('dialog__header');
+        expect(getByText(input.footer.renderBody.text)).has.class('dialog__footer');
+    });
+
     it('renders in open state', async() => {
         const input = mock.Fill_Dialog_Open;
         const { getByRole } = await render(template, input);
@@ -35,11 +47,11 @@ describe('dialog', () => {
 
             if (type === 'full') {
                 expect($dialog).has.class('dialog--no-mask');
+                expect($window).has.class('dialog__window--slide');
             } else {
                 expect($dialog).has.class('dialog--mask-fade');
+                expect($window).has.class('dialog__window--fade');
             }
-
-            expect($window).has.class('dialog__window--fade');
         });
     });
 


### PR DESCRIPTION
## Description
Changed dialog to consume the new skin changes

## Context
Most of it is a syntax change. If the new markup is not there it works as before.
* Added slide for full screen dialog animation
* Added `<@header>` and `<@footer>` markup for header and footer

## References
https://github.com/eBay/skin/issues/994

