### PR TITLE
Removed showPaddles code which should be handled by controls-disabled

### DIFF
--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -59,7 +59,6 @@ function getTemplateData(state) {
         slide,
         offset: hasOverride ? config.offsetOverride : offset,
         disableTransition: hasOverride,
-        showPaddles: itemsPerSlide ? items.length > itemsPerSlide : true,
         totalSlides,
         a11yStatusText,
         prevControlDisabled,

--- a/src/components/ebay-carousel/index.marko
+++ b/src/components/ebay-carousel/index.marko
@@ -36,20 +36,18 @@ $ var data = component.getTemplateData(state, input);
                 </else>
             </>
         </if>
-        <if(data.showPaddles)>
-            <button
-                class=[
-                    "carousel__control",
-                    "carousel__control--prev"
-                ]
-                type="button"
-                on-click(!data.prevControlDisabled && "handleMove", -1)
-                aria-describedby=statusId
-                aria-label=data.a11yPreviousText
-                aria-disabled=(data.prevControlDisabled && "true")>
-                <ebay-icon name="carousel-prev"/>
-            </button>
-        </if>
+        <button
+            class=[
+                "carousel__control",
+                "carousel__control--prev"
+            ]
+            type="button"
+            on-click(!data.prevControlDisabled && "handleMove", -1)
+            aria-describedby=statusId
+            aria-label=data.a11yPreviousText
+            aria-disabled=(data.prevControlDisabled && "true")>
+            <ebay-icon name="carousel-prev"/>
+        </button>
         <div class=[
             "carousel__viewport",
             !data.itemsPerSlide &&
@@ -79,22 +77,20 @@ $ var data = component.getTemplateData(state, input);
                 </for>
             </ul>
         </div>
-        <if(data.showPaddles)>
-            <button
-                class=[
-                    "carousel__control",
-                    "carousel__control--next"
-                ]
-                type="button"
-                on-click(!data.nextControlDisabled && "handleMove", 1)
-                aria-describedby=statusId
-                aria-label=data.a11yNextText
-                aria-disabled=(data.nextControlDisabled && "true")
-                key="next"
-                id:scoped="next">
-                <ebay-icon name="carousel-next"/>
-            </button>
-        </if>
+        <button
+            class=[
+                "carousel__control",
+                "carousel__control--next"
+            ]
+            type="button"
+            on-click(!data.nextControlDisabled && "handleMove", 1)
+            aria-describedby=statusId
+            aria-label=data.a11yNextText
+            aria-disabled=(data.nextControlDisabled && "true")
+            key="next"
+            id:scoped="next">
+            <ebay-icon name="carousel-next"/>
+        </button>
         <if(data.autoplayInterval && !data.bothControlsDisabled)>
             <button
                 class="carousel__playback"

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -238,8 +238,8 @@ describe('given a discrete carousel', () => {
         });
 
         it('then prev and next controls are disabled', () => {
-            expect(component.queryByLabelText(input.a11yPreviousText)).to.equal(null);
-            expect(component.queryByLabelText(input.a11yNextText)).to.equal(null);
+            expect(component.getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
+            expect(component.getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
         });
     });
 
@@ -251,8 +251,8 @@ describe('given a discrete carousel', () => {
         });
 
         it('then prev and next controls are disabled', () => {
-            expect(component.queryByLabelText(input.a11yPreviousText)).to.equal(null);
-            expect(component.queryByLabelText(input.a11yNextText)).to.equal(null);
+            expect(component.getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
+            expect(component.getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
         });
 
         it('then has the appropriate heading', () => {

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -21,20 +21,12 @@ describe('carousel', () => {
             input.items.forEach(item => expect(queryByText(item.renderBody.text)).not.to.equal(null));
         });
 
-        it('renders without paddles', async() => {
-            const input = assign({}, mock.Discrete_1PerSlide_3Items, { itemsPerSlide: '3' });
-            const { queryByLabelText } = await render(template, input);
-
-            expect(queryByLabelText(input.a11yPreviousText)).to.equal(null);
-            expect(queryByLabelText(input.a11yNextText)).to.equal(null);
-        });
-
         it('renders without any provided items', async() => {
             const input = mock.Discrete_1PerSlide_0Items;
-            const { queryByLabelText } = await render(template, input);
+            const { getByLabelText } = await render(template, input);
 
-            expect(queryByLabelText(input.a11yPreviousText)).to.equal(null);
-            expect(queryByLabelText(input.a11yNextText)).to.equal(null);
+            expect(getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
+            expect(getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
         });
 
         describe('with autoplay enabled', () => {


### PR DESCRIPTION
This is to remove the useless `showPaddles` code since the fix from https://github.com/eBay/skin/pull/1109 should handle that. 