### PR TITLE
fix: @* target property, remove unneeded tag def

### DIFF
--- a/src/components/ebay-menu-button/marko-tag.json
+++ b/src/components/ebay-menu-button/marko-tag.json
@@ -39,7 +39,5 @@
     "@badge-number": "expression",
     "@badge-aria-label": "string"
   },
-  "@label <label>": {
-    "@*": "expression"
-  }
+  "@label <label>": {}
 }

--- a/src/components/ebay-section-title/marko-tag.json
+++ b/src/components/ebay-section-title/marko-tag.json
@@ -10,9 +10,6 @@
     "enum": ["small", "large", "giant"]
   },
   "@href": "#html-href",
-  "@_default <_default>": {
-    "@*": "expression"
-  },
   "@title <title>": {
     "@*": {
       "targetProperty": null,


### PR DESCRIPTION
## Description
Fixes a couple of Marko deprecation warnings coming from this module.

https://github.com/eBay/ebayui-core/compare/5.4.0...marko-4-deprecation-fixes?expand=1#diff-7a7104cd3a42bc1e229609e76935f270L43 warns that there should be a `targetProperty` defined, however in this case we do not accept any attributes on the label and so I just removed the `@*` definition.

https://github.com/eBay/ebayui-core/compare/5.4.0...marko-4-deprecation-fixes?expand=1#diff-b0533e363afb62c8b736b4a1603c2c4bL14 has the same issue as above, but I believe this is a remnant from Marko 3 since I cannot find a reference to `_default` anywhere else in the codebase.