### PR TITLE
Fixed ebay textbox ignored list for post/prefix icons

### DIFF
--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -12,8 +12,10 @@ static var ignoredAttributes = [
     "fluid",
     "multiline",
     "floatingLabel",
-    "prefix-icon",
-    "postfix-icon",
+    "prefixIcon",
+    "postfixIcon",
+    "prefixIconTag",
+    "postfixIconTag",
     "toJSON"
 ];
 


### PR DESCRIPTION
## Description
Just changed the ignored list for textbox to have the right syntax (no dashed and camel case)

## References
#1180

## Screenshots
<img width="577" alt="Screen Shot 2020-08-10 at 10 08 59 AM" src="https://user-images.githubusercontent.com/1755269/89810198-87e31080-daf1-11ea-9a53-d6981f5d5fdd.png">
