### PR TITLE
Changed ebay-image in notice to use a11yText instead

### DIFF
--- a/src/components/ebay-notice/index.marko
+++ b/src/components/ebay-notice/index.marko
@@ -38,7 +38,7 @@ $ var isIconVisible = input.icon !== "none";
                     <ebay-icon
                         class="window-notice__icon"
                         name="confirmation-filled"
-                        aria-label=input.a11yHeadingText/>
+                        a11y-text=input.a11yHeadingText/>
                 </if>
                 <span
                     ...processHtmlAttributes(input.title)
@@ -48,13 +48,13 @@ $ var isIconVisible = input.icon !== "none";
             </if>
             <else>
                 <if(status === "confirmation" || status === "celebration")>
-                    <ebay-icon name="confirmation-filled" aria-label=input.a11yHeadingText/>
+                    <ebay-icon name="confirmation-filled" a11y-text=input.a11yHeadingText/>
                 </if>
                 <else if(status === "attention")>
-                    <ebay-icon name="attention-filled" aria-label=input.a11yHeadingText/>
+                    <ebay-icon name="attention-filled" a11y-text=input.a11yHeadingText/>
                 </else>
                 <else if(status === "information")>
-                    <ebay-icon name="information-filled" aria-label=input.a11yHeadingText/>
+                    <ebay-icon name="information-filled" a11y-text=input.a11yHeadingText/>
                 </else>
             </else>
         </>


### PR DESCRIPTION
## Description
Changed `<ebay-icon>` to use `a11yText` insteaf of `aria-label`

## References
#1198 

## Screenshots
<img width="1234" alt="Screen Shot 2020-08-19 at 12 38 28 PM" src="https://user-images.githubusercontent.com/1755269/90681822-e490aa80-e218-11ea-844f-ae7b4e7567da.png">
