### PR TITLE
Fixed carousel paddles to not show if there is no scrollable content

### DIFF
--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -59,7 +59,7 @@ function getTemplateData(state) {
         slide,
         offset: hasOverride ? config.offsetOverride : offset,
         disableTransition: hasOverride,
-        showPaddles: itemsPerSlide ? items.length > itemsPerSlide : true,
+        showPaddles: itemsPerSlide ? items.length > itemsPerSlide : !bothControlsDisabled,
         totalSlides,
         a11yStatusText,
         prevControlDisabled,

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -31,9 +31,9 @@ describe('given a continuous carousel', () => {
             component = await render(template, input);
         });
 
-        it('then prev and next controls are disabled', () => {
-            expect(component.getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
-            expect(component.getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
+        it('then prev and next controls are not present', () => {
+            expect(component.queryByLabelText(input.a11yPreviousText)).to.equal(null);
+            expect(component.queryByLabelText(input.a11yNextText)).to.equal(null);
         });
     });
 
@@ -44,9 +44,9 @@ describe('given a continuous carousel', () => {
             component = await render(template, input);
         });
 
-        it('then prev and next controls are disabled', () => {
-            expect(component.getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
-            expect(component.getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
+        it('then prev and next controls not present', () => {
+            expect(component.queryByLabelText(input.a11yPreviousText)).to.equal(null);
+            expect(component.queryByLabelText(input.a11yNextText)).to.equal(null);
         });
     });
 

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -57,7 +57,7 @@ describe('carousel', () => {
     describe('without items per slide (continuous)', () => {
         it('renders base version', async() => {
             const input = mock.Continuous_6Items;
-            const { queryByText, queryByLabelText, getByLabelText } = await render(template, input);
+            const { queryByText, queryByLabelText } = await render(template, input);
 
             // Status text is only used for discrete carousels.
             expect(queryByText(/\d+ of \d+/)).equals(null);
@@ -65,19 +65,19 @@ describe('carousel', () => {
             // Also it should not have the dot controls.
             expect(queryByLabelText(/go to slide/)).equals(null);
 
-            // Controls should not be linked to the status text (slide x of y).
-            expect(getByLabelText(input.a11yPreviousText)).not.has.attr('aria-describedby');
-            expect(getByLabelText(input.a11yNextText)).not.has.attr('aria-describedby');
+            // Controls will not be rendered by server because server cannot check carousel width
+            expect(queryByLabelText(input.a11yPreviousText)).to.equal(null);
+            expect(queryByLabelText(input.a11yNextText)).to.equal(null);
 
             input.items.forEach(item => expect(queryByText(item.renderBody.text)).does.not.equal(null));
         });
 
         it('renders without any provided items', async() => {
             const input = mock.Continuous_0Items;
-            const { getByLabelText } = await render(template, input);
+            const { queryByLabelText } = await render(template, input);
 
-            expect(getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
-            expect(getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
+            expect(queryByLabelText(input.a11yPreviousText)).to.equal(null);
+            expect(queryByLabelText(input.a11yNextText)).to.equal(null);
         });
     });
 


### PR DESCRIPTION
## Description
There was code to basically disable carousel paddles on scrolling. However the code to hide paddles was not there. 
Changed it so that is both paddles are disabled, will hide paddles. This is done by checking `bothControlsDisabled` variable.
I had to update some tests to pass in order to get this to work. Server side will always be false because it cannot check width, however client will work properly. 

## Screenshots
![carousel](https://user-images.githubusercontent.com/1755269/82011886-2c58d200-962b-11ea-97b5-90dc815b0aa3.gif)
