### PR TITLE
Added setTimeout to listbox-change so it will wait for form to be filled

### DIFF
--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -26,16 +26,18 @@ module.exports = {
         elementScroll.scroll(el);
         this.state.selectedIndex = selectedIndex;
 
-        this.emit('listbox-change', {
-            index: selectedIndex,
-            selected: [option.value],
-            el
-        });
-
         if (this.wasClicked) {
             this._expander.collapse();
             this.wasClicked = false;
         }
+
+        setTimeout(() => {
+            this.emit('listbox-change', {
+                index: selectedIndex,
+                selected: [option.value],
+                el
+            });
+        }, 0);
     },
 
     onCreate() {


### PR DESCRIPTION
## Description
If `listbox-change` is triggered, then will need to wait till stack is cleared in order to allow forms to be submitted. Added a setTimeout to allow that to happen. 

## Context
Tests all passed with this change so it seems safe
Also if there is a better way to do this in more marko syntax, let me know. I couldn't find a better way.  

## References
#1115 