### PR TITLE
Removed w-preserve-body on menu-button

### DIFF
--- a/src/components/ebay-menu-button/template.marko
+++ b/src/components/ebay-menu-button/template.marko
@@ -57,7 +57,7 @@
         </if>
         <else>
             <span class=['expand-btn__cell', (data.label && 'menu-button__control--custom-label')]>
-                <span if(data.label) w-preserve-body>
+                <span if(data.label)>
                     <span w-body=data.label.renderBody body-only-if(true)/>
                 </span>
                 <else>


### PR DESCRIPTION
## Description
We fixed this in `5.2.x` but this is affecting people on the `4.5.x` release. Backported this fix in order to support them.

## References
For #1087 
