### PR TITLE
Added radio version of filter-menu-button

### DIFF
--- a/src/common/menu-utils/index.js
+++ b/src/common/menu-utils/index.js
@@ -1,0 +1,70 @@
+const findIndex = require('core-js-pure/features/array/find-index');
+
+function isRadio() {
+    return this.type === 'radio';
+}
+
+function getCheckedValues() {
+    if (this.isRadio()) {
+        const item = this.input.items[this.state.checkedIndex] || {};
+        return [item.value];
+    }
+    return this.input.items
+        .filter((item, index) => this.state.checkedItems[index])
+        .map(item => item.value);
+}
+
+function getCheckedIndexes() {
+    if (this.isRadio()) {
+        return [this.state.checkedIndex];
+    }
+    return this.input.items
+        .map((item, i) => this.state.checkedItems[i] && i)
+        .filter(item => item !== false && typeof item !== 'undefined');
+}
+
+function getInputState(input) {
+    this.type = input.type;
+    if (this.isRadio()) {
+        return {
+            checkedIndex: findIndex(input.items || [], item => item.checked || false)
+        };
+    }
+    return {
+        checkedItems: (input.items || []).map(item => item.checked || false)
+    };
+}
+
+function isChecked(index) {
+    if (this.isRadio()) {
+        return index === this.state.checkedIndex;
+    }
+    return this.state.checkedItems[index];
+}
+
+function toggleChecked(index) {
+    if (Array.isArray(index)) {
+        if (this.isRadio()) {
+            this.state.checkedIndex = index[0];
+        } else {
+            this.state.checkedItems = this.state.checkedItems.map((item, i) => index.indexOf(i) !== -1);
+        }
+        return;
+    }
+
+    if (this.isRadio() && index !== this.state.checkedIndex) {
+        this.state.checkedIndex = index;
+    } else if (this.type !== 'radio') {
+        this.state.checkedItems[index] = !this.state.checkedItems[index];
+        this.setStateDirty('checkedItems');
+    }
+}
+
+module.exports = {
+    isRadio,
+    getInputState,
+    isChecked,
+    getCheckedIndexes,
+    getCheckedValues,
+    toggleChecked
+};

