### PR TITLE
Added postfix and prefix icon to textbox

### DIFF
--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -17,7 +17,7 @@ Name | Type | Stateful | Required | Description
 `invalid` | Boolean | No | No | indicates a field-level error with red border if true
 `prefix-icon` | String | No | No | name of the icon from skin to show as the prefix icon
 `postfix-icon` | String | No | No | name of the icon from skin to show as the postfix icon
-`postfix-aria-label` | String | No | No | aria-label for postfix. Required to be set in order to render postfix button and attach a `textbox-postfix-click event`
+`button-aria-label` | String | No | No | aria-label for postfix. Required to be set in order to render postfix button and attach a `textbox-button-click event`
 
 ## ebay-textbox Events
 
@@ -31,4 +31,4 @@ Event | Data | Description
 `textbox-keypress` | `{ originalEvent, value }` |
 `textbox-keyup` | `{ originalEvent, value }` |
 `textbox-floating-label-init` | `{ originalEvent: null, value: null }` |
-`textbox-postfix-click` | `{ originalEvent, value }` | Triggers when clicking on postfix-icon-button. Requires postfix-aria-label to be present in order to attach correctly
+`textbox-button-click` | `{ originalEvent, value }` | Triggers when clicking on postfix-icon-button. Requires button-aria-label to be present in order to attach correctly

--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -15,8 +15,9 @@ Name | Type | Stateful | Required | Description
 `fluid` | Boolean | No | No |
 `multiline` | Boolean | No | No | renders a multi-line texbox if true
 `invalid` | Boolean | No | No | indicates a field-level error with red border if true
-`icon` | String | No | No | name of the icon from skin
-`icon-position` | String | No | No | Can be "prefix" / "postfix". If not specified or if the value passed is neither "prefix" nor "postfix",  the `icon-position` is set by default to "prefix"
+`prefix-icon` | String | No | No | name of the icon from skin to show as the prefix icon
+`postfix-icon` | String | No | No | name of the icon from skin to show as the postfix icon
+`postfix-aria-label` | String | No | No | aria-label for postfix. Required to be set in order to render postfix button and attach a `textbox-postfix-click event`
 
 ## ebay-textbox Events
 
@@ -30,3 +31,4 @@ Event | Data | Description
 `textbox-keypress` | `{ originalEvent, value }` |
 `textbox-keyup` | `{ originalEvent, value }` |
 `textbox-floating-label-init` | `{ originalEvent: null, value: null }` |
+`textbox-postfix-click` | `{ originalEvent, value }` | Triggers when clicking on postfix-icon-button. Requires postfix-aria-label to be present in order to attach correctly

