### PR TITLE
Menu: keyboard focus issue with menu items #1172

### DIFF
--- a/src/components/ebay-menu/examples/08-item-disabled/template.marko
+++ b/src/components/ebay-menu/examples/08-item-disabled/template.marko
@@ -1,0 +1,5 @@
+<ebay-menu>
+    <ebay-menu-item>item 1 that has very long text</ebay-menu-item>
+    <ebay-menu-item disabled>item 2</ebay-menu-item>
+    <ebay-menu-item>item 3</ebay-menu-item>
+</ebay-menu>

--- a/src/components/ebay-menu/examples/09-fake-item-disabled/template.marko
+++ b/src/components/ebay-menu/examples/09-fake-item-disabled/template.marko
@@ -1,0 +1,5 @@
+<ebay-menu type="fake">
+    <ebay-menu-item href="#" current>item 1</ebay-menu-item>
+    <ebay-menu-item>item 2</ebay-menu-item>
+    <ebay-menu-item type="button">item 3</ebay-menu-item>
+</ebay-menu>

--- a/src/components/ebay-menu/index.marko
+++ b/src/components/ebay-menu/index.marko
@@ -67,7 +67,6 @@ $ var baseClass = input.classPrefix || (isFake ? "fake-menu" : "menu");
                 aria-checked=(!isNotCheckable && (checked ? "true" : "false"))
                 aria-current=(isNotCheckable && item.current ? "page" : false)
                 aria-disabled=(item.disabled && "true")
-                tabindex=(item.disabled ? -1 : item.tabindex)
                 href=(item.disabled ? null : item.href)
                 role=itemRole
                 onClick("handleItemClick", index)


### PR DESCRIPTION
Fixes #1172 

Reverts this change which is causing issues with rovingtabindex: https://github.com/eBay/ebayui-core/pull/1160/files#diff-ea16c9f6e2d541d4df9ad58a4be943dbR70

Adds two new stories for disabled menu items.