### PR TITLE
Added tabindex=-1 on menu-button

### DIFF
--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -82,6 +82,7 @@ $ var isOverflowVariant = input.variant === "overflow";
         type=input.type
         reverse=(isOverflowVariant ? !input.reverse : input.reverse)
         fix-width=input.fixWidth
+        tabindex=-1
         onMenu-keydown("handleMenuKeydown")
         onMenu-change("handleMenuChange")
         onMenu-select("handleMenuSelect")


### PR DESCRIPTION
## Description
* This fix  prevents menu from closing when tabindex is on an element outside of menu

## References
Skin portion which removes outline: https://github.com/eBay/skin/pull/1101
