### PR TITLE
Added mini-dialog to ebay-infotip

### DIFF
--- a/src/components/components/ebay-dialog-base/browser.json
+++ b/src/components/components/ebay-dialog-base/browser.json
@@ -1,0 +1,7 @@
+{
+    "requireRemap": [{
+        "from": "./style.js",
+        "to": "../../../common/empty.js",
+        "if-flag": "ebayui-no-skin"
+    }]
+}

--- a/src/components/components/ebay-dialog-base/style.js
+++ b/src/components/components/ebay-dialog-base/style.js
@@ -1,0 +1,1 @@
+require('@ebay/skin/dialog');

--- a/src/components/components/ebay-tooltip-base/component.js
+++ b/src/components/components/ebay-tooltip-base/component.js
@@ -28,6 +28,10 @@ module.exports = {
         this._expander.collapse();
     },
 
+    expand() {
+        this._expander.expand();
+    },
+
     onDestroy() {
         this._cleanupMakeup();
     },

--- a/src/components/components/ebay-tooltip-base/component.js
+++ b/src/components/components/ebay-tooltip-base/component.js
@@ -37,7 +37,7 @@ module.exports = {
         const { type } = input;
         const container = this.getEl('container');
         const isTooltip = type === 'tooltip';
-        const isInfotip = type === 'infotip';
+        const isInfotip = type === 'infotip' || type === 'dialog--mini';
         const hostClass = `${type}__host`;
         const hostSelector = `.${hostClass}`;
         const expanderEl = container.getElementsByClassName(type)[0];

--- a/src/components/ebay-infotip/component.js
+++ b/src/components/ebay-infotip/component.js
@@ -6,6 +6,12 @@ module.exports = {
         };
     },
 