--- a/src/common/menu-utils/test/test.browser.js
+++ b/src/common/menu-utils/test/test.browser.js
@@ -1,0 +1,120 @@
+const assign = require('core-js-pure/features/object/assign');
+const sinon = require('sinon');
+const { expect } = require('chai');
+const menuUtils = require('../');
+const { getNItems } = require('../../test-utils/shared');
+
+describe('non radio component', () => {
+    const input = {
+        type: 'checkbox',
+        items: getNItems(3, i => ({
+            value: `item ${i}`,
+            checked: i === 2
+        }))
+    };
+    let menu;
+
+    beforeEach(() => {
+        menu = assign({}, menuUtils, {
+            input,
+            setStateDirty: sinon.spy()
+        });
+        menu.state = menu.getInputState(input);
+    });
+
+    it('check initial state', () => {
+        expect(menu.state.checkedItems).to.deep.equal([false, false, true]);
+        expect(menu.isChecked(1)).to.equal(false);
+        expect(menu.isChecked(2)).to.equal(true);
+        expect(menu.getCheckedValues()).to.deep.equal(['item 2']);
+        expect(menu.getCheckedIndexes()).to.deep.equal([2]);
+    });
+    it('should toggle items', () => {
+        menu.toggleChecked(1);
+        menu.toggleChecked(2);
+        expect(menu.state.checkedItems).to.deep.equal([false, true, false]);
+        expect(menu.isChecked(0)).to.equal(false);
+        expect(menu.isChecked(1)).to.equal(true);
+        expect(menu.isChecked(2)).to.equal(false);
+        expect(menu.getCheckedValues()).to.deep.equal(['item 1']);
+        expect(menu.getCheckedIndexes()).to.deep.equal([1]);
+    });
+
+    it('should have multiple items toggled', () => {
+        menu.toggleChecked(0);
+        expect(menu.state.checkedItems).to.deep.equal([true, false, true]);
+        expect(menu.isChecked(0)).to.equal(true);
+        expect(menu.isChecked(1)).to.equal(false);
+        expect(menu.isChecked(2)).to.equal(true);
+        expect(menu.getCheckedValues()).to.deep.equal(['item 0', 'item 2']);
+        expect(menu.getCheckedIndexes()).to.deep.equal([0, 2]);
+    });
+
+    it('should toggle array of items', () => {
+        menu.toggleChecked([0, 2]);
+        expect(menu.state.checkedItems).to.deep.equal([true, false, true]);
+        expect(menu.isChecked(0)).to.equal(true);
+        expect(menu.isChecked(1)).to.equal(false);
+        expect(menu.isChecked(2)).to.equal(true);
+        expect(menu.getCheckedValues()).to.deep.equal(['item 0', 'item 2']);
+        expect(menu.getCheckedIndexes()).to.deep.equal([0, 2]);
+    });
+});
+
+describe('radio component', () => {
+    const input = {
+        type: 'radio',
+        items: getNItems(3, i => ({
+            value: `item ${i}`,
+            checked: i === 2
+        }))
+    };
+    let menu;
+
+    beforeEach(() => {
+        menu = assign({}, menuUtils, {
+            input,
+            setStateDirty: sinon.spy()
+        });
+        menu.state = menu.getInputState(input);
+    });
+
+    it('check initial state', () => {
+        expect(menu.state.checkedIndex).to.equal(2);
+        expect(menu.isChecked(1)).to.equal(false);
+        expect(menu.isChecked(2)).to.equal(true);
+        expect(menu.getCheckedValues()).to.deep.equal(['item 2']);
+        expect(menu.getCheckedIndexes()).to.deep.equal([2]);
+    });
+    it('should toggle items', () => {
+        menu.toggleChecked(1);
+        expect(menu.state.checkedIndex).to.equal(1);
+        expect(menu.isChecked(0)).to.equal(false);
+        expect(menu.isChecked(1)).to.equal(true);
+        expect(menu.isChecked(2)).to.equal(false);
+        expect(menu.getCheckedValues()).to.deep.equal(['item 1']);
+        expect(menu.getCheckedIndexes()).to.deep.equal([1]);
+    });
+
+    it('should have multiple items toggled', () => {
+        menu.toggleChecked(2);
+        menu.toggleChecked(1);
+        menu.toggleChecked(0);
+        expect(menu.state.checkedIndex).to.equal(0);
+        expect(menu.isChecked(0)).to.equal(true);
+        expect(menu.isChecked(1)).to.equal(false);
+        expect(menu.isChecked(2)).to.equal(false);
+        expect(menu.getCheckedValues()).to.deep.equal(['item 0']);
+        expect(menu.getCheckedIndexes()).to.deep.equal([0]);
+    });
+
+    it('should toggle array of items', () => {
+        menu.toggleChecked([0]);
+        expect(menu.state.checkedIndex).to.equal(0);
+        expect(menu.isChecked(0)).to.equal(true);
+        expect(menu.isChecked(1)).to.equal(false);
+        expect(menu.isChecked(2)).to.equal(false);
+        expect(menu.getCheckedValues()).to.deep.equal(['item 0']);
+        expect(menu.getCheckedIndexes()).to.deep.equal([0]);
+    });
+});

--- a/src/components/ebay-filter-menu-button/component.js
+++ b/src/components/ebay-filter-menu-button/component.js
@@ -1,15 +1,17 @@
+const assign = require('core-js-pure/features/object/assign');
 const Expander = require('makeup-expander');
 const eventUtils = require('../../common/event-utils');
+const menuUtils = require('../../common/menu-utils');
 
