### PR TITLE
Fixed findIndex in radio menu/menu-button to use polyfill

### DIFF
--- a/src/components/ebay-menu-button/component.js
+++ b/src/components/ebay-menu-button/component.js
@@ -135,7 +135,7 @@ module.exports = {
         this.type = input.type;
         if (this.isRadio) {
             this.state = {
-                checkedIndex: (input.items || []).findIndex(item => item.checked || false)
+                checkedIndex: findIndex(input.items || [], item => item.checked || false)
             };
         } else {
             this.state = {

--- a/src/components/ebay-menu/component.js
+++ b/src/components/ebay-menu/component.js
@@ -118,7 +118,7 @@ module.exports = {
         this.type = input.type;
         if (this.isRadio) {
             this.state = {
-                checkedIndex: (input.items || []).findIndex(item => item.checked || false)
+                checkedIndex: findIndex(input.items || [], item => item.checked || false)
             };
         } else {
             this.state = {


### PR DESCRIPTION
## Description

Found a remaining use of the non polyfilled findIndex which was breaking on IE. 