--- a/src/components/ebay-textbox/component.js
+++ b/src/components/ebay-textbox/component.js
@@ -9,7 +9,7 @@ module.exports = {
     handleInput: forwardEvent('input'),
     handleFocus: forwardEvent('focus'),
     handleBlur: forwardEvent('blur'),
-    handlePostfixClick: forwardEvent('postfix-click'),
+    handleButtonClick: forwardEvent('button-click'),
 
     onMount() {
         this._setupMakeup();

--- a/src/components/ebay-textbox/component.js
+++ b/src/components/ebay-textbox/component.js
@@ -9,6 +9,7 @@ module.exports = {
     handleInput: forwardEvent('input'),
     handleFocus: forwardEvent('focus'),
     handleBlur: forwardEvent('blur'),
+    handlePostfixClick: forwardEvent('postfix-click'),
 
     onMount() {
         this._setupMakeup();

--- a/src/components/ebay-textbox/examples/19-both-icons/template.marko
+++ b/src/components/ebay-textbox/examples/19-both-icons/template.marko
@@ -17,7 +17,7 @@ class {
     value=state.value
     prefix-icon="user-profile"
     postfix-icon="close"
-    postfix-aria-label="Clear"
+    button-aria-label="Clear"
     placeholder="name"
     on-textbox-change("change")
-    on-textbox-postfix-click("clear")/>
+    on-textbox-button-click("clear")/>

--- a/src/components/ebay-textbox/examples/19-both-icons/template.marko
+++ b/src/components/ebay-textbox/examples/19-both-icons/template.marko
@@ -1,0 +1,23 @@
+class {
+    onCreate() {
+        this.state = {
+            value: ""
+        };
+    }
+    change({ value }) {
+        this.state.value = value
+    }
+    clear() {
+        this.state.value = "";
+    }
+}
+
+<ebay-textbox
+    key="textbox"
+    value=state.value
+    prefix-icon="user-profile"
+    postfix-icon="close"
+    postfix-aria-label="Clear"
+    placeholder="name"
+    on-textbox-change("change")
+    on-textbox-postfix-click("clear")/>

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -58,7 +58,7 @@ $ var id = input.id || component.getElId("textbox");
             <if(input.multiline && input.value)>${input.value}</if>
         </>
         <if(displayIcon && input.postfixIcon)>
-            <${input.postfixAriaLabel && "button"} class="icon-btn" aria-label=input.postfixAriaLabel on-click("handlePostfixClick") >
+            <${input.buttonAriaLabel && "button"} class="icon-btn" aria-label=input.buttonAriaLabel on-click("handleButtonClick") >
                 <${input.postfixIconTag} />
             </>
         </if>

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -6,14 +6,14 @@ static var ignoredAttributes = [
     "invalid",
     "fluid",
     "multiline",
-    "icon",
-    "iconPosition",
-    "iconTag",
-    "floatingLabel"
+    "floatingLabel",
+    "prefix-icon",
+    "postfix-icon"
 ];
 
-$ var isPostfixIcon = input.iconPosition === "postfix";
-$ var displayIcon = Boolean(!input.multiline && input.iconTag);
+$ var isPostfix = !!input.postfixIcon;
+$ var hasIcon = (input.prefixIcon || isPostfix);
+$ var displayIcon = Boolean(!input.multiline && hasIcon);
 $ var id = input.id || component.getElId("textbox");
 <${input.floatingLabel && "span"} class="floating-label">
     <if(input.floatingLabel)>
@@ -31,10 +31,10 @@ $ var id = input.id || component.getElId("textbox");
         class=[
             "textbox",
             input.class,
-            displayIcon && isPostfixIcon && "textbox--icon-end"
+            displayIcon && isPostfix && "textbox--icon-end"
         ]>
-        <if(displayIcon && !isPostfixIcon)>
-            <${input.iconTag}/>
+        <if(displayIcon && input.prefixIcon)>
+            <${input.prefixIconTag}/>
         </if>
         <${input.multiline ? "textarea" : "input"}
             ...processHtmlAttributes(input, ignoredAttributes)
@@ -57,8 +57,10 @@ $ var id = input.id || component.getElId("textbox");
             onBlur("handleBlur")>
             <if(input.multiline && input.value)>${input.value}</if>
         </>
-        <if(displayIcon && isPostfixIcon)>
-            <${input.iconTag}/>
+        <if(displayIcon && input.postfixIcon)>
+            <${input.postfixAriaLabel && "button"} class="icon-btn" aria-label=input.postfixAriaLabel on-click("handlePostfixClick") >
+                <${input.postfixIconTag} />
+            </>
         </if>
     </>
 </>

--- a/src/components/ebay-textbox/marko-tag.json
+++ b/src/components/ebay-textbox/marko-tag.json
@@ -1,6 +1,7 @@
 {
   "template": "./index.marko",
   "transformer": "./transformer.js",
+  "migrator": "./migrator.js",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,
@@ -15,10 +16,14 @@
   "@multiline": "boolean",
   "@floating-label": "string",
   "@icon": "string",
+  "@prefix-icon": "string",
+  "@postfix-icon": "string",
   "@icon-position": {
     "enum": ["prefix", "postfix"]
   },
-  "@iconTag <_icon>": {},
+  "@postfixIconTag <_postfixIcon>": {},
+  "@prefixIconTag <_prefixIcon>": {},
+  "@postfix-aria-label": "string",
   "@autocomplete": "#html-autocomplete",
   "@autofocus": "#html-autofocus",
   "@dirname": "#html-dirname",

--- a/src/components/ebay-textbox/marko-tag.json
+++ b/src/components/ebay-textbox/marko-tag.json
@@ -23,7 +23,7 @@
   },
   "@postfixIconTag <_postfixIcon>": {},
   "@prefixIconTag <_prefixIcon>": {},
-  "@postfix-aria-label": "string",
+  "@button-aria-label": "string",
   "@autocomplete": "#html-autocomplete",
   "@autofocus": "#html-autofocus",
   "@dirname": "#html-dirname",

--- a/src/components/ebay-textbox/migrator.js
+++ b/src/components/ebay-textbox/migrator.js
@@ -1,0 +1,16 @@
+// Transforms old icon to prefix or postfix icon
+function migrate(el, context) {
+    if (el.hasAttribute('icon')) {
+        const attr = el.getAttribute('icon');
+        const isPostfix = el.hasAttribute('icon-position') &&
+            el.getAttributeValue('icon-position').value === 'postfix';
+
+        el.setAttributeValue(isPostfix ? 'postfix-icon' : 'prefix-icon', attr.value);
+        el.removeAttribute('icon-position');
+        el.removeAttribute('icon');
+
+        context.deprecate('attribute icon is now deprecated. Use prefix-icon or postfix-icon instead');
+    }
+}
+
+module.exports = migrate;

--- a/src/components/ebay-textbox/style.js
+++ b/src/components/ebay-textbox/style.js
@@ -1,2 +1,3 @@
 require('@ebay/skin/label');
 require('@ebay/skin/textbox');
+require('@ebay/skin/actionable');

--- a/src/components/ebay-textbox/test/mock/index.js
+++ b/src/components/ebay-textbox/test/mock/index.js
@@ -44,7 +44,7 @@ exports.Postfix_Icon = assign({}, exports.Basic, {
 });
 
 exports.Postfix_Icon_Button = assign({}, exports.Postfix_Icon, {
-    postfixAriaLabel: 'search button'
+    buttonAriaLabel: 'search button'
 });
 
 exports.Floating_Label = assign({}, exports.Basic, {

--- a/src/components/ebay-textbox/test/mock/index.js
+++ b/src/components/ebay-textbox/test/mock/index.js
@@ -1,5 +1,13 @@
 const assign = require('core-js-pure/features/object/assign');
 const { createRenderBody } = require('../../../../common/test-utils/shared');
+const iconBody = {
+    renderBody: createRenderBody(
+        '<svg class="textbox__icon" focusable="false" id="w11-w0" ' +
+        'aria-hidden="true"> <defs id="w11-w0-defs"></defs><use ' +
+        'xlink:href="#icon-profile"></use></svg>',
+        ''
+    )
+};
 
 exports.Basic = {
     value: 'textbox value'
@@ -26,19 +34,17 @@ exports.Multiline = assign({}, exports.Basic, {
 });
 
 exports.Prefix_Icon = assign({}, exports.Basic, {
-    icon: 'search',
-    iconTag: {
-        renderBody: createRenderBody(
-            '<svg class="textbox__icon" focusable="false" id="w11-w0" ' +
-            'aria-hidden="true"> <defs id="w11-w0-defs"></defs><use ' +
-            'xlink:href="#icon-profile"></use></svg>',
-            ''
-        )
-    }
+    prefixIcon: 'search',
+    prefixIconTag: iconBody
 });
 
-exports.Postfix_Icon = assign({}, exports.Prefix_Icon, {
-    iconPosition: 'postfix'
+exports.Postfix_Icon = assign({}, exports.Basic, {
+    postfixIcon: 'search',
+    postfixIconTag: iconBody
+});
+
+exports.Postfix_Icon_Button = assign({}, exports.Postfix_Icon, {
+    postfixAriaLabel: 'search button'
 });
 
 exports.Floating_Label = assign({}, exports.Basic, {

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -91,10 +91,10 @@ describe('when the component has a postfix button', () => {
 
     beforeEach(async() => {
         component = await render(template, input);
-        await fireEvent.click(component.getByLabelText(input.postfixAriaLabel));
+        await fireEvent.click(component.getByLabelText(input.buttonAriaLabel));
     });
 
     it('it should trigger a postfix click event', () => {
-        expect(component.emitted('textbox-postfix-click')).has.length(1);
+        expect(component.emitted('textbox-button-click')).has.length(1);
     });
 });

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -85,3 +85,16 @@ describe('given an input textbox with floating label and no value', () => {
         });
     });
 });
+
+describe('when the component has a postfix button', () => {
+    const input = mock.Postfix_Icon_Button;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+        await fireEvent.click(component.getByLabelText(input.postfixAriaLabel));
+    });
+
+    it('it should trigger a postfix click event', () => {
+        expect(component.emitted('textbox-postfix-click')).has.length(1);
+    });
+});

--- a/src/components/ebay-textbox/transformer.js
+++ b/src/components/ebay-textbox/transformer.js
@@ -1,11 +1,8 @@
 const ebayUIAttributeTransformer = require('../../common/transformers/ebayui-attribute');
 
-// Transforms an `icon` attribute into an `<ebay-textbox:_icon>` tag
-function transform(el, context) {
-    ebayUIAttributeTransformer(el, context);
-
+function setIconTag(el, context, name, tag) {
     const builder = context.builder;
-    const iconAttribute = el.getAttribute('icon');
+    const iconAttribute = el.getAttribute(name);
     const iconName = iconAttribute && iconAttribute.value.value;
     if (iconName) {
         const iconTag = context.createNodeForEl('ebay-icon', [
@@ -23,13 +20,21 @@ function transform(el, context) {
             },
             {
                 name: 'class',
-                value: builder.literal('textbox__icon')
+                value: builder.literal('icon textbox__icon')
             }
         ]);
-        const ebayTextIconTag = context.createNodeForEl('ebay-textbox:_icon');
+        const ebayTextIconTag = context.createNodeForEl(`ebay-textbox:_${tag}`);
         ebayTextIconTag.appendChild(iconTag);
         el.prependChild(ebayTextIconTag);
     }
+}
+
+// Transforms an `icon` attribute into an `<ebay-textbox:_icon>` tag
+function transform(el, context) {
+    ebayUIAttributeTransformer(el, context);
+
+    setIconTag(el, context, 'prefix-icon', 'prefixIcon');
+    setIconTag(el, context, 'postfix-icon', 'postfixIcon');
 }
 
 module.exports = transform;


### PR DESCRIPTION
## Description
Added `postfix-icon` and `prefix-icon` attributes which can show prefix/postfix icons. Can combine both.
In order to render a button I added a `postfix-aria-label` attrbute which is required for the button to render (this way we don't need another attribute to set as button, if aria-label is set it should be a button)

## Context
I added a migrator to take icon to convert to prefix/postfix depdening on the iconPosition attribute. 

## References
#1132

## Screenshots
<img width="566" alt="image" src="https://user-images.githubusercontent.com/1755269/84951346-2714fa00-b0a5-11ea-90e5-e13c65657ab0.png">