-module.exports = {
+module.exports = assign({}, menuUtils, {
     handleMenuKeydown({ originalEvent }) {
         eventUtils.handleEscapeKeydown(originalEvent, () => this._expander.collapse());
     },
 
-    handleMenuChange({ checked, el, originalEvent }) {
+    handleMenuChange({ checkedIndex, el, originalEvent }) {
         // TODO: the event data from the filter-menu should probably
         // change to include which items are checked not just the values.
-        this.state.isChecked = this.input.items.map(item => checked.indexOf(item.value) !== -1);
+        this.toggleChecked(checkedIndex);
         this._emitComponentEvent('change', el, originalEvent);
     },
 
@@ -32,9 +34,7 @@ module.exports = {
 
     onInput(input) {
         input.items = input.items || [];
-        this.state = {
-            isChecked: input.items.map(item => Boolean(item.checked))
-        };
+        this.state = this.getInputState(input);
     },
 
     onMount() {
@@ -64,10 +64,7 @@ module.exports = {
             case 'collapse':
             case 'form-submit':
             case 'footer-click': {
-                const { input, state } = this;
-                const checked = input.items
-                    .filter((_, i) => state.isChecked[i])
-                    .map(item => item.value);
+                const checked = this.getCheckedValues();
                 this.emit(`filter-menu-button-${eventType}`, {
                     el,
                     checked,
@@ -97,4 +94,4 @@ module.exports = {
             this._expander = undefined;
         }
     }
-};
+});

--- a/src/components/ebay-filter-menu-button/examples/06-radio/template.marko
+++ b/src/components/ebay-filter-menu-button/examples/06-radio/template.marko
@@ -1,0 +1,5 @@
+<ebay-filter-menu-button text="Radio menu" type="radio">
+    <ebay-filter-menu-button-item value="item 1">item 1</ebay-filter-menu-button-item>
+    <ebay-filter-menu-button-item value="item 2">item 2</ebay-filter-menu-button-item>
+    <ebay-filter-menu-button-item value="item 3">item 3</ebay-filter-menu-button-item>
+</ebay-filter-menu-button>

--- a/src/components/ebay-filter-menu-button/examples/07-radio-form-variant/template.marko
+++ b/src/components/ebay-filter-menu-button/examples/07-radio-form-variant/template.marko
@@ -1,0 +1,5 @@
+<ebay-filter-menu-button text="Filter Menu Footer" type="radio" footer-text="Apply" variant="form" form-name="filter-menu-button-form" form-action="http://www.ebay.com/">
+    <ebay-filter-menu-button-item value="item 1">item 1</ebay-filter-menu-button-item>
+    <ebay-filter-menu-button-item value="item 2">item 2</ebay-filter-menu-button-item>
+    <ebay-filter-menu-button-item value="item 3">item 3</ebay-filter-menu-button-item>
+</ebay-filter-menu-button>

--- a/src/components/ebay-filter-menu-button/index.marko
+++ b/src/components/ebay-filter-menu-button/index.marko
@@ -9,7 +9,8 @@ static var ignoredAttributes = [
     "formName",
     "formAction",
     "formMethod",
-    "items"
+    "items",
+    "type"
 ];
 
 <span
@@ -25,7 +26,7 @@ static var ignoredAttributes = [
         aria-expanded:no-update="false"
         aria-haspopup="true"
         aria-label=input.a11yText
-        aria-pressed=(state.isChecked.some(Boolean) && "true")>
+        aria-pressed=(component.getCheckedValues().some(Boolean) && "true")>
         <span class="filter-menu-button__button-cell">
             <span class="filter-menu-button__button-text">${input.text}</span>
             <ebay-icon name="chevron-down"/>
@@ -34,6 +35,7 @@ static var ignoredAttributes = [
     <ebay-filter-menu
         class-prefix="filter-menu-button"
         variant=input.variant
+        type=input.type
         form-name=input.formName
         form-action=input.formAction
         form-method=input.formMethod
@@ -43,7 +45,7 @@ static var ignoredAttributes = [
         onFilter-menu-form-submit("handleFormSubmit")
         onFilter-menu-footer-click("handleFooterButtonClick")>
         <for|item, i| of=input.items>
-            <@item ...item checked=state.isChecked[i]/>
+            <@item ...item checked=component.isChecked(i)/>
         </for>
     </ebay-filter-menu>
 </span>

--- a/src/components/ebay-filter-menu/README.md
+++ b/src/components/ebay-filter-menu/README.md
@@ -18,6 +18,7 @@ The `ebay-filter-menu` component is used as a checkbox menu specificially styled
 
 Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
+`type` | String | No | No | Can be "radio" / "checkbox"
 `footer-text` | String | Yes | No | footer button text
 `variant` | String | No | No | "" (default) / "form"
 `form-name` | String | No | No | form's `name` attribute (used with `variant="form"`)

--- a/src/components/ebay-filter-menu/component.js
+++ b/src/components/ebay-filter-menu/component.js
@@ -1,10 +1,14 @@
+const assign = require('core-js-pure/features/object/assign');
 const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 const rovingTabIndex = require('makeup-roving-tabindex');
 const eventUtils = require('../../common/event-utils');
+const menuUtils = require('../../common/menu-utils');
 
-module.exports = {
+module.exports = assign({}, menuUtils, {
     handleItemClick(index, ev, itemEl) {
-        this._toggleItemChecked(index, itemEl);
+        if (this.input.variant !== 'form' || ev.target.tagName !== 'INPUT') {
+            this._toggleItemChecked(index, itemEl);
+        }
     },
 
     handleItemKeydown(index, ev, itemEl) {
@@ -30,10 +34,7 @@ module.exports = {
     },
 
     onInput(input) {
-        input.items = input.items || [];
-        this.state = {
-            isChecked: input.items.map(item => Boolean(item.checked))
-        };
+        this.state = this.getInputState(input);
     },
 
     onMount() {
@@ -55,20 +56,18 @@ module.exports = {
     },
 
     _toggleItemChecked(index, itemEl) {
-        this.state.isChecked[index] = !this.state.isChecked[index];
-        this.setStateDirty('isChecked');
+        this.toggleChecked(index);
         this._emitComponentEvent('change', itemEl);
     },
 
     _emitComponentEvent(eventType, el, originalEvent) {
-        const { input, state } = this;
-        const checked = input.items
-            .filter((_, i) => state.isChecked[i])
-            .map(item => item.value);
+        const checked = this.getCheckedValues();
+        const checkedIndex = this.getCheckedIndexes();
 
         this.emit(`filter-menu-${eventType}`, {
             el,
             checked,
+            checkedIndex,
             originalEvent
         });
     },
@@ -93,4 +92,4 @@ module.exports = {
             scrollKeyPreventer.remove(this.getEl('container'));
         }
     }
-};
+});

--- a/src/components/ebay-filter-menu/component.js
+++ b/src/components/ebay-filter-menu/component.js
@@ -5,8 +5,13 @@ const eventUtils = require('../../common/event-utils');
 const menuUtils = require('../../common/menu-utils');
 
 module.exports = assign({}, menuUtils, {
+    handleRadioClick(index, ev, itemEl) {
+        this._toggleItemChecked(index, itemEl);
+    },
+
     handleItemClick(index, ev, itemEl) {
-        if (this.input.variant !== 'form' || ev.target.tagName !== 'INPUT') {
+        const targetEv = ev.originalEvent || ev;
+        if (this.input.variant !== 'form' || targetEv.target.tagName !== 'INPUT') {
             this._toggleItemChecked(index, itemEl);
         }
     },

--- a/src/components/ebay-filter-menu/examples/06-radio/template.marko
+++ b/src/components/ebay-filter-menu/examples/06-radio/template.marko
@@ -1,0 +1,5 @@
+<ebay-filter-menu type="radio">
+    <ebay-filter-menu-item value="item 1">item 1</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 2">item 2</ebay-filter-menu-item>
+    <ebay-filter-menu-item value="item 3">item 3</ebay-filter-menu-item>
+</ebay-filter-menu>

--- a/src/components/ebay-filter-menu/index.marko
+++ b/src/components/ebay-filter-menu/index.marko
@@ -9,11 +9,14 @@ static var ignoredAttributes = [
     "formName",
     "formAction",
     "formMethod",
-    "items"
+    "items",
+    "type"
 ];
 
 static var itemIgnoredAttributes = ["checked", "value"];
 
+$ var isRadio = input.type === "radio";
+$ var prefixName = isRadio ? 'radio' : 'checkbox';
 $ var baseClass = input.classPrefix || "filter-menu";
 $ var isForm = input.variant === "form";
 <span
@@ -28,27 +31,44 @@ $ var isForm = input.variant === "form";
         onSubmit("handleFormSubmit")>
         <div key="menu" class=`${baseClass}__items` role=(!isForm && "menu")>
             <for|item, i| of=input.items>
-                $ var isChecked = state.isChecked[i];
+                $ var isChecked = component.isChecked(i);
                 <${isForm ? "label" : "div"}
                     ...processHtmlAttributes(item, itemIgnoredAttributes)
                     class=[`${baseClass}__item`, item.class]
-                    role="menuitemcheckbox"
+                    role=(isRadio ? "menuitemradio" : "menuitemcheckbox")
                     aria-checked=String(isChecked)
-                    for=(isForm && component.elId(`checkbox-${i}`))
+                    for=(isForm && component.elId(`${prefixName}-${i}`))
                     onClick("handleItemClick", i)
                     onKeydown("handleItemKeydown", i)>
                     <if(isForm)>
-                        <ebay-checkbox id:scoped=`checkbox-${i}` checked=isChecked/>
+                        <if (isRadio)>
+                            <ebay-radio id:scoped=`${prefixName}-${i}` checked=isChecked/>
+                        </if>
+                        <else>
+                            <ebay-checkbox id:scoped=`${prefixName}-${i}` checked=isChecked/>
+                        </else>
                     </if>
                     <else>
-                        <span class=`${baseClass}__status`>
-                            <if(isChecked)>
-                                <ebay-icon name="checkbox-checked"/>
-                            </if>
-                            <else>
-                                <ebay-icon name="checkbox-unchecked"/>
-                            </else>
-                        </span>
+                        <if (isRadio)>
+                            <span class=`${baseClass}__radio`>
+                                <if(isChecked)>
+                                    <ebay-icon name="radio-checked"/>
+                                </if>
+                                <else>
+                                    <ebay-icon name="radio-unchecked"/>
+                                </else>
+                            </span>
+                        </if>
+                        <else>
+                            <span class=`${baseClass}__status`>
+                                <if(isChecked)>
+                                    <ebay-icon name="checkbox-checked"/>
+                                </if>
+                                <else>
+                                    <ebay-icon name="checkbox-unchecked"/>
+                                </else>
+                            </span>
+                        </else>
                     </else>
                     <span class=`${baseClass}__text`>
                         <${item.renderBody}/>

--- a/src/components/ebay-filter-menu/index.marko
+++ b/src/components/ebay-filter-menu/index.marko
@@ -42,7 +42,7 @@ $ var isForm = input.variant === "form";
                     onKeydown("handleItemKeydown", i)>
                     <if(isForm)>
                         <if (isRadio)>
-                            <ebay-radio id:scoped=`${prefixName}-${i}` checked=isChecked/>
+                            <ebay-radio id:scoped=`${prefixName}-${i}` checked=isChecked on-radio-change("handleRadioClick", i)/>
                         </if>
                         <else>
                             <ebay-checkbox id:scoped=`${prefixName}-${i}` checked=isChecked/>

--- a/src/components/ebay-filter-menu/test/mock/index.js
+++ b/src/components/ebay-filter-menu/test/mock/index.js
@@ -17,3 +17,22 @@ exports.Basic_3Items = assign({}, exports.Basic_2Items, {
         renderBody: createRenderBody(`Item text ${i}`)
     }))
 });
+
+exports.Radio_2Items = {
+    text: 'Radio Filter Menu Button',
+    type: 'radio',
+    footerText: 'Apply',
+    a11yText: 'Filter Menu Button A11y Text',
+    items: getNItems(2, i => ({
+        value: `item ${i}`,
+        renderBody: createRenderBody(`Item text ${i}`)
+    }))
+};
+
+exports.Radio_3Items = assign({}, exports.Radio_2Items, {
+    type: 'radio',
+    items: getNItems(3, i => ({
+        value: `item ${i}`,
+        renderBody: createRenderBody(`Item text ${i}`)
+    }))
+});

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -125,3 +125,118 @@ describe('given the menu is in the default state', () => {
         });
     });
 });
+
+describe('given the menu is in the radio state', () => {
+    const input = mock.Radio_2Items;
+    const firstItemText = input.items[0].renderBody.text;
+    let footerButton, firstItem, secondItem;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+        footerButton = component.getAllByRole('button')[0];
+        firstItem = component.getAllByRole('menuitemradio')[0];
+        secondItem = component.getAllByRole('menuitemradio')[1];
+    });
+
+    describe('when an item is clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(component.getByText(firstItemText));
+        });
+
+        it('then it emits the filter-menu-change event with correct data', () => {
+            const selectEvents = component.emitted('filter-menu-change');
+            expect(selectEvents).to.length(1);
+
+            const [[eventArg]] = selectEvents;
+            expect(eventArg).has.property('el').with.text(firstItemText);
+            expect(eventArg).has.property('checked').to.deep.equal(['item 0']);
+        });
+    });
+
+    describe('when two items are clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(firstItem);
+            await fireEvent.click(secondItem);
+        });
+
+        it('then it emits two menu-change events with correct data', () => {
+            const changeEvents = component.emitted('filter-menu-change');
+            expect(changeEvents).to.have.length(2);
+
+            const [firstEventData, secondEventData] = flat(changeEvents);
+            expect(firstEventData).has.property('el', firstItem);
+            expect(secondEventData).has.property('el', secondItem);
+        });
+
+        it('then only last item is selected', () => {
+            expect(firstItem).to.have.attr('aria-checked', 'false');
+            expect(secondItem).to.have.attr('aria-checked', 'true');
+        });
+    });
+
+    describe('when an item is clicked twice', () => {
+        beforeEach(async() => {
+            await fireEvent.click(firstItem);
+            await fireEvent.click(firstItem);
+        });
+
+        it('then it emits the filter-menu-change events with correct data', () => {
+            const changeEvents = component.emitted('filter-menu-change');
+            expect(changeEvents).to.have.length(2);
+
+            const [firstEventData, secondEventData] = flat(changeEvents);
+            expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
+            expect(secondEventData).has.property('checked').to.deep.equal(['item 0']);
+        });
+
+        it('then the item is still checked', () => {
+            expect(firstItem).to.have.attr('aria-checked', 'true');
+        });
+    });
+
+    describe('when an item is checked via the keyboard', () => {
+        beforeEach(async() => {
+            await pressKey(firstItem, {
+                key: '(Space character)',
+                keyCode: 32
+            });
+        });
+
+        it('then it emits the filter-menu-change events with correct data', () => {
+            const changeEvents = component.emitted('filter-menu-change');
+            expect(changeEvents).to.have.length(1);
+
+            const [firstEventData] = flat(changeEvents);
+            expect(firstEventData).has.property('el').with.text(firstItemText);
+            expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
+        });
+    });
+
+    describe('when the footer button is clicked', () => {
+        beforeEach(async() => {
+            await fireEvent.click(footerButton);
+        });
+
+        it('then it emits the filter-menu-footer-click event', () => {
+            const changeEvents = component.emitted('filter-menu-footer-click');
+            expect(changeEvents).to.have.length(1);
+        });
+    });
+
+    describe('when an item is added via input from its parent and the new item is clicked', () => {
+        const newInput = mock.Radio_3Items;
+        const thirdItemText = newInput.items[2].renderBody.text;
+        beforeEach(async() => {
+            await component.rerender(newInput);
+            await fireEvent.click(component.getByText(thirdItemText));
+        });
+
+        it('then it uses the new input in event data', () => {
+            const selectEvents = component.emitted('filter-menu-change');
+            expect(selectEvents).has.length(1);
+
+            const [[eventArg]] = selectEvents;
+            expect(eventArg).has.property('checked').to.deep.equal(['item 2']);
+        });
+    });
+});


