### PR TITLE
Omit toJSON attribute

### DIFF
--- a/src/components/ebay-breadcrumbs/index.marko
+++ b/src/components/ebay-breadcrumbs/index.marko
@@ -5,7 +5,8 @@ static var ignoredAttributes = [
     "a11yHeadingText",
     "a11yHeadingTag",
     "hijax",
-    "items"
+    "items",
+    "toJSON"
 ];
 
 $ input.toJSON = noop;

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -16,7 +16,8 @@ static var ignoredAttributes = [
     "truncate",
     "transparent",
     "badgeNumber",
-    "badgeAriaLabel"
+    "badgeAriaLabel",
+    "toJSON"
 ];
 
 $ {

--- a/src/components/ebay-checkbox/index.marko
+++ b/src/components/ebay-checkbox/index.marko
@@ -1,7 +1,7 @@
 import processHtmlAttributes from "../../common/html-attributes"
 
 static function noop() {}
-static var ignoredAttributes = ["class", "style", "size"];
+static var ignoredAttributes = ["class", "style", "size", "toJSON"];
 
 $ input.toJSON = noop;
 

--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -1,7 +1,7 @@
 import processHtmlAttributes from "../../common/html-attributes"
 
 static function noop() {}
-static var ignoredAttributes = ["open", "type", "size", "text"];
+static var ignoredAttributes = ["open", "type", "size", "text", "toJSON"];
 
 $ input.toJSON = noop;
 

--- a/src/components/ebay-expand-button/index.marko
+++ b/src/components/ebay-expand-button/index.marko
@@ -11,7 +11,8 @@ static var ignoredAttributes = [
     "fluid",
     "truncate",
     "fixedHeight",
-    "partiallyDisabled"
+    "partiallyDisabled",
+    "toJSON"
 ];
 
 $ input.toJSON = toJSON;

--- a/src/components/ebay-icon/index.marko
+++ b/src/components/ebay-icon/index.marko
@@ -7,7 +7,8 @@ static var browserLookup = {};
 static var ignoredAttributes = [
     "name",
     "noSkinClasses",
-    "_themes"
+    "_themes",
+    "toJSON"
 ];
 
 $ input.toJSON = noop;

--- a/src/components/ebay-radio/index.marko
+++ b/src/components/ebay-radio/index.marko
@@ -1,7 +1,7 @@
 import processHtmlAttributes from "../../common/html-attributes"
 
 static function noop() {}
-static var ignoredAttributes = ["class", "style", "size"];
+static var ignoredAttributes = ["class", "style", "size", "toJSON"];
 
 $ input.toJSON = noop;
 

--- a/src/components/ebay-switch/index.marko
+++ b/src/components/ebay-switch/index.marko
@@ -1,7 +1,7 @@
 import processHtmlAttributes from "../../common/html-attributes"
 
 static function noop() {}
-static var ignoredAttributes = ["class", "style"];
+static var ignoredAttributes = ["class", "style", "toJSON"];
 
 $ input.toJSON = noop;
 

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -13,7 +13,8 @@ static var ignoredAttributes = [
     "multiline",
     "floatingLabel",
     "prefix-icon",
-    "postfix-icon"
+    "postfix-icon",
+    "toJSON"
 ];
 
 $ input.toJSON = toJSON;

--- a/src/components/ebay-tourtip/index.marko
+++ b/src/components/ebay-tourtip/index.marko
@@ -8,7 +8,8 @@ static var ignoredAttributes = [
     "styleRight",
     "styleBottom",
     "a11yCloseText",
-    "host"
+    "host",
+    "toJSON"
 ];
 
 $ input.toJSON = noop;


### PR DESCRIPTION
## Description
In the previous patch to prevent serializing additional data there was a minor regression where now a `to-json` attribute is added to some of the split components since it was not added to the `ingnoredAttributesList`. This PR fixes that.
