### PR TITLE
Removed conditional header in dialog

### DIFF
--- a/src/components/components/ebay-dialog-base/index.marko
+++ b/src/components/components/ebay-dialog-base/index.marko
@@ -44,7 +44,7 @@ $ var header = input.header;
         <if(input.top)>
             <${input.top.renderBody}/>
         </if>
-        <${header ? "div" : null} class=`${input.classPrefix}__header`>
+        <div class=`${input.classPrefix}__header`>
             <if(header && buttonPosition === "right")>
                 <header-content/>
             </if>


### PR DESCRIPTION
## Description
In dialog, header was only shown if a `<@header>` was passed. However since close button is there, we should always have it to provide the right padding. 

## References
https://github.com/eBay/skin/issues/1215