+    onMount() {
+        if (this.state.open) {
+            this.getComponent('base').expand();
+        }
+    },
+
     setOpen(isOpen) {
         if (this.input.modal) {
             this.state.open = isOpen;

--- a/src/components/ebay-infotip/component.js
+++ b/src/components/ebay-infotip/component.js
@@ -1,6 +1,19 @@
 
 module.exports = {
+    onInput(input) {
+        this.state = {
+            open: input.open || false
+        };
+    },
+
+    setOpen(isOpen) {
+        if (this.input.modal) {
+            this.state.open = isOpen;
+        }
+    },
+
     handleExpand() {
+        this.setOpen(true);
         this.emit('tooltip-expand');
     },
 
@@ -9,6 +22,8 @@ module.exports = {
     },
 
     handleCollapse() {
+        this.setOpen(false);
+
         this.getEl('host').focus();
         this.emit('tooltip-collapse');
     }

--- a/src/components/ebay-infotip/examples/05-infotip-modal/template.marko
+++ b/src/components/ebay-infotip/examples/05-infotip-modal/template.marko
@@ -1,0 +1,5 @@
+class {}
+
+<ebay-infotip a11y-close-text="Dismiss infotip" aria-label="Important information" modal>
+    <ebay-infotip-content>This is some important info</ebay-infotip-content>
+</ebay-infotip>

--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -17,7 +17,7 @@ static var ignoredAttributes = [
     "modal"
 ];
 
-$ var classPrefix = (input.modal !== true ? "infotip" : "dialog--mini");
+$ var classPrefix = input.modal !== true ? "infotip" : "dialog--mini";
 $ var pointer = input.pointer || "bottom";
 <span>
     <ebay-tooltip-base
@@ -29,13 +29,14 @@ $ var pointer = input.pointer || "bottom";
         onBase-collapse("handleCollapse")>
         <span
             ...processHtmlAttributes(input, ignoredAttributes)
-            class:no-update=["infotip", input.modal === true && "dialog--mini", input.class]>
+            class:no-update=[
+                "infotip",
+                input.modal === true && "dialog--mini",
+                input.class
+            ]>
             <button
                 key="host"
-                class=[
-                    `${classPrefix}__host`,
-                    "icon-btn"
-                ]
+                class=[`${classPrefix}__host`, "icon-btn"]
                 type="button"
                 disabled=input.disabled
                 aria-label=input.ariaLabel>
@@ -46,20 +47,7 @@ $ var pointer = input.pointer || "bottom";
                     <ebay-icon name="information"/>
                 </else>
             </button>
-            <if(input.modal === true)>
-                <ebay-dialog-base
-                    open=state.open
-                    buttonPosition="right"
-                    classPrefix="dialog"
-                    class=[`${classPrefix}__overlay`]
-                    windowClass=["dialog__window--mini", "dialog__window--fade"]
-                    renderBody=input.content.renderBody
-                    on-modal-show("handleExpand")
-                    on-modal-close("handleOverlayClose")
-                    ...input
-                ></ebay-dialog-base>
-            </if>
-            <else>
+            <if(input.modal !== true)>
                 <ebay-tooltip-overlay
                     type="infotip"
                     id:scoped="overlay"
@@ -71,8 +59,20 @@ $ var pointer = input.pointer || "bottom";
                     heading=input.heading
                     content=input.content
                     a11y-close-text=input.a11yCloseText
-                    onOverlay-close("handleOverlayClose")>
-                    </>
+                    onOverlay-close("handleOverlayClose")/>
+            </if>
+            <else>
+                <ebay-dialog-base
+                    open=state.open
+                    buttonPosition="right"
+                    classPrefix="dialog"
+                    class=[`${classPrefix}__overlay`]
+                    windowClass=["dialog__window--mini", "dialog__window--fade"]
+                    a11y-close-text=input.a11yCloseText
+                    on-modal-show("handleExpand")
+                    on-modal-close("handleOverlayClose")>
+                    <${input.content}/>
+                </ebay-dialog-base>
             </else>
         </span>
     </ebay-tooltip-base>

--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -13,24 +13,29 @@ static var ignoredAttributes = [
     "iconTag",
     "host",
     "heading",
-    "content"
+    "content",
+    "modal"
 ];
 
+$ var classPrefix = (input.modal !== true ? "infotip" : "dialog--mini");
 $ var pointer = input.pointer || "bottom";
 <span>
     <ebay-tooltip-base
         key="base"
-        type="infotip"
+        type=classPrefix
         pointer=pointer
         overlay-id:scoped="overlay"
         onBase-expand("handleExpand")
         onBase-collapse("handleCollapse")>
         <span
             ...processHtmlAttributes(input, ignoredAttributes)
-            class:no-update=["infotip", input.class]>
+            class:no-update=["infotip", input.modal === true && "dialog--mini", input.class]>
             <button
                 key="host"
-                class="infotip__host icon-btn"
+                class=[
+                    `${classPrefix}__host`,
+                    "icon-btn"
+                ]
                 type="button"
                 disabled=input.disabled
                 aria-label=input.ariaLabel>
@@ -41,18 +46,33 @@ $ var pointer = input.pointer || "bottom";
                     <ebay-icon name="information"/>
                 </else>
             </button>
-            <ebay-tooltip-overlay
-                type="infotip"
-                id:scoped="overlay"
-                style-left=input.styleLeft
-                style-top=input.styleTop
-                style-right=input.styleRight
-                style-bottom=input.styleBottom
-                pointer=pointer
-                heading=input.heading
-                content=input.content
-                a11y-close-text=input.a11yCloseText
-                onOverlay-close("handleOverlayClose")/>
+            <if(input.modal === true)>
+                <ebay-dialog-base
+                    open=state.open
+                    buttonPosition="right"
+                    classPrefix="dialog"
+                    class=[`${classPrefix}__overlay`]
+                    windowClass=["dialog__window--mini", "dialog__window--fade"]
+                    renderBody=input.content.renderBody
+                    on-modal-show("handleExpand")
+                    on-modal-close("handleOverlayClose")
+                ></ebay-dialog-base>
+            </if>
+            <else>
+                <ebay-tooltip-overlay
+                    type="infotip"
+                    id:scoped="overlay"
+                    style-left=input.styleLeft
+                    style-top=input.styleTop
+                    style-right=input.styleRight
+                    style-bottom=input.styleBottom
+                    pointer=pointer
+                    heading=input.heading
+                    content=input.content
+                    a11y-close-text=input.a11yCloseText
+                    onOverlay-close("handleOverlayClose")>
+                    </>
+            </else>
         </span>
     </ebay-tooltip-base>
 </span>

--- a/src/components/ebay-infotip/test/mock/index.js
+++ b/src/components/ebay-infotip/test/mock/index.js
@@ -17,3 +17,9 @@ exports.WithContentAndHeader = assign({}, exports.WithContent, {
 exports.Disabled = assign({}, exports.WithContent, {
     disabled: true
 });
+
+exports.ModalWithContent = assign({}, exports.WithContent, { modal: true });
+
+exports.ModalDisabled = assign({}, exports.ModalWithContent, {
+    disabled: true
+});

--- a/src/components/ebay-infotip/test/mock/index.js
+++ b/src/components/ebay-infotip/test/mock/index.js
@@ -15,11 +15,13 @@ exports.WithContentAndHeader = assign({}, exports.WithContent, {
 });
 
 exports.Disabled = assign({}, exports.WithContent, {
-    disabled: true,
-    a11yCloseText: "Close mini dialog"
+    disabled: true
 });
 
-exports.ModalWithContent = assign({}, exports.WithContent, { modal: true });
+exports.ModalWithContent = assign({}, exports.WithContent, {
+    modal: true,
+    a11yCloseText: 'Close mini dialog'
+});
 
 exports.ModalDisabled = assign({}, exports.ModalWithContent, {
     disabled: true

--- a/src/components/ebay-infotip/test/test.browser.js
+++ b/src/components/ebay-infotip/test/test.browser.js
@@ -1,6 +1,6 @@
 const assign = require('core-js-pure/features/object/assign');
 const { expect, use } = require('chai');
-const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const { render, fireEvent, cleanup, wait } = require('@marko/testing-library');
 const template = require('..');
 const mock = require('./mock');
 
@@ -50,6 +50,58 @@ describe('given the default infotip', () => {
 
                 it('then it is collapsed', () => {
                     expect(component.getByLabelText(input.ariaLabel)).does.not.have.attr('aria-expanded', 'true');
+                });
+            });
+        });
+    }
+});
+
+describe('given the modal infotip', () => {
+    const input = mock.ModalWithContent;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+    });
+
+    thenItCanBeOpenAndClosed();
+
+    describe('when it is rerendered', () => {
+        // Needed to change input for rerender to work correctly
+        beforeEach(async() => await component.rerender(assign({}, input, { disabled: false })));
+        thenItCanBeOpenAndClosed();
+    });
+
+    function thenItCanBeOpenAndClosed() {
+        describe('when the host element is clicked', () => {
+            beforeEach(async() => {
+                await fireEvent.click(component.getByLabelText(input.ariaLabel));
+            });
+
+            it('then it emits the tooltip-expand event', () => {
+                expect(component.emitted('tooltip-expand')).has.length(1);
+            });
+
+            it('then it is expanded', async() => {
+                await wait(() => {
+                    expect(component.getByLabelText(input.ariaLabel)).has.attr('aria-expanded', 'true');
+                    expect(component.getByRole('dialog')).does.not.have.attr('hidden');
+                });
+            });
+
+            describe('when the host element is clicked a second time to close', () => {
+                beforeEach(async() => {
+                    await fireEvent.click(component.getByLabelText(input.ariaLabel));
+                });
+
+                it('then it emits the tooltip-collapse event', () => {
+                    expect(component.emitted('tooltip-collapse')).has.length(1);
+                });
+
+                it('then it is collapsed', async() => {
+                    await wait(() => {
+                        expect(component.getByLabelText(input.ariaLabel)).does.not.have.attr('aria-expanded', 'true');
+                        expect(component.getByRole('dialog')).has.attr('hidden');
+                    });
                 });
             });
         });

--- a/src/components/ebay-infotip/test/test.server.js
+++ b/src/components/ebay-infotip/test/test.server.js
@@ -1,5 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
+const assign = require('core-js-pure/features/object/assign');
 const { runTransformer } = require('../../../common/test-utils/server');
 const transformer = require('../transformer');
 const template = require('..');
@@ -29,6 +30,21 @@ describe('infotip', () => {
 
     // TODO: Does not look like this tag passes through class and style?
     // testPassThroughAttributes(template);
+});
+
+describe('infotip modal', () => {
+    it('renders modal infotip', async() => {
+        const input = mock.ModalWithContent;
+        const { getByLabelText, getByText } = await render(template, input);
+        expect(getByLabelText(input.ariaLabel)).has.class('dialog--mini__host');
+        expect(getByText(input.content.renderBody.text)).has.class('dialog__main');
+    });
+
+    it('renders modal infotip without header', async() => {
+        const input = assign({}, mock.WithContentAndHeader, { modal: true });
+        const { queryByText } = await render(template, input);
+        expect(queryByText(input.heading.renderBody.text)).equals(null);
+    });
 });
 
 describe('transformer', () => {

--- a/src/components/marko.json
+++ b/src/components/marko.json
@@ -1,4 +1,7 @@
 {
+  "<ebay-dialog-base>": {
+    "renderer": "./components/ebay-dialog-base/index.marko"
+  },
   "<ebay-tooltip-base>": {
     "renderer": "./components/ebay-tooltip-base/index.marko"
   },


### PR DESCRIPTION
## Description
When `modal` is true on infotip, then will render with mini dialog instead.
 
## Context
* I didn't see any header content on the skin side, I removed it
* I had to add a `class {}` (thanks Dylan) to the top of the example because there was marko re-rendering issue when doing the first render
* Some tests were causing pagination to fail. I changed it so it checks the state change too.
* Loaded css for dialog-base since I did not want to load dialog on infotip
* I tried to match as best as I could from the skin side. It looks like it had backdrop, and keyboard trap. I can remove those if needed.

## References
#1118 

## Screenshots
<img width="1137" alt="Screen Shot 2020-05-20 at 1 39 03 PM" src="https://user-images.githubusercontent.com/1755269/82494997-4a955680-9a9f-11ea-9abc-e41cb0fa04a4.png">