### PR DESCRIPTION
## Description
Changed filter menu to have a radio component

## Context
Since menu and menu-button had similar code to do the radio/non radio versions, I basically took the code that those were using and put them into a menu-utils. This basically has common methods used across both menu and menu-button. This way we don't have to replicate code. There are some things I don't like such as state management in that, but this is by far the cleanest. 
At the moment, I extend the object using assign, but if there is a better way then I'm up for it.
This way all menu, menu-button, filter-menu, and filter-menu-button all have the same code for radio/non radio versions. 

## References
#1163 

## Screenshots
Basic radio popup
<img width="805" alt="Screen Shot 2020-07-14 at 8 24 54 PM" src="https://user-images.githubusercontent.com/1755269/87500702-07c0ac80-c612-11ea-91ef-c548f8d9081d.png">

Radio form
<img width="515" alt="Screen Shot 2020-07-14 at 8 25 00 PM" src="https://user-images.githubusercontent.com/1755269/87500718-11e2ab00-c612-11ea-934c-4a27b43892e9.png">

Radio selected item
<img width="700" alt="Screen Shot 2020-07-14 at 8 31 27 PM" src="https://user-images.githubusercontent.com/1755269/87500730-19a24f80-c612-11ea-93c2-a54731c27cf4.png">

Radio menu selected item.
<img width="390" alt="Screen Shot 2020-07-14 at 8 30 58 PM" src="https://user-images.githubusercontent.com/1755269/87500742-20c95d80-c612-11ea-9870-2345ffbb815f.png">
