### PR TITLE
Updated CI to use chrome 55 to fix async problems in tests

### DIFF
--- a/marko-cli.js
+++ b/marko-cli.js
@@ -29,7 +29,7 @@ module.exports = ({ config }) => {
             os_version: '10'
         }, {
             browser: 'Chrome',
-            browser_version: '49.0',
+            browser_version: '55.0',
             os: 'Windows',
             os_version: '7'
         // }, {

--- a/src/components/ebay-filter-menu-button/test/test.browser.js
+++ b/src/components/ebay-filter-menu-button/test/test.browser.js
@@ -1,4 +1,5 @@
 const assign = require('core-js-pure/features/object/assign');
+const flat = require('core-js-pure/features/array/flat');
 const { expect, use } = require('chai');
 const { render, fireEvent, cleanup } = require('@marko/testing-library');
 const { pressKey } = require('../../../common/test-utils/browser');
@@ -148,7 +149,7 @@ describe('given the menu is in the expanded state', () => {
             const changeEvents = component.emitted('filter-menu-button-change');
             expect(changeEvents).to.have.length(2);
 
-            const [firstEventData, secondEventData] = changeEvents.flat();
+            const [firstEventData, secondEventData] = flat(changeEvents);
             expect(firstEventData).has.property('el', firstItem);
             expect(secondEventData).has.property('el', secondItem);
         });
@@ -169,7 +170,7 @@ describe('given the menu is in the expanded state', () => {
             const changeEvents = component.emitted('filter-menu-button-change');
             expect(changeEvents).to.have.length(2);
 
-            const [firstEventData, secondEventData] = changeEvents.flat();
+            const [firstEventData, secondEventData] = flat(changeEvents);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
             expect(secondEventData).has.property('checked').to.deep.equal([]);
         });
@@ -191,7 +192,7 @@ describe('given the menu is in the expanded state', () => {
             const changeEvents = component.emitted('filter-menu-button-change');
             expect(changeEvents).to.have.length(1);
 
-            const [firstEventData] = changeEvents.flat();
+            const [firstEventData] = flat(changeEvents);
             expect(firstEventData).has.property('el').with.text(firstItemText);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
         });

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -1,5 +1,6 @@
 const { expect, use } = require('chai');
 const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const flat = require('core-js-pure/features/array/flat');
 const { pressKey } = require('../../../common/test-utils/browser');
 const template = require('..');
 const mock = require('./mock');
@@ -47,7 +48,7 @@ describe('given the menu is in the default state', () => {
             const changeEvents = component.emitted('filter-menu-change');
             expect(changeEvents).to.have.length(2);
 
-            const [firstEventData, secondEventData] = changeEvents.flat();
+            const [firstEventData, secondEventData] = flat(changeEvents);
             expect(firstEventData).has.property('el', firstItem);
             expect(secondEventData).has.property('el', secondItem);
         });
@@ -68,7 +69,7 @@ describe('given the menu is in the default state', () => {
             const changeEvents = component.emitted('filter-menu-change');
             expect(changeEvents).to.have.length(2);
 
-            const [firstEventData, secondEventData] = changeEvents.flat();
+            const [firstEventData, secondEventData] = flat(changeEvents);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
             expect(secondEventData).has.property('checked').to.deep.equal([]);
         });
@@ -90,7 +91,7 @@ describe('given the menu is in the default state', () => {
             const changeEvents = component.emitted('filter-menu-change');
             expect(changeEvents).to.have.length(1);
 
-            const [firstEventData] = changeEvents.flat();
+            const [firstEventData] = flat(changeEvents);
             expect(firstEventData).has.property('el').with.text(firstItemText);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
         });


### PR DESCRIPTION
## Description
It seems like the CI has an issue with `async` and `await` not being transformed. This is only for tests. I updated the chrome version to support `55` which seems to be working. 
I did also have to change a polyfill in core-js in some of the tests to get it working.

Also I want to merge this into `5.5.0` before cutting off a `5.6.0` branch so our tests pass when creating PRs