### PR TITLE
Added listbox-change even to fire only when marko updates

### DIFF
--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -23,20 +23,22 @@ module.exports = {
         const el = this.getEls('option')[selectedIndex];
         const option = this.input.options[selectedIndex];
 
-        elementScroll.scroll(el);
-        this.state.selectedIndex = selectedIndex;
+        if (this.state.selectedIndex !== selectedIndex) {
+            elementScroll.scroll(el);
 
-        this.once('update', () => {
-            this.emit('listbox-change', {
-                index: selectedIndex,
-                selected: [option.value],
-                el
+            this.state.selectedIndex = selectedIndex;
+            this.once('update', () => {
+                this.emit('listbox-change', {
+                    index: selectedIndex,
+                    selected: [option.value],
+                    el
+                });
             });
-        });
 
-        if (this.wasClicked) {
-            this._expander.collapse();
-            this.wasClicked = false;
+            if (this.wasClicked) {
+                this._expander.collapse();
+                this.wasClicked = false;
+            }
         }
     },
 

--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -26,10 +26,12 @@ module.exports = {
         elementScroll.scroll(el);
         this.state.selectedIndex = selectedIndex;
 
-        this.emit('listbox-change', {
-            index: selectedIndex,
-            selected: [option.value],
-            el
+        this.once('update', () => {
+            this.emit('listbox-change', {
+                index: selectedIndex,
+                selected: [option.value],
+                el
+            });
         });
 
         if (this.wasClicked) {

--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -23,9 +23,14 @@ module.exports = {
         const el = this.getEls('option')[selectedIndex];
         const option = this.input.options[selectedIndex];
 
-        if (this.state.selectedIndex !== selectedIndex) {
-            elementScroll.scroll(el);
+        elementScroll.scroll(el);
 
+        if (this.wasClicked) {
+            this._expander.collapse();
+            this.wasClicked = false;
+        }
+
+        if (this.state.selectedIndex !== selectedIndex) {
             this.state.selectedIndex = selectedIndex;
             this.once('update', () => {
                 this.emit('listbox-change', {
@@ -34,11 +39,6 @@ module.exports = {
                     el
                 });
             });
-
-            if (this.wasClicked) {
-                this._expander.collapse();
-                this.wasClicked = false;
-            }
         }
     },
 


### PR DESCRIPTION
## Description
Added `this.once('update')` to trigger change event on listbox.

## Context
Couple of issues with this new change
* This leads to an issue where if the user presses the currently selected item, it does not trigger a change event. This makes sense but can lead to a possible breaking change since we are changing how `listbox-change` event works.
* I added a check to see if the selected index did change and this way it makes it so the event only is triggered when the non selected item is clicked. It also doesn't collapse the menu since it is already selected. 

Another option would be to always trigger the change event and then maybe have another event on update which only triggers on changing. 


## References
#1115 
