### PR TITLE
Fixed aria-selected check to check for value or text

### DIFF
--- a/src/components/ebay-combobox/index.marko
+++ b/src/components/ebay-combobox/index.marko
@@ -70,7 +70,7 @@ $ var hasButton = !!input.button;
     <if(component._hasVisibleOptions())>
         <div key="listbox" role="listbox" class="combobox__listbox">
             <for|option| of=component._getVisibleOptions()>
-                $ var isSelected = option.value === state.currentValue;
+                $ var isSelected = (option.value || option.text) === state.currentValue;
                 <div
                     ...processHtmlAttributes(option, itemIgnoredAttributes)
                     key="options[]"


### PR DESCRIPTION
## Description
We check state.selectedValue to item.value. If item.value is not set aria-selected to all values initially. So changed check to check text as well. 

## References
#1199
