### PR TITLE
Added focusables to triger after request Animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "makeup-active-descendant": "0.3.9",
     "makeup-expander": "~0.8.6",
     "makeup-floating-label": "~0.0.6",
-    "makeup-focusables": "~0.0.5",
+    "makeup-focusables": "~0.1.0",
     "makeup-key-emitter": "~0.1.3",
     "makeup-keyboard-trap": "~0.2.3",
     "makeup-prevent-scroll-keys": "~0.0.4",

--- a/src/components/components/ebay-tooltip-base/component.js
+++ b/src/components/components/ebay-tooltip-base/component.js
@@ -32,27 +32,13 @@ module.exports = {
         this._cleanupMakeup();
     },
 
-    _setupMakeup() {
+    _setupExpander(host, hostSelector) {
         const { input } = this;
         const { type } = input;
         const container = this.getEl('container');
         const isTooltip = type === 'tooltip';
         const isInfotip = type === 'infotip';
-        const hostClass = `${type}__host`;
-        const hostSelector = `.${hostClass}`;
         const expanderEl = container.getElementsByClassName(type)[0];
-        let host = container.querySelector(hostSelector);
-
-        if (!host) {
-            const curFocusable = focusables(container)[0];
-            if (curFocusable) {
-                host = curFocusable;
-
-                if (!curFocusable.classList.contains(hostClass)) {
-                    curFocusable.classList.add(hostClass);
-                }
-            }
-        }
 
         if (host) {
             this._expander = new Expander(expanderEl, {
@@ -72,7 +58,40 @@ module.exports = {
         }
     },
 
+    _setupMakeup() {
+        const { input } = this;
+        const { type } = input;
+        const container = this.getEl('container');
+        const hostClass = `${type}__host`;
+        const hostSelector = `.${hostClass}`;
+        let host = container.querySelector(hostSelector);
+
+        if (!host) {
+            if (this.cancelFocus) {
+                this.cancelFocus();
+            }
+
+            this.cancelFocus = focusables(container, false, (curFocusables) => {
+                const curFocusable = curFocusables[0];
+                if (curFocusable) {
+                    host = curFocusable;
+
+                    if (!curFocusable.classList.contains(hostClass)) {
+                        curFocusable.classList.add(hostClass);
+                    }
+                }
+                this._setupExpander(host, hostSelector);
+            });
+        } else {
+            this._setupExpander(host, hostSelector);
+        }
+    },
+
     _cleanupMakeup() {
+        if (this.cancelFocus) {
+            this.cancelFocus();
+        }
+
         if (this._expander) {
             this._expander.cancelAsync();
             this._expander = undefined;

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -91,14 +91,13 @@ function onRender() {
 
         // Ensure only visible items within the carousel are focusable.
         // We don't have access to these items in the template so me must update manually.
-        forEls(listEl, itemEl => {
-            cleanupFocusables.call(this);
-            this.cancelFocusList.push(focusables(itemEl, false, (focusEl) => {
-                focusEl.forEach(itemEl.getAttribute('aria-hidden') !== 'true'
+        this.focusFrame = requestAnimationFrame(() => {
+            forEls(listEl, itemEl => {
+                focusables(itemEl).forEach(itemEl.getAttribute('aria-hidden') !== 'true'
                     ? child => child.removeAttribute('tabindex')
                     : child => child.setAttribute('tabindex', '-1')
                 );
-            }));
+            });
         });
 
         if (config.nativeScrolling) {
@@ -151,19 +150,13 @@ function onRender() {
     });
 }
 
-function cleanupFocusables() {
-    while (this.cancelFocusList && this.cancelFocusList.length) {
-        this.cancelFocusList.pop()();
-    }
-}
-
 /**
  * Called before updates and before the widget is destroyed to remove any pending async timers / actions.
  */
 function cleanupAsync() {
     clearTimeout(this.autoplayTimeout);
     cancelAnimationFrame(this.renderFrame);
-    cleanupFocusables.call(this);
+    cancelAnimationFrame(this.focusFrame);
 
     if (this.cancelScrollTransition) {
         this.cancelScrollTransition();

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -92,10 +92,13 @@ function onRender() {
         // Ensure only visible items within the carousel are focusable.
         // We don't have access to these items in the template so me must update manually.
         forEls(listEl, itemEl => {
-            focusables(itemEl).forEach(itemEl.getAttribute('aria-hidden') !== 'true'
-                ? child => child.removeAttribute('tabindex')
-                : child => child.setAttribute('tabindex', '-1')
-            );
+            cleanupFocusables.call(this);
+            this.cancelFocusList.push(focusables(itemEl, false, (focusEl) => {
+                focusEl.forEach(itemEl.getAttribute('aria-hidden') !== 'true'
+                    ? child => child.removeAttribute('tabindex')
+                    : child => child.setAttribute('tabindex', '-1')
+                );
+            }));
         });
 
         if (config.nativeScrolling) {
@@ -148,12 +151,19 @@ function onRender() {
     });
 }
 
+function cleanupFocusables() {
+    while (this.cancelFocusList && this.cancelFocusList.length) {
+        this.cancelFocusList.pop()();
+    }
+}
+
 /**
  * Called before updates and before the widget is destroyed to remove any pending async timers / actions.
  */
 function cleanupAsync() {
     clearTimeout(this.autoplayTimeout);
     cancelAnimationFrame(this.renderFrame);
+    cleanupFocusables.call(this);
 
     if (this.cancelScrollTransition) {
         this.cancelScrollTransition();
@@ -521,6 +531,7 @@ module.exports = {
 
     onMount() {
         const { state: { config } } = this;
+        this.cancelFocusList = [];
         this.listEl = this.getEl('list');
         this.nextEl = this.getEl('next');
         this.containerEl = this.getEl('container');

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -524,7 +524,6 @@ module.exports = {
 
     onMount() {
         const { state: { config } } = this;
-        this.cancelFocusList = [];
         this.listEl = this.getEl('list');
         this.nextEl = this.getEl('next');
         this.containerEl = this.getEl('container');

--- a/yarn.lock
+++ b/yarn.lock
@@ -11483,6 +11483,11 @@ makeup-focusables@latest, makeup-focusables@~0.0.5:
   resolved "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.0.5.tgz#591490ba28b442c63882783082c8a7d960866985"
   integrity sha512-64FMsmJ6icCZTrXdHex12JQu4sPdFVX2qFRFNxnDco4ZT+PzFaGKC8rWPeXE+Cy/7TtjKViXjO1FePts8wAaeA==
 
+makeup-focusables@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.1.0.tgz#df3a0d70b58f6e40cb973514855f4fbd3b53febc"
+  integrity sha512-rBUb7cECtGGC60Z1zRjEUyweCh4gMqWOUzDERLu2xEKBGdh+upDciOucrLiGt/gawJhFnI+HA3AabLSo6mm43Q==
+
 makeup-key-emitter@~0.1.2, makeup-key-emitter@~0.1.3:
   version "0.1.3"
   resolved "https://registry.npmjs.org/makeup-key-emitter/-/makeup-key-emitter-0.1.3.tgz#2537a5733622d843759b91d1670222b09d05c57b"


### PR DESCRIPTION

## Description
Changed focusables to trigger on callback. If this PR looks good will push it to `4.5.0` as well.

## Context
* For carousel, there are multiple focusable calls. We could optimize to add them all in 1 call, but for now I left it to trigger each one. I also have the return be set in an array and cancel will cancel all the requests
* For tooltip-base I had to refactor since the host retrieved from focusables was used in expander. I split up the setupMakeup to have a setupExpander method too to be used in two places. 
