### PR TITLE
fix: issue to ebay-icon serializing to much data

### DIFF
--- a/src/components/ebay-icon/component-browser.js
+++ b/src/components/ebay-icon/component-browser.js
@@ -1,11 +1,6 @@
 let rootSvg;
 
-function noop() {}
-
 module.exports = {
-    onInput(input) {
-        input.toJSON = noop;
-    },
     onMount() {
         // Create a hidden svg to store all symbols on startup.
         if (!rootSvg) {

--- a/src/components/ebay-icon/index.marko
+++ b/src/components/ebay-icon/index.marko
@@ -1,5 +1,6 @@
 import processHtmlAttributes from "../../common/html-attributes"
 
+static function noop() {}
 static var isBrowser = typeof window !== "undefined";
 static var browserLookup = {};
 static var ignoredAttributes = [
@@ -8,6 +9,7 @@ static var ignoredAttributes = [
     "_themes"
 ];
 
+$ input.toJSON = noop;
 $ var lookup = isBrowser ? browserLookup : out.global;
 $ var a11yAttributes = input.a11yText ? { role: "img" } : { "aria-hidden": "true" }
 


### PR DESCRIPTION
## Description
I discovered our recent patch to fix the serialization for ebay-icon did not work. Reason being is that we put the `onInput` handler inside of `component-browser.js` which will never be called in the browser. Instead that'd need to be in `component.js`.

In this PR I opted to move that logic inside the template which also fixes the issue and doesn't require an additional file for this one handler.

