### PR TITLE
Shortned all events and removed all on-{component} prefixes

### DIFF
--- a/src/common/migrators/index.js
+++ b/src/common/migrators/index.js
@@ -1,3 +1,13 @@
+function convertToCamel(attribute) {
+    const newAttr = attribute.split('-');
+    newAttr.forEach((attr, index) => {
+        if (index > 0) {
+            newAttr[index] = attr.charAt(0).toUpperCase() + attr.slice(1);
+        }
+    });
+    return newAttr.join('');
+}
+
 /**
  * @description
  * Changes @heading content if wrapped with <h[1-6]> to be unrapped
@@ -9,6 +19,10 @@ function setAttributeIfPresent(el, context, oldAttribute, newAttribute) {
         el.removeAttribute(oldAttribute);
         attr.name = newAttribute;
         el.addAttribute(attr);
+    }
+    if (oldAttribute.indexOf('-') > -1) {
+        // Convert on-something to onSomething
+        setAttributeIfPresent(el, context, convertToCamel(oldAttribute), convertToCamel(newAttribute));
     }
 }
 

--- a/src/common/migrators/test/test.server.js
+++ b/src/common/migrators/test/test.server.js
@@ -39,7 +39,7 @@ describe('migrators', () => {
         expect(el.hasAttribute('on-menu-button-click')).to.equal(false);
     });
 
-    it('does not changes attributes if they do notexist', async() => {
+    it('does not changes attributes if they do not exist', async() => {
         const tagString = '<ebay-menu-button on-button-click(() => {})/>';
         const { el } = runTransformer(migratorFn, tagString, componentPath);
 
@@ -48,14 +48,14 @@ describe('migrators', () => {
     });
 
     it('does multiple changes', async() => {
-        const tagString = '<ebay-menu-button on-button-click(() => {}) icon="settings" old-attribute="val"/>';
+        const tagString = '<ebay-menu-button on-button-click(() => {}) icon="settings" oldAttribute="val"/>';
         const { el } = runTransformer(migratorFn, tagString, componentPath);
 
         const { body: { array: [iconEl] } } = el;
         const { body: { array: [tag] } } = iconEl;
         expect(el.hasAttribute('on-click')).to.equal(false);
         expect(el.hasAttribute('on-button-click')).to.equal(true);
-        expect(el.getAttributeValue('new-attribute').value).to.equal('val');
+        expect(el.getAttributeValue('newAttribute').value).to.equal('val');
         expect(iconEl.tagName).to.equal('@icon');
         expect(tag.tagName).to.equal('ebay-settings-icon');
     });

--- a/src/common/test-utils/server.js
+++ b/src/common/test-utils/server.js
@@ -57,6 +57,26 @@ module.exports = {
             }
         );
     },
+    testEventsMigrator(migrator, component, events, componentPath) {
+        it(`checks all events ${component.component || component} events are migrated ${events.join(',')}`, () => {
+            const str = events.map((event) =>
+                `on-${component.event || component}-${event.from || event}(() => {})`)
+                .join(' ');
+            const srcString = `<ebay-${component.component || component} ${str}/>`;
+
+            const { context, templateAST } = getTransformerData(srcString, componentPath);
+            migrator(templateAST.body.array[0], context);
+            const el = templateAST.body.array[0];
+
+            events.forEach((event) => {
+                const fromEvent = event.from || event;
+                const toEvent = event.to || event;
+
+                expect(el.hasAttribute(`on-${toEvent}`)).to.equal(true, `should have on-${toEvent}`);
+                expect(el.hasAttribute(`on-${component.event || component}-${fromEvent}`)).to.equal(false);
+            });
+        });
+    },
     getTransformedTemplate(transformer, srcString, componentPath) {
         const { prettyPrintAST } = require('marko-prettyprint');
         const { context, templateAST } = getTransformerData(srcString, componentPath);

--- a/src/components/ebay-breadcrumbs/README.md
+++ b/src/components/ebay-breadcrumbs/README.md
@@ -23,7 +23,7 @@ Name | Type | Stateful | Required | Description
 
 Event | Description | Data
 --- | --- | ---
-`breadcrumbs-select` | click breadcrumb items | `{ originalEvent, el }`
+`select` | click breadcrumb items | `{ originalEvent, el }`
 
 ## @item Attributes
 
@@ -31,4 +31,4 @@ Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
 `href` | String | No | No | anchor href; omitting the href will switch to a button
 
-**Note:** If you want to have client side or ajax based navigation then you should omit the `href` attribute on each item. This will cause each item to be `<button>` instead of an `<a>`. Alternatively you can manually `preventDefault` the provided `originalEvent` on the `breadcrumbs-select` event.
+**Note:** If you want to have client side or ajax based navigation then you should omit the `href` attribute on each item. This will cause each item to be `<button>` instead of an `<a>`. Alternatively you can manually `preventDefault` the provided `originalEvent` on the `select` event.

--- a/src/components/ebay-breadcrumbs/component-browser.js
+++ b/src/components/ebay-breadcrumbs/component-browser.js
@@ -1,5 +1,5 @@
 module.exports = {
     handleClick(originalEvent) {
-        this.emit('breadcrumbs-select', { originalEvent, el: originalEvent.target });
+        this.emit('select', { originalEvent, el: originalEvent.target });
     }
 };

--- a/src/components/ebay-breadcrumbs/index.marko
+++ b/src/components/ebay-breadcrumbs/index.marko
@@ -1,6 +1,7 @@
-import processHtmlAttributes from "../../common/html-attributes";
+import processHtmlAttributes from "../../common/html-attributes"
 
 static function noop() {}
+
 static var ignoredAttributes = [
     "a11yHeadingText",
     "a11yHeadingTag",
@@ -9,7 +10,6 @@ static var ignoredAttributes = [
 ];
 
 $ input.toJSON = noop;
-
 <nav
     ...processHtmlAttributes(input, ignoredAttributes)
     aria-labelledby:scoped="breadcrumbs-heading"
@@ -27,10 +27,10 @@ $ input.toJSON = noop;
                     ...processHtmlAttributes(item)
                     aria-current=(current && "location")
                     onClick(!current && "handleClick")>
-                    <${item.renderBody} />
+                    <${item.renderBody}/>
                 </>
-                <if (!isLast)>
-                    <ebay-icon name="breadcrumb" />
+                <if(!isLast)>
+                    <ebay-breadcrumb-icon/>
                 </if>
             </li>
         </for>

--- a/src/components/ebay-breadcrumbs/marko-tag.json
+++ b/src/components/ebay-breadcrumbs/marko-tag.json
@@ -1,5 +1,6 @@
 {
   "attribute-groups": ["html-attributes"],
+  "migrator": "./migrator.js",
   "@*": {
     "targetProperty": null,
     "type": "expression"

--- a/src/components/ebay-breadcrumbs/migrator.js
+++ b/src/components/ebay-breadcrumbs/migrator.js
@@ -1,0 +1,23 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-breadcrumbs-select', 'on-select');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-breadcrumbs/test/test.browser.js
+++ b/src/components/ebay-breadcrumbs/test/test.browser.js
@@ -23,8 +23,8 @@ describe('given a basic breadcrumb', () => {
             await fireEvent.click(component.getByText(firstItem.renderBody.text));
         });
 
-        it('then it emits the breadcrumbs-select event with correct data', () => {
-            expect(component.emitted('breadcrumbs-select')).has.length(1);
+        it('then it emits the select event with correct data', () => {
+            expect(component.emitted('select')).has.length(1);
         });
     });
 
@@ -33,8 +33,8 @@ describe('given a basic breadcrumb', () => {
             await fireEvent.click(component.getByText(lastItem.renderBody.text));
         });
 
-        it('then it does not emit the breadcrumbs-select event', () => {
-            expect(component.emitted('breadcrumbs-select')).has.length(0);
+        it('then it does not emit the select event', () => {
+            expect(component.emitted('select')).has.length(0);
         });
     });
 });

--- a/src/components/ebay-breadcrumbs/test/test.server.js
+++ b/src/components/ebay-breadcrumbs/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const mock = require('../mock');
 const template = require('..');
 
@@ -53,6 +53,7 @@ describe('breadcrumbs', () => {
     });
 });
 
+testEventsMigrator(require('../migrator'), 'breadcrumbs', ['select'], '../index.marko');
 testPassThroughAttributes(template);
 testPassThroughAttributes(template, {
     child: {

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 
 use(require('chai-dom'));
@@ -148,3 +148,4 @@ it('renders large fixed-height button', async() => {
 });
 
 testPassThroughAttributes(template);
+testEventsMigrator(require('../migrator'), 'button', ['click', 'escape'], '../index.marko');

--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -45,27 +45,27 @@ Name | Type | Stateful | Required | Description
 Event | Data | Description
 --- | --- | ---
 `carousel-update` | { [visibleIndexes] } | called whenever item visibility changes, including initialization
-`carousel-next` | { originalEvent } | click next control
-`carousel-previous` | { originalEvent } | click previous control
+`next` | { originalEvent } | click next control
+`previous` | { originalEvent } | click previous control
 
 ### Additional Events for when items-per-slide is set
 
 Event | Data | Description
 --- | --- | ---
-`carousel-slide` | `{ slide }` | new slide is navigated to (by controls or API)
+`slide` | `{ slide }` | new slide is navigated to (by controls or API)
 
 ### Additional Events for when autoplay is set
 
 Event | Data | Description
 --- | --- | ---
-`carousel-play` | `{ originalEvent }` | called when the autoplay play button is pressed
-`carousel-pause` | `{ originalEvent }` | called when the autoplay pause button is pressed
+`play` | `{ originalEvent }` | called when the autoplay play button is pressed
+`pause` | `{ originalEvent }` | called when the autoplay pause button is pressed
 
 ### Additional Events for touch devices
 
 Event | Data | Description
 --- | --- | ---
-`carousel-scroll` | `{ index }` | new index is navigated to by native scrolling
+`scroll` | `{ index }` | new index is navigated to by native scrolling
 
 **Notes:**
 

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -122,7 +122,7 @@ function onRender() {
             const moveRight = this.move.bind(this, RIGHT);
             this.autoplayTimeout = setTimeout(() => {
                 if (this.isMoving) {
-                    return this.once('carousel-update', moveRight);
+                    return this.once('move', moveRight);
                 }
                 moveRight();
             }, autoplayInterval);
@@ -167,7 +167,7 @@ function cleanupAsync() {
 function emitUpdate() {
     const { state: { config, items } } = this;
     config.scrollTransitioning = false;
-    this.emit('carousel-update', {
+    this.emit('move', {
         visibleIndexes: items
             .filter(({ fullyVisible }) => fullyVisible)
             .map(item => items.indexOf(item))
@@ -187,8 +187,8 @@ function handleMove(direction, originalEvent) {
     const { state } = this;
     const nextIndex = this.move(direction);
     const slide = getSlide(state, nextIndex);
-    this.emit('carousel-slide', { slide: slide + 1, originalEvent });
-    this.emit(`carousel-${direction === 1 ? 'next' : 'previous'}`, { originalEvent });
+    this.emit('slide', { slide: slide + 1, originalEvent });
+    this.emit(`${direction === 1 ? 'next' : 'previous'}`, { originalEvent });
 }
 
 /**
@@ -203,7 +203,7 @@ function togglePlay(originalEvent) {
     if (paused && !this.isMoving) {
         this.move(RIGHT);
     }
-    this.emit(`carousel-${paused ? 'play' : 'pause'}`, { originalEvent });
+    this.emit(`${paused ? 'play' : 'pause'}`, { originalEvent });
 }
 
 /**
@@ -243,7 +243,7 @@ function handleScroll(scrollLeft) {
         config.skipScrolling = true;
         config.preserveItems = true;
         this.setState('index', closest);
-        this.emit('carousel-scroll', { index: closest });
+        this.emit('scroll', { index: closest });
     }
 }
 
@@ -297,7 +297,7 @@ function move(delta) {
     }
 
     this.setState('index', nextIndex);
-    this.once('carousel-update', () => {
+    this.once('move', () => {
         this.isMoving = false;
 
         if (offsetOverride !== undefined) {

--- a/src/components/ebay-carousel/marko-tag.json
+++ b/src/components/ebay-carousel/marko-tag.json
@@ -3,6 +3,7 @@
     "targetProperty": null,
     "type": "expression"
   },
+  "migrator": "./migrator",
   "@html-attributes": "expression",
   "@class": "string",
   "@style": "string",

--- a/src/components/ebay-carousel/migrator.js
+++ b/src/components/ebay-carousel/migrator.js
@@ -1,0 +1,29 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-carousel-update', 'on-move');
+    setAttributeIfPresent(el, context, 'on-carousel-next', 'on-next');
+    setAttributeIfPresent(el, context, 'on-carousel-previous', 'on-previous');
+    setAttributeIfPresent(el, context, 'on-carousel-slide', 'on-slide');
+    setAttributeIfPresent(el, context, 'on-carousel-scroll', 'on-scroll');
+    setAttributeIfPresent(el, context, 'on-carousel-play', 'on-play');
+    setAttributeIfPresent(el, context, 'on-carousel-pause', 'on-pause');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -104,7 +104,7 @@ describe('given a continuous carousel', () => {
             });
 
             it('then it did not emit the prev event', () => {
-                expect(component.emitted('carousel-previous')).has.length(0);
+                expect(component.emitted('previous')).has.length(0);
             });
         });
 
@@ -119,7 +119,7 @@ describe('given a continuous carousel', () => {
             });
 
             it('then it emitted the next event', () => {
-                expect(component.emitted('carousel-next')).has.length(1);
+                expect(component.emitted('next')).has.length(1);
             });
 
             it('then it moved to the next hidden item', () => {
@@ -142,7 +142,7 @@ describe('given a continuous carousel', () => {
             });
 
             it('then it did not emit the next event', () => {
-                expect(component.emitted('carousel-next')).has.length(0);
+                expect(component.emitted('next')).has.length(0);
             });
         });
 
@@ -159,7 +159,7 @@ describe('given a continuous carousel', () => {
             });
 
             it('then it emitted the previous event', () => {
-                expect(component.emitted('carousel-previous')).has.length(1);
+                expect(component.emitted('previous')).has.length(1);
             });
 
             it('then it moved to the previous hidden item', () => {
@@ -192,7 +192,7 @@ describe('given a continuous carousel', () => {
             });
 
             it('then emitted 3 next events', () => {
-                expect(component.emitted('carousel-next')).has.length(3);
+                expect(component.emitted('next')).has.length(3);
             });
 
             it('then the last item is visible', () => {
@@ -214,11 +214,11 @@ describe('given a continuous carousel', () => {
             });
 
             it('then emitted 3 next events', () => {
-                expect(component.emitted('carousel-next')).has.length(3);
+                expect(component.emitted('next')).has.length(3);
             });
 
             it('then emitted a prev event', () => {
-                expect(component.emitted('carousel-previous')).has.length(1);
+                expect(component.emitted('previous')).has.length(1);
             });
 
             it('then the last item is not visible', () => {
@@ -326,7 +326,7 @@ describe('given a discrete carousel', () => {
             });
 
             it('then it did not emit the prev event', () => {
-                expect(component.emitted('carousel-previous')).has.length(0);
+                expect(component.emitted('previous')).has.length(0);
             });
         });
 
@@ -337,11 +337,11 @@ describe('given a discrete carousel', () => {
             });
 
             it('then it emitted the next event', () => {
-                expect(component.emitted('carousel-next')).has.length(1);
+                expect(component.emitted('next')).has.length(1);
             });
 
             it('then it emitted the slide event', () => {
-                expect(component.emitted('carousel-slide')).has.nested.property('[0][0].slide', 2);
+                expect(component.emitted('slide')).has.nested.property('[0][0].slide', 2);
             });
 
             thenItMovedToTheSecondSlide();
@@ -361,7 +361,7 @@ describe('given a discrete carousel', () => {
             });
 
             it('then it emitted the scroll event', () => {
-                expect(component.emitted('carousel-scroll')).has.length(1);
+                expect(component.emitted('scroll')).has.length(1);
             });
 
             thenItMovedToTheSecondSlide();
@@ -403,11 +403,11 @@ describe('given a discrete carousel', () => {
             });
 
             it('then it emitted the previous event', () => {
-                expect(component.emitted('carousel-previous')).has.length(1);
+                expect(component.emitted('previous')).has.length(1);
             });
 
             it('then it emitted the slide event', () => {
-                expect(component.emitted('carousel-slide')).has.nested.property('[0][0].slide', 2);
+                expect(component.emitted('slide')).has.nested.property('[0][0].slide', 2);
             });
 
             it('then it moved to the second item', () => {
@@ -445,7 +445,7 @@ describe('given a discrete carousel', () => {
             });
 
             it('then it emitted the next event', () => {
-                expect(component.emitted('carousel-next')).has.length(1);
+                expect(component.emitted('next')).has.length(1);
             });
 
             thenItMovedToTheSecondSlide();
@@ -453,7 +453,7 @@ describe('given a discrete carousel', () => {
 
         function thenItMovedToTheSecondSlide() {
             it('then it emitted the slide event', () => {
-                expect(component.emitted('carousel-slide')).has.length(1);
+                expect(component.emitted('slide')).has.length(1);
             });
 
             it('then it moved to the third item', () => {
@@ -499,11 +499,11 @@ describe('given a discrete carousel', () => {
             });
 
             it('then it emitted the next event', () => {
-                expect(component.emitted('carousel-next')).has.length(1);
+                expect(component.emitted('next')).has.length(1);
             });
 
             it('then it emitted the slide event', () => {
-                expect(component.emitted('carousel-slide')).has.length(1);
+                expect(component.emitted('slide')).has.length(1);
             });
 
             it('then it moved to the third item', () => {
@@ -536,8 +536,8 @@ describe('given a discrete carousel', () => {
             });
 
             it('then it does not emit next or slide events', () => {
-                expect(component.emitted('carousel-next')).has.length(0);
-                expect(component.emitted('carousel-slide')).has.length(0);
+                expect(component.emitted('next')).has.length(0);
+                expect(component.emitted('slide')).has.length(0);
             });
 
             it('then it moved to the third item', () => {
@@ -551,7 +551,7 @@ describe('given a discrete carousel', () => {
                 });
 
                 it('then it does not emit the next event', () => {
-                    expect(component.emitted('carousel-next')).has.length(0);
+                    expect(component.emitted('next')).has.length(0);
                 });
 
                 thenItIsOnTheFirstSlide();
@@ -564,11 +564,11 @@ describe('given a discrete carousel', () => {
                 });
 
                 it('then it emitted the next event', () => {
-                    expect(component.emitted('carousel-next')).has.length(1);
+                    expect(component.emitted('next')).has.length(1);
                 });
 
                 it('then it emitted the slide event', () => {
-                    expect(component.emitted('carousel-slide')).has.length(1);
+                    expect(component.emitted('slide')).has.length(1);
                 });
 
                 thenItIsOnTheFirstSlide();
@@ -582,7 +582,7 @@ describe('given a discrete carousel', () => {
             });
 
             it('then it did not emit any updates', () => {
-                expect(component.emitted('carousel-update')).has.length(0);
+                expect(component.emitted('move')).has.length(0);
             });
 
             thenItIsOnTheFirstSlide();
@@ -595,7 +595,7 @@ describe('given a discrete carousel', () => {
 
             it('then the autoplay does not run', async() => {
                 await new Promise(resolve => setTimeout(resolve, 600));
-                expect(component.emitted('carousel-update')).has.length(0);
+                expect(component.emitted('move')).has.length(0);
             });
 
             describe('when the interaction has finished', () => {
@@ -623,7 +623,7 @@ describe('given a discrete carousel', () => {
 });
 
 function waitForCarouselUpdate() {
-    return wait(() => expect(component.emitted('carousel-update')).has.length(1));
+    return wait(() => expect(component.emitted('move')).has.length(1));
 }
 
 function doesNotEventuallyScroll() {

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -1,7 +1,7 @@
 const assign = require('core-js-pure/features/object/assign');
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -81,3 +81,7 @@ describe('carousel', () => {
         }
     });
 });
+
+testEventsMigrator(require('../migrator'), 'carousel',
+    [{ from: 'update', to: 'move' },
+        'next', 'previous', 'slide', 'play', 'pause', 'scroll'], '../index.marko');

--- a/src/components/ebay-checkbox/README.md
+++ b/src/components/ebay-checkbox/README.md
@@ -19,5 +19,5 @@ Note: For this component, `class`/`style` are applied to the root tag, while all
 
 Event | Data | Description
 --- | --- | --
-`checkbox-change` | `{ originalEvent, value, checked }` | selected value and checked status
-`checkbox-focus` | `{ originalEvent, value }` |
+`change` | `{ originalEvent, value, checked }` | selected value and checked status
+`focus` | `{ originalEvent, value }` |

--- a/src/components/ebay-checkbox/component-browser.js
+++ b/src/components/ebay-checkbox/component-browser.js
@@ -6,7 +6,7 @@ module.exports = {
 
 function forwardEvent(eventName) {
     return function(originalEvent) {
-        this.emit(`checkbox-${eventName}`, {
+        this.emit(`${eventName}`, {
             originalEvent,
             value: this.getEl('input').value,
             checked: this.getEl('input').checked

--- a/src/components/ebay-checkbox/marko-tag.json
+++ b/src/components/ebay-checkbox/marko-tag.json
@@ -1,5 +1,6 @@
 {
   "attribute-groups": ["html-attributes"],
+  "migrator": "./migrator",
   "@*": {
     "targetProperty": null,
     "type": "expression"

--- a/src/components/ebay-checkbox/migrator.js
+++ b/src/components/ebay-checkbox/migrator.js
@@ -1,0 +1,24 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-checkbox-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-checkbox-focus', 'on-focus');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-checkbox/test/test.browser.js
+++ b/src/components/ebay-checkbox/test/test.browser.js
@@ -20,7 +20,7 @@ describe('given checkbox button is enabled', () => {
         });
 
         it('then it emitted the change event', () => {
-            const changeEvents = component.emitted('checkbox-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[changeEvent]] = changeEvents;
@@ -46,7 +46,7 @@ describe('given checkbox button is disabled', () => {
         });
 
         it('then it does not emit the change event', () => {
-            expect(component.emitted('checkbox-change')).has.length(0);
+            expect(component.emitted('change')).has.length(0);
         });
 
         it('then it remains unchecked', () => {
@@ -62,7 +62,7 @@ describe('when native focus event is fired', () => {
     });
 
     it('then it emits the event', () => {
-        const events = component.emitted('checkbox-focus');
+        const events = component.emitted('focus');
         expect(events).has.length(1);
 
         const [[eventArg]] = events;

--- a/src/components/ebay-checkbox/test/test.server.js
+++ b/src/components/ebay-checkbox/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 
 use(require('chai-dom'));
@@ -28,3 +28,5 @@ testPassThroughAttributes(template, {
         return component.getByRole('checkbox').parentElement;
     }
 });
+
+testEventsMigrator(require('../migrator'), 'checkbox', ['change', 'focus'], '../index.marko');

--- a/src/components/ebay-combobox-readonly/README.md
+++ b/src/components/ebay-combobox-readonly/README.md
@@ -42,9 +42,9 @@ Note: For this component, `class` is applied to the root tag, while all other HT
 
 Event | Data |  Description
 --- | --- | ---
-`combobox-collapse` | | collapse content
-`combobox-expand` | | expand content
-`combobox-change` | `{ el, index, selected }` | option selected
+`collapse` | | collapse content
+`expand` | | expand content
+`change` | `{ el, index, selected }` | option selected
 ---
 
 ## @option Tag

--- a/src/components/ebay-combobox-readonly/component.js
+++ b/src/components/ebay-combobox-readonly/component.js
@@ -7,10 +7,10 @@ const eventUtils = require('../../common/event-utils');
 module.exports = {
     handleExpand() {
         elementScroll.scroll(this.getEls('options')[this.state.selectedIndex]);
-        this.emit('combobox-expand');
+        this.emit('expand');
     },
     handleCollapse() {
-        this.emit('combobox-collapse');
+        this.emit('collapse');
     },
 
     /**
@@ -82,7 +82,7 @@ module.exports = {
             const el = this.getEls('options')[index];
             this.state.selectedIndex = index;
             elementScroll.scroll(el);
-            this.emit('combobox-change', {
+            this.emit('change', {
                 index,
                 selected: [this.input.options[index].value],
                 el

--- a/src/components/ebay-combobox-readonly/marko-tag.json
+++ b/src/components/ebay-combobox-readonly/marko-tag.json
@@ -1,5 +1,6 @@
 {
   "attribute-groups": ["html-attributes"],
+  "migrator": "./migrator",
   "@*": {
     "targetProperty": null,
     "type": "expression"

--- a/src/components/ebay-combobox-readonly/migrator.js
+++ b/src/components/ebay-combobox-readonly/migrator.js
@@ -7,7 +7,7 @@ const { setAttributeIfPresent } = require('../../common/migrators');
 
 function migratorMarko4(el, context) {
     setAttributeIfPresent(el, context, 'on-combobox-change', 'on-change');
-    setAttributeIfPresent(el, context, 'on-combobox-collpase', 'on-collpase');
+    setAttributeIfPresent(el, context, 'on-combobox-collapse', 'on-collapse');
     setAttributeIfPresent(el, context, 'on-combobox-expand', 'on-expand');
     return el;
 }

--- a/src/components/ebay-combobox-readonly/migrator.js
+++ b/src/components/ebay-combobox-readonly/migrator.js
@@ -1,0 +1,25 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-combobox-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-combobox-collpase', 'on-collpase');
+    setAttributeIfPresent(el, context, 'on-combobox-expand', 'on-expand');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-combobox-readonly/test/test.browser.js
+++ b/src/components/ebay-combobox-readonly/test/test.browser.js
@@ -44,8 +44,8 @@ describe('given the readonly combobox with 3 items', () => {
             expect(getVisibleCombobox()).has.attr('aria-expanded', 'false');
         });
 
-        it('then it emits the combobox-change event with the correct data', () => {
-            const changeEvents = component.emitted('combobox-change');
+        it('then it emits the change event with the correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[changeEvent]] = changeEvents;
@@ -61,15 +61,15 @@ describe('given the readonly combobox with 3 items', () => {
 
         describe('when the up arrow key is pressed', () => {
             beforeEach(async() => {
-                expect(component.emitted('combobox-change')).has.length(1);
+                expect(component.emitted('change')).has.length(1);
                 await pressKey(getVisibleCombobox(), {
                     key: 'ArrowUp',
                     keyCode: 38
                 });
             });
 
-            it('then it emits the combobox-change event with the correct data', () => {
-                const changeEvents = component.emitted('combobox-change');
+            it('then it emits the change event with the correct data', () => {
+                const changeEvents = component.emitted('change');
                 expect(changeEvents).has.length(1);
 
                 const [[changeEvent]] = changeEvents;
@@ -92,7 +92,7 @@ describe('given the readonly combobox with 3 items', () => {
         });
 
         it('then it does not change the selection', () => {
-            const changeEvents = component.emitted('combobox-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(0);
         });
     });
@@ -103,7 +103,7 @@ describe('given the readonly combobox with 3 items', () => {
         });
 
         it('then it emits the event from expander-expand', () => {
-            expect(component.emitted('combobox-expand')).has.length(1);
+            expect(component.emitted('expand')).has.length(1);
         });
 
         it('then it has expanded the combobox', () => {
@@ -121,8 +121,8 @@ describe('given the readonly combobox with 3 items', () => {
                     .with.property('value', input.options[1].value);
             });
 
-            it('then it emits the combobox-change event with correct data', () => {
-                const changeEvents = component.emitted('combobox-change');
+            it('then it emits the change event with correct data', () => {
+                const changeEvents = component.emitted('change');
                 expect(changeEvents).has.length(1);
 
                 const [[changeEvent]] = changeEvents;
@@ -144,8 +144,8 @@ describe('given the readonly combobox with 3 items', () => {
                     .with.property('value', input.options[1].value);
             });
 
-            it('then it emits the combobox-change event with correct data', () => {
-                const changeEvents = component.emitted('combobox-change');
+            it('then it emits the change event with correct data', () => {
+                const changeEvents = component.emitted('change');
                 expect(changeEvents).has.length(1);
 
                 const [[changeEvent]] = changeEvents;
@@ -177,7 +177,7 @@ describe('given the readonly combobox with 3 items', () => {
 
         function thenItHasCollapsed() {
             it('then it emits the event from expander-collapse', () => {
-                expect(component.emitted('combobox-collapse')).has.length(1);
+                expect(component.emitted('collapse')).has.length(1);
             });
 
             it('then it has collapsed the combobox', () => {
@@ -204,7 +204,7 @@ describe('given the readonly combobox with 3 items that is disabled', () => {
         });
 
         it('then it does not emit the event from expander-expand', () => {
-            expect(component.emitted('combobox-expand')).has.length(0);
+            expect(component.emitted('expand')).has.length(0);
         });
 
         it('then it has not expanded the combobox', () => {

--- a/src/components/ebay-combobox-readonly/test/test.server.js
+++ b/src/components/ebay-combobox-readonly/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -66,3 +66,6 @@ function isAriaSelected(el) {
 function isVisible(el) {
     return !el.hasAttribute('hidden') && !el.closest('[hidden]');
 }
+
+testEventsMigrator(require('../migrator'), { event: 'combobox', component: 'combobox-readonly' },
+    ['collapse', 'change', 'expand'], '../index.marko');

--- a/src/components/ebay-combobox/README.md
+++ b/src/components/ebay-combobox/README.md
@@ -53,11 +53,11 @@ Note: For this component, `class` is applied to the root tag, while all other HT
 
 Event | Data |  Description
 --- | --- | ---
-`combobox-collapse` | | collapsed content
-`combobox-expand` | | expanded content
-`combobox-change` | `{ el, index, selected }` | same as the `onChange` event, which fires on blur
-`combobox-input` | `{ el, index, selected }` | same as the `onInput` event, which fires with every keypress
-`combobox-select` | `{ el, index, selected }` | similar to a `<select>`, which fires when an option is clicked or selected
+`collapse` | | collapsed content
+`expand` | | expanded content
+`change` | `{ el, index, selected }` | same as the `onChange` event, which fires on blur
+`input-change` | `{ el, index, selected }` | same as the `onInput` event, which fires with every keypress
+`select` | `{ el, index, selected }` | similar to a `<select>`, which fires when an option is clicked or selected
 
 ## @option Tag
 

--- a/src/components/ebay-combobox/component.js
+++ b/src/components/ebay-combobox/component.js
@@ -20,7 +20,7 @@ module.exports = {
 
     handleButtonClick(originalEvent) {
         this.buttonClicked = true;
-        this.emit('combobox-button-click', { originalEvent });
+        this.emit('button-click', { originalEvent });
     },
 
     handleExpand() {
@@ -32,12 +32,12 @@ module.exports = {
             elementScroll.scroll(selectedEl);
         }
 
-        this.emit('combobox-expand');
+        this.emit('expand');
     },
 
     handleCollapse() {
         this.activeDescendant.reset();
-        this.emit('combobox-collapse');
+        this.emit('collapse');
     },
 
     handleComboboxKeyDown(originalEvent) {
@@ -79,7 +79,7 @@ module.exports = {
                 }
             });
 
-            this._emitComboboxEvent('input');
+            this._emitComboboxEvent('input-change');
         });
     },
 
@@ -203,7 +203,7 @@ module.exports = {
     },
 
     _emitComboboxEvent(eventName) {
-        this.emit(`combobox-${eventName}`, {
+        this.emit(`${eventName}`, {
             currentInputValue: this.state.currentValue,
             selectedOption: this._getSelectedOption(),
             options: this.input.options

--- a/src/components/ebay-combobox/examples/09-actionable-button/template.marko
+++ b/src/components/ebay-combobox/examples/09-actionable-button/template.marko
@@ -9,7 +9,7 @@ class {
     name="example2text"
     value="Basic Offer 22"
     autocomplete="list"
-    on-combobox-button-click("toggle")>
+    on-button-click("toggle")>
     <@button aria-label="Toggle autocomplete">
         <ebay-dropdown-icon/>
     </@button>

--- a/src/components/ebay-combobox/marko-tag.json
+++ b/src/components/ebay-combobox/marko-tag.json
@@ -1,5 +1,6 @@
 {
   "attribute-groups": ["html-attributes"],
+  "migrator": "./migrator",
   "@*": {
     "targetProperty": null,
     "type": "expression"

--- a/src/components/ebay-combobox/migrator.js
+++ b/src/components/ebay-combobox/migrator.js
@@ -1,0 +1,29 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-combobox-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-combobox-input', 'on-input-change');
+    setAttributeIfPresent(el, context, 'on-combobox-select', 'on-select');
+    setAttributeIfPresent(el, context, 'on-combobox-collpase', 'on-collpase');
+    setAttributeIfPresent(el, context, 'on-combobox-expand', 'on-expand');
+    setAttributeIfPresent(el, context, 'on-combobox-focus', 'on-focus');
+    setAttributeIfPresent(el, context, 'on-combobox-button-click', 'on-button-click');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-combobox/migrator.js
+++ b/src/components/ebay-combobox/migrator.js
@@ -9,7 +9,7 @@ function migratorMarko4(el, context) {
     setAttributeIfPresent(el, context, 'on-combobox-change', 'on-change');
     setAttributeIfPresent(el, context, 'on-combobox-input', 'on-input-change');
     setAttributeIfPresent(el, context, 'on-combobox-select', 'on-select');
-    setAttributeIfPresent(el, context, 'on-combobox-collpase', 'on-collpase');
+    setAttributeIfPresent(el, context, 'on-combobox-collapse', 'on-collapse');
     setAttributeIfPresent(el, context, 'on-combobox-expand', 'on-expand');
     setAttributeIfPresent(el, context, 'on-combobox-focus', 'on-focus');
     setAttributeIfPresent(el, context, 'on-combobox-button-click', 'on-button-click');

--- a/src/components/ebay-combobox/test/test.browser.js
+++ b/src/components/ebay-combobox/test/test.browser.js
@@ -54,7 +54,7 @@ describe('given the combobox with 3 items', () => {
                 });
 
                 it('then it should emit a input event', () => {
-                    expect(component.emitted('combobox-input')).has.length(1);
+                    expect(component.emitted('input-change')).has.length(1);
                 });
 
                 describe('when blur happens on the combobox', () => {
@@ -63,7 +63,7 @@ describe('given the combobox with 3 items', () => {
                     });
 
                     it('then it should emit a change event', () => {
-                        expect(component.emitted('combobox-change')).has.length(1);
+                        expect(component.emitted('change')).has.length(1);
                     });
                 });
             });
@@ -95,7 +95,7 @@ describe('given the combobox with 3 items', () => {
                     });
 
                     it('then it emitted the select event', () => {
-                        expect(component.emitted('combobox-select')).has.length(1);
+                        expect(component.emitted('select')).has.length(1);
                     });
                 });
 
@@ -121,7 +121,7 @@ describe('given the combobox with 3 items', () => {
                 });
 
                 it('then it should emit a select event', () => {
-                    expect(component.emitted('combobox-select')).has.length(1);
+                    expect(component.emitted('select')).has.length(1);
                 });
 
                 it('then it should update the input', () => {
@@ -175,7 +175,7 @@ describe('given the combobox starts with zero options', () => {
         });
 
         it('then it should emit a input event', () => {
-            expect(component.emitted('combobox-input')).has.length(1);
+            expect(component.emitted('input-change')).has.length(1);
         });
         describe('when blur happens on the combobox', () => {
             beforeEach(async() => {
@@ -183,7 +183,7 @@ describe('given the combobox starts with zero options', () => {
             });
 
             it('then it should emit a change event', () => {
-                expect(component.emitted('combobox-change')).has.length(1);
+                expect(component.emitted('change')).has.length(1);
             });
         });
     });
@@ -213,7 +213,7 @@ describe('given the combobox starts with zero options', () => {
                 });
 
                 it('then it should emit a input event', () => {
-                    expect(component.emitted('combobox-input')).has.length(1);
+                    expect(component.emitted('input-change')).has.length(1);
                 });
 
                 describe('when blur happens on the combobox', () => {
@@ -222,7 +222,7 @@ describe('given the combobox starts with zero options', () => {
                     });
 
                     it('then it should emit a change event', () => {
-                        expect(component.emitted('combobox-change')).has.length(1);
+                        expect(component.emitted('change')).has.length(1);
                     });
                 });
             });
@@ -254,7 +254,7 @@ describe('given the combobox starts with zero options', () => {
                     });
 
                     it('then it emitted the select event', () => {
-                        expect(component.emitted('combobox-select')).has.length(1);
+                        expect(component.emitted('select')).has.length(1);
                     });
                 });
 
@@ -280,7 +280,7 @@ describe('given the combobox starts with zero options', () => {
                 });
 
                 it('then it should emit a select event', () => {
-                    expect(component.emitted('combobox-select')).has.length(1);
+                    expect(component.emitted('select')).has.length(1);
                 });
 
                 it('then it should update the input', () => {
@@ -317,7 +317,7 @@ describe('when it is rerendered with actionable', () => {
         });
 
         it('should emit event', () => {
-            expect(component.emitted('combobox-button-click')).has.length(1);
+            expect(component.emitted('button-click')).has.length(1);
         });
     });
 
@@ -329,7 +329,7 @@ describe('when it is rerendered with actionable', () => {
 
         it('should emit event and not close', () => {
             expect(component.getByRole('combobox')).has.attr('aria-expanded', 'true');
-            expect(component.emitted('combobox-button-click')).has.length(1);
+            expect(component.emitted('button-click')).has.length(1);
         });
     });
 });

--- a/src/components/ebay-combobox/test/test.server.js
+++ b/src/components/ebay-combobox/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -70,3 +70,7 @@ describe('combobox-option', () => {
 function isAriaSelected(el) {
     return el.getAttribute('aria-selected') === 'true';
 }
+
+testEventsMigrator(require('../migrator'), 'combobox',
+    [{ from: 'input', to: 'input-change' },
+        'collapse', 'change', 'select', 'expand'], '../index.marko');

--- a/src/components/ebay-details/component-browser.js
+++ b/src/components/ebay-details/component-browser.js
@@ -1,8 +1,8 @@
 module.exports = {
     toggleDetails(ev) {
-        this.emit('details-toggle', { originalEvent: ev, open: this.getEl('root').open });
+        this.emit('toggle', { originalEvent: ev, open: this.getEl('root').open });
     },
     clickDetails(ev) {
-        this.emit('details-click', { originalEvent: ev });
+        this.emit('click', { originalEvent: ev });
     }
 };

--- a/src/components/ebay-details/examples/05-multiple-options/template.marko
+++ b/src/components/ebay-details/examples/05-multiple-options/template.marko
@@ -1,5 +1,5 @@
 class {}
 
-<ebay-details text="details" size="small" type="center" open on-details-toggle((ev) => console.log('toggle', ev.open)) >
+<ebay-details text="details" size="small" type="center" open on-toggle((ev) => console.log('toggle', ev.open)) >
     Sample content inside of details
 </ebay-details>

--- a/src/components/ebay-details/marko-tag.json
+++ b/src/components/ebay-details/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-details/migrator.js
+++ b/src/components/ebay-details/migrator.js
@@ -1,0 +1,24 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-details-toggle', 'on-toggle');
+    setAttributeIfPresent(el, context, 'on-details-click', 'on-click');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-details/test/test.browser.js
+++ b/src/components/ebay-details/test/test.browser.js
@@ -49,7 +49,7 @@ describe('given the details is in the default state and click is triggered', () 
             await fireEvent.click(component.getByText(detailsText));
         });
 
-        it('then it emits the details-toggle and click', async() => {
+        it('then it emits the toggle and click', async() => {
             wait(() => verifyToggleEvent());
             wait(() => verifyClickEvent());
         });
@@ -89,7 +89,7 @@ describe('given the details is in the open state and click is triggered', () => 
             await fireEvent.click(component.getByText(detailsText));
         });
 
-        it('then it emits the details-toggle and click', async() => {
+        it('then it emits the toggle and click', async() => {
             wait(() => verifyToggleEvent());
             wait(() => verifyClickEvent());
         });
@@ -116,7 +116,7 @@ describe('given the details is in the open state and click is triggered', () => 
 });
 
 function verifyToggleEvent() {
-    const toggleEvent = component.emitted('details-toggle');
+    const toggleEvent = component.emitted('toggle');
     expect(toggleEvent.length).to.be.greaterThan(0);
 
     const [eventArg] = toggleEvent.pop();
@@ -125,7 +125,7 @@ function verifyToggleEvent() {
 }
 
 function verifyClickEvent() {
-    const toggleEvent = component.emitted('details-click');
+    const toggleEvent = component.emitted('click');
     expect(toggleEvent).to.length(1);
     const [[eventArg]] = toggleEvent;
     expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);

--- a/src/components/ebay-details/test/test.server.js
+++ b/src/components/ebay-details/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -39,3 +39,5 @@ describe('details', () => {
 
     testPassThroughAttributes(template);
 });
+
+testEventsMigrator(require('../migrator'), 'details', ['toggle', 'click'], '../index.marko');

--- a/src/components/ebay-drawer/component.js
+++ b/src/components/ebay-drawer/component.js
@@ -7,9 +7,9 @@ module.exports = {
         if (isExpanded !== this.state.expanded) {
             this.state.expanded = isExpanded;
             if (isExpanded) {
-                this.emit('drawer-expanded');
+                this.emit('expanded');
             } else {
-                this.emit('drawer-collapsed');
+                this.emit('collapsed');
             }
         }
     },

--- a/src/components/ebay-drawer/examples/01-default/template.marko
+++ b/src/components/ebay-drawer/examples/01-default/template.marko
@@ -1,22 +1,28 @@
-<ebay-drawer a11y-close-text="Close drawer" aria-labelledby="drawer-title" open=state.open on-drawer-close('closeDrawer')>
-    <@header><h2 id="drawer-title">Heading</h2></@header>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-    <@footer><ebay-button>Close</ebay-button></@footer>
+<ebay-drawer
+    a11y-close-text="Close drawer"
+    aria-labelledby="drawer-title"
+    open=state.open
+    on-close("closeDrawer")>
+    <@header id="drawer-title">Heading</@header>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        <a href="http://www.ebay.com">www.ebay.com</a>
+    </p>
+    <@footer>
+        <ebay-button>Close</ebay-button>
+    </@footer>
 </ebay-drawer>
-
-<ebay-button on-click('openDrawer')>
-    Opendrawer
-</ebay-button>
-
+<ebay-button on-click("openDrawer")>Opendrawer</ebay-button>
 class {
-  onCreate() {
-    this.state = { open: false };
-  }
-  openDrawer() {
-    this.state.open = true;
-  }
-  closeDrawer() {
-    this.state.open = false;
-  }
+    onCreate() {
+        this.state = { open: false };
+    }
+    openDrawer() {
+        this.state.open = true;
+    }
+    closeDrawer() {
+        this.state.open = false;
+    }
 }

--- a/src/components/ebay-drawer/examples/02-no-handle/template.marko
+++ b/src/components/ebay-drawer/examples/02-no-handle/template.marko
@@ -1,21 +1,26 @@
-<ebay-drawer a11y-close-text="Close drawer" aria-labelledby="drawer-title" open=state.open noHandle on-drawer-close('closeDrawer')>
-    <@header><h2 id="drawer-title">Heading</h2></@header>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+<ebay-drawer
+    a11y-close-text="Close drawer"
+    aria-labelledby="drawer-title"
+    open=state.open
+    noHandle
+    on-close("closeDrawer")>
+    <@header id="drawer-title">Heading</@header>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        <a href="http://www.ebay.com">www.ebay.com</a>
+    </p>
 </ebay-drawer>
-
-<ebay-button on-click('openDrawer')>
-    Opendrawer
-</ebay-button>
-
+<ebay-button on-click("openDrawer")>Opendrawer</ebay-button>
 class {
-  onCreate() {
-    this.state = { open: false };
-  }
-  openDrawer() {
-    this.state.open = true;
-  }
-  closeDrawer() {
-    this.state.open = false;
-  }
+    onCreate() {
+        this.state = { open: false };
+    }
+    openDrawer() {
+        this.state.open = true;
+    }
+    closeDrawer() {
+        this.state.open = false;
+    }
 }

--- a/src/components/ebay-drawer/examples/03-lots-of-text/template.marko
+++ b/src/components/ebay-drawer/examples/03-lots-of-text/template.marko
@@ -1,32 +1,58 @@
-<ebay-drawer a11y-close-text="Close drawer" aria-labelledby="drawer-title" open=state.open on-drawer-close('closeDrawer')>
-    <@header><h2 id="drawer-title">Heading</h2></@header>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+<ebay-drawer
+    a11y-close-text="Close drawer"
+    aria-labelledby="drawer-title"
+    open=state.open
+    on-close("closeDrawer")>
+    <@header id="drawer-title">Heading</@header>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <p>
+        <a href="http://www.ebay.com">www.ebay.com</a>
+    </p>
 </ebay-drawer>
-
-<ebay-button on-click('openDrawer')>
-    Opendrawer
-</ebay-button>
-
+<ebay-button on-click("openDrawer")>Opendrawer</ebay-button>
 class {
-  onCreate() {
-    this.state = { open: false };
-  }
-  openDrawer() {
-    this.state.open = true;
-  }
-  closeDrawer() {
-    this.state.open = false;
-  }
+    onCreate() {
+        this.state = { open: false };
+    }
+    openDrawer() {
+        this.state.open = true;
+    }
+    closeDrawer() {
+        this.state.open = false;
+    }
 }

--- a/src/components/ebay-drawer/index.marko
+++ b/src/components/ebay-drawer/index.marko
@@ -7,8 +7,8 @@ import processHtmlAttributes from "../../common/html-attributes"
     buttonPosition="right"
     key="dialog"
     on-scroll('handleScroll')
-    on-open("emit", "drawer-show")
-    on-close("emit", "drawer-close")
+    on-open("emit", "open")
+    on-close("emit", "close")
     class=[
         input.class,
         "drawer--mask-fade-slow"

--- a/src/components/ebay-drawer/marko-tag.json
+++ b/src/components/ebay-drawer/marko-tag.json
@@ -1,5 +1,5 @@
 {
-  "migrator": "../components/ebay-dialog-base/migrator.js",
+  "migrator": "./migrator.js",
   "attribute-groups": [
     "html-attributes"
   ],

--- a/src/components/ebay-drawer/migrator.js
+++ b/src/components/ebay-drawer/migrator.js
@@ -1,0 +1,22 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+const dialogBaseMigrator = require('../components/ebay-dialog-base/migrator');
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-drawer-show', `on-open`);
+    setAttributeIfPresent(el, context, 'on-drawer-close', `on-close`);
+    setAttributeIfPresent(el, context, 'on-drawer-expanded', `on-expanded`);
+    setAttributeIfPresent(el, context, 'on-drawer-collapsed', `on-collapsed`);
+    dialogBaseMigrator(el, context);
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-drawer/test/test.browser.js
+++ b/src/components/ebay-drawer/test/test.browser.js
@@ -56,7 +56,7 @@ describe('given a closed drawer', () => {
         });
 
         it('then it is visible in the DOM', async() => {
-            await wait(() => expect(component.emitted('drawer-show')).has.length(1));
+            await wait(() => expect(component.emitted('open')).has.length(1));
         });
         describe('then it is expanded', () => {
             beforeEach(async() => {
@@ -64,7 +64,7 @@ describe('given a closed drawer', () => {
             });
 
             it('then it is expanded in DOM', async() => {
-                await wait(() => expect(component.emitted('drawer-expanded')).has.length(1));
+                await wait(() => expect(component.emitted('expanded')).has.length(1));
             });
         });
         describe('then it is expanded on scroll', () => {
@@ -76,7 +76,7 @@ describe('given a closed drawer', () => {
             });
 
             it('then it is expanded in DOM', async() => {
-                await wait(() => expect(component.emitted('drawer-expanded')).has.length(1));
+                await wait(() => expect(component.emitted('expanded')).has.length(1));
             });
         });
     });
@@ -99,7 +99,7 @@ describe('given an open and expanded drawer', () => {
         });
 
         it('then it is expanded in DOM', async() => {
-            await wait(() => expect(component.emitted('drawer-collapsed')).has.length(1));
+            await wait(() => expect(component.emitted('collapsed')).has.length(1));
         });
     });
 
@@ -109,7 +109,7 @@ describe('given an open and expanded drawer', () => {
         });
 
         it('then it is expanded in DOM', async() => {
-            await wait(() => expect(component.emitted('drawer-expanded')).has.length(0));
+            await wait(() => expect(component.emitted('expanded')).has.length(0));
         });
     });
 });
@@ -131,7 +131,7 @@ describe('given an open and non expanded drawer for touch events', () => {
         });
 
         it('then it is expanded in DOM', async() => {
-            await wait(() => expect(component.emitted('drawer-expanded')).has.length(1));
+            await wait(() => expect(component.emitted('expanded')).has.length(1));
         });
     });
 
@@ -141,9 +141,9 @@ describe('given an open and non expanded drawer for touch events', () => {
         });
 
         it('then it did not trigger', async() => {
-            await wait(() => expect(component.emitted('drawer-expanded')).has.length(0));
-            await wait(() => expect(component.emitted('drawer-close')).has.length(0));
-            await wait(() => expect(component.emitted('drawer-collapsed')).has.length(0));
+            await wait(() => expect(component.emitted('expanded')).has.length(0));
+            await wait(() => expect(component.emitted('close')).has.length(0));
+            await wait(() => expect(component.emitted('collapsed')).has.length(0));
         });
     });
 
@@ -163,7 +163,7 @@ describe('given an open and non expanded drawer for touch events', () => {
         });
 
         it('then it is closed', async() => {
-            await wait(() => expect(component.emitted('drawer-close')).has.length(1));
+            await wait(() => expect(component.emitted('close')).has.length(1));
         });
 
         it('then it is hidden in the DOM when dragged down', async() => {
@@ -189,7 +189,7 @@ describe('given an open and expanded drawer for touch events', () => {
         });
 
         it('then it is expanded in DOM', async() => {
-            await wait(() => expect(component.emitted('drawer-expanded')).has.length(0));
+            await wait(() => expect(component.emitted('expanded')).has.length(0));
         });
     });
 
@@ -199,7 +199,7 @@ describe('given an open and expanded drawer for touch events', () => {
         });
 
         it('then it is closed', async() => {
-            await wait(() => expect(component.emitted('drawer-collapsed')).has.length(1));
+            await wait(() => expect(component.emitted('collapsed')).has.length(1));
         });
     });
 
@@ -225,7 +225,7 @@ describe('given an open and expanded drawer for touch events', () => {
 });
 
 async function checkNoEvenets(triggerComponent) {
-    await wait(() => expect(triggerComponent.emitted('drawer-expanded')).has.length(0));
-    await wait(() => expect(triggerComponent.emitted('drawer-close')).has.length(0));
-    await wait(() => expect(triggerComponent.emitted('drawer-collapsed')).has.length(0));
+    await wait(() => expect(triggerComponent.emitted('expanded')).has.length(0));
+    await wait(() => expect(triggerComponent.emitted('close')).has.length(0));
+    await wait(() => expect(triggerComponent.emitted('collapsed')).has.length(0));
 }

--- a/src/components/ebay-drawer/test/test.server.js
+++ b/src/components/ebay-drawer/test/test.server.js
@@ -1,7 +1,7 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
 const assign = require('core-js-pure/features/object/assign');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -44,4 +44,7 @@ describe('drawer', () => {
     });
 
     testPassThroughAttributes(template);
+    testEventsMigrator(require('../migrator'), 'drawer',
+        [{ from: 'show', to: 'open' },
+            'collapsed', 'close', 'expanded'], '../index.marko');
 });

--- a/src/components/ebay-filter-menu-button/README.md
+++ b/src/components/ebay-filter-menu-button/README.md
@@ -43,11 +43,11 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`filter-menu-button-expand` | | expand content
-`filter-menu-button-collapse` | `{ checked, originalEvent }` | collapse content (emits current checked state)
-`filter-menu-button-change` | `{ el, checked, originalEvent }` | items changed/checked
-`filter-menu-button-footer-click` | `{ checked, originalEvent }` | footer button clicked
-`filter-menu-button-form-submit` |  | `{ checked, originalEvent }` | when using `variant="form"`, and form is submitted (emits current checked state)
+`expand` | | expand content
+`collapse` | `{ checked, originalEvent }` | collapse content (emits current checked state)
+`change` | `{ el, checked, originalEvent }` | items changed/checked
+`footer-click` | `{ checked, originalEvent }` | footer button clicked
+`form-submit` |  | `{ checked, originalEvent }` | when using `variant="form"`, and form is submitted (emits current checked state)
 
 ## @item Tag
 

--- a/src/components/ebay-filter-menu-button/component.js
+++ b/src/components/ebay-filter-menu-button/component.js
@@ -58,14 +58,14 @@ module.exports = assign({}, menuUtils, {
     _emitComponentEvent(eventType, el, originalEvent) {
         switch (eventType) {
             case 'expand':
-                this.emit(`filter-menu-button-${eventType}`);
+                this.emit(eventType);
                 break;
             case 'change':
             case 'collapse':
             case 'form-submit':
             case 'footer-click': {
                 const checked = this.getCheckedValues();
-                this.emit(`filter-menu-button-${eventType}`, {
+                this.emit(eventType, {
                     el,
                     checked,
                     originalEvent

--- a/src/components/ebay-filter-menu-button/index.marko
+++ b/src/components/ebay-filter-menu-button/index.marko
@@ -40,10 +40,10 @@ static var ignoredAttributes = [
         form-action=input.formAction
         form-method=input.formMethod
         footer-text=input.footerText
-        onFilter-menu-keydown("handleMenuKeydown")
-        onFilter-menu-change("handleMenuChange")
-        onFilter-menu-form-submit("handleFormSubmit")
-        onFilter-menu-footer-click("handleFooterButtonClick")>
+        on-keydown("handleMenuKeydown")
+        on-change("handleMenuChange")
+        on-form-submit("handleFormSubmit")
+        on-footer-click("handleFooterButtonClick")>
         <for|item, i| of=input.items>
             <@item ...item checked=component.isChecked(i)/>
         </for>

--- a/src/components/ebay-filter-menu-button/marko-tag.json
+++ b/src/components/ebay-filter-menu-button/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-filter-menu-button/migrator.js
+++ b/src/components/ebay-filter-menu-button/migrator.js
@@ -1,0 +1,27 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-filter-menu-button-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-filter-menu-button-expand', 'on-expand');
+    setAttributeIfPresent(el, context, 'on-filter-menu-button-collapse', 'on-collapse');
+    setAttributeIfPresent(el, context, 'on-filter-menu-button-footer-click', 'on-footer-click');
+    setAttributeIfPresent(el, context, 'on-filter-menu-button-form-submit', 'on-form-submit');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-filter-menu-button/test/test.browser.js
+++ b/src/components/ebay-filter-menu-button/test/test.browser.js
@@ -31,7 +31,7 @@ describe('given the filter menu is in the default state', () => {
         });
 
         it('then it emits the marko event from expander-expand', () => {
-            expect(component.emitted('filter-menu-button-expand')).has.length(1);
+            expect(component.emitted('expand')).has.length(1);
         });
 
         describe('when it is clicked again', () => {
@@ -44,7 +44,7 @@ describe('given the filter menu is in the default state', () => {
             });
 
             it('then it emits the marko event from expander-collapse', () => {
-                expect(component.emitted('filter-menu-button-collapse')).has.length(1);
+                expect(component.emitted('collapse')).has.length(1);
             });
         });
     });
@@ -59,7 +59,7 @@ describe('given the filter menu is in the default state', () => {
         });
 
         it('then it doesn\'t emit the marko collapse event', () => {
-            expect(component.emitted('filter-menu-button-collapse')).has.length(0);
+            expect(component.emitted('collapse')).has.length(0);
         });
     });
 
@@ -74,7 +74,7 @@ describe('given the filter menu is in the default state', () => {
         });
 
         it('then it emits the menu-expand event', () => {
-            expect(component.emitted('filter-menu-button-expand')).has.length(1);
+            expect(component.emitted('expand')).has.length(1);
         });
     });
 });
@@ -91,7 +91,7 @@ describe('given the menu is in the expanded state', () => {
         firstItem = component.getAllByRole('menuitemcheckbox')[0];
         secondItem = component.getAllByRole('menuitemcheckbox')[1];
         await fireEvent.click(filterButton);
-        expect(component.emitted('filter-menu-button-expand')).has.length(1);
+        expect(component.emitted('expand')).has.length(1);
     });
 
     // TODO: we should make the `expanded` property controllable via input.
@@ -105,7 +105,7 @@ describe('given the menu is in the expanded state', () => {
         });
 
         it('then it doesn\'t emit the marko expand event', () => {
-            expect(component.emitted('filter-menu-button-expand')).has.length(0);
+            expect(component.emitted('expand')).has.length(0);
         });
     });
 
@@ -119,8 +119,8 @@ describe('given the menu is in the expanded state', () => {
             expect(filterButton).to.have.attr('aria-expanded', 'false');
         });
 
-        it('then it emits the filter-menu-button-expand event', () => {
-            expect(component.emitted('filter-menu-button-collapse')).has.length(1);
+        it('then it emits the expand event', () => {
+            expect(component.emitted('collapse')).has.length(1);
         });
     });
 
@@ -129,8 +129,8 @@ describe('given the menu is in the expanded state', () => {
             await fireEvent.click(component.getByText(firstItemText));
         });
 
-        it('then it emits the filter-menu-button-change event with correct data', () => {
-            const selectEvents = component.emitted('filter-menu-button-change');
+        it('then it emits the change event with correct data', () => {
+            const selectEvents = component.emitted('change');
             expect(selectEvents).to.length(1);
 
             const [[eventArg]] = selectEvents;
@@ -146,7 +146,7 @@ describe('given the menu is in the expanded state', () => {
         });
 
         it('then it emits two menu-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-button-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [firstEventData, secondEventData] = flat(changeEvents);
@@ -166,8 +166,8 @@ describe('given the menu is in the expanded state', () => {
             await fireEvent.click(firstItem);
         });
 
-        it('then it emits the filter-menu-button-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-button-change');
+        it('then it emits the change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [firstEventData, secondEventData] = flat(changeEvents);
@@ -188,8 +188,8 @@ describe('given the menu is in the expanded state', () => {
             });
         });
 
-        it('then it emits the filter-menu-button-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-button-change');
+        it('then it emits the change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const [firstEventData] = flat(changeEvents);
@@ -203,8 +203,8 @@ describe('given the menu is in the expanded state', () => {
             await fireEvent.click(footerButton);
         });
 
-        it('then it emits the filter-menu-button-footer-click event', () => {
-            const changeEvents = component.emitted('filter-menu-button-footer-click');
+        it('then it emits the footer-click event', () => {
+            const changeEvents = component.emitted('footer-click');
             expect(changeEvents).to.have.length(1);
             expect(filterButton).to.have.attr('aria-expanded', 'false');
         });
@@ -221,7 +221,7 @@ describe('given the menu is in the expanded state', () => {
         it('then the new item is selected or something');
 
         it('then it uses the new input in event data', () => {
-            const selectEvents = component.emitted('filter-menu-button-change');
+            const selectEvents = component.emitted('change');
             expect(selectEvents).has.length(1);
 
             const [[eventArg]] = selectEvents;

--- a/src/components/ebay-filter-menu-button/test/test.server.js
+++ b/src/components/ebay-filter-menu-button/test/test.server.js
@@ -45,4 +45,6 @@ describe('filter-menu-button', () => {
     });
 
     testUtils.testPassThroughAttributes(template);
+    testUtils.testEventsMigrator(require('../migrator'), 'filter-menu-button',
+        ['form-submit', 'change', 'footer-click', 'expand', 'collapse'], '../index.marko');
 });

--- a/src/components/ebay-filter-menu/README.md
+++ b/src/components/ebay-filter-menu/README.md
@@ -36,9 +36,9 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`filter-menu-button-change` | `{ el, checked, originalEvent }` | items changed/checked
-`filter-menu-button-footer-click` | `{ checked, originalEvent }` | footer button clicked
-`filter-menu-button-form-submit` |  | `{ checked, originalEvent }` | when using `variant="form"`, and form is submitted (emits current checked state)
+`change` | `{ el, checked, originalEvent }` | items changed/checked
+`footer-click` | `{ checked, originalEvent }` | footer button clicked
+`form-submit` |  | `{ checked, originalEvent }` | when using `variant="form"`, and form is submitted (emits current checked state)
 
 ## @item Tag
 

--- a/src/components/ebay-filter-menu/component.js
+++ b/src/components/ebay-filter-menu/component.js
@@ -69,7 +69,7 @@ module.exports = assign({}, menuUtils, {
         const checked = this.getCheckedValues();
         const checkedIndex = this.getCheckedIndexes();
 
-        this.emit(`filter-menu-${eventType}`, {
+        this.emit(`${eventType}`, {
             el,
             checked,
             checkedIndex,

--- a/src/components/ebay-filter-menu/index.marko
+++ b/src/components/ebay-filter-menu/index.marko
@@ -42,7 +42,7 @@ $ var isForm = input.variant === "form";
                     onKeydown("handleItemKeydown", i)>
                     <if(isForm)>
                         <if (isRadio)>
-                            <ebay-radio id:scoped=`${prefixName}-${i}` checked=isChecked on-radio-change("handleRadioClick", i)/>
+                            <ebay-radio id:scoped=`${prefixName}-${i}` checked=isChecked on-change("handleRadioClick", i)/>
                         </if>
                         <else>
                             <ebay-checkbox id:scoped=`${prefixName}-${i}` checked=isChecked/>

--- a/src/components/ebay-filter-menu/marko-tag.json
+++ b/src/components/ebay-filter-menu/marko-tag.json
@@ -1,5 +1,6 @@
 {
   "attribute-groups": ["html-attributes"],
+  "migrator": "./migrator",
   "@*": {
     "targetProperty": null,
     "type": "expression"

--- a/src/components/ebay-filter-menu/migrator.js
+++ b/src/components/ebay-filter-menu/migrator.js
@@ -1,0 +1,25 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-filter-menu-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-filter-menu-footer-click', 'on-footer-click');
+    setAttributeIfPresent(el, context, 'on-filter-menu-form-submit', 'on-form-submit');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -28,8 +28,8 @@ describe('given the menu is in the default state', () => {
             await fireEvent.click(component.getByText(firstItemText));
         });
 
-        it('then it emits the filter-menu-change event with correct data', () => {
-            const selectEvents = component.emitted('filter-menu-change');
+        it('then it emits the change event with correct data', () => {
+            const selectEvents = component.emitted('change');
             expect(selectEvents).to.length(1);
 
             const [[eventArg]] = selectEvents;
@@ -45,7 +45,7 @@ describe('given the menu is in the default state', () => {
         });
 
         it('then it emits two menu-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [firstEventData, secondEventData] = flat(changeEvents);
@@ -65,8 +65,8 @@ describe('given the menu is in the default state', () => {
             await fireEvent.click(firstItem);
         });
 
-        it('then it emits the filter-menu-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-change');
+        it('then it emits the change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [firstEventData, secondEventData] = flat(changeEvents);
@@ -87,8 +87,8 @@ describe('given the menu is in the default state', () => {
             });
         });
 
-        it('then it emits the filter-menu-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-change');
+        it('then it emits the change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const [firstEventData] = flat(changeEvents);
@@ -102,8 +102,8 @@ describe('given the menu is in the default state', () => {
             await fireEvent.click(footerButton);
         });
 
-        it('then it emits the filter-menu-footer-click event', () => {
-            const changeEvents = component.emitted('filter-menu-footer-click');
+        it('then it emits the footer-click event', () => {
+            const changeEvents = component.emitted('footer-click');
             expect(changeEvents).to.have.length(1);
         });
     });
@@ -117,7 +117,7 @@ describe('given the menu is in the default state', () => {
         });
 
         it('then it uses the new input in event data', () => {
-            const selectEvents = component.emitted('filter-menu-change');
+            const selectEvents = component.emitted('change');
             expect(selectEvents).has.length(1);
 
             const [[eventArg]] = selectEvents;
@@ -143,8 +143,8 @@ describe('given the menu is in the radio state', () => {
             await fireEvent.click(component.getByText(firstItemText));
         });
 
-        it('then it emits the filter-menu-change event with correct data', () => {
-            const selectEvents = component.emitted('filter-menu-change');
+        it('then it emits the change event with correct data', () => {
+            const selectEvents = component.emitted('change');
             expect(selectEvents).to.length(1);
 
             const [[eventArg]] = selectEvents;
@@ -160,7 +160,7 @@ describe('given the menu is in the radio state', () => {
         });
 
         it('then it emits two menu-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [firstEventData, secondEventData] = flat(changeEvents);
@@ -180,8 +180,8 @@ describe('given the menu is in the radio state', () => {
             await fireEvent.click(firstItem);
         });
 
-        it('then it emits the filter-menu-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-change');
+        it('then it emits the change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [firstEventData, secondEventData] = flat(changeEvents);
@@ -202,8 +202,8 @@ describe('given the menu is in the radio state', () => {
             });
         });
 
-        it('then it emits the filter-menu-change events with correct data', () => {
-            const changeEvents = component.emitted('filter-menu-change');
+        it('then it emits the change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const [firstEventData] = flat(changeEvents);
@@ -217,8 +217,8 @@ describe('given the menu is in the radio state', () => {
             await fireEvent.click(footerButton);
         });
 
-        it('then it emits the filter-menu-footer-click event', () => {
-            const changeEvents = component.emitted('filter-menu-footer-click');
+        it('then it emits the footer-click event', () => {
+            const changeEvents = component.emitted('footer-click');
             expect(changeEvents).to.have.length(1);
         });
     });
@@ -232,7 +232,7 @@ describe('given the menu is in the radio state', () => {
         });
 
         it('then it uses the new input in event data', () => {
-            const selectEvents = component.emitted('filter-menu-change');
+            const selectEvents = component.emitted('change');
             expect(selectEvents).has.length(1);
 
             const [[eventArg]] = selectEvents;

--- a/src/components/ebay-filter-menu/test/test.server.js
+++ b/src/components/ebay-filter-menu/test/test.server.js
@@ -39,4 +39,6 @@ describe('filter-menu', () => {
             multiple: true
         }
     });
+    testUtils.testEventsMigrator(require('../migrator'), 'filter-menu',
+        ['change', 'footer-click', 'form-submit'], '../index.marko');
 });

--- a/src/components/ebay-filter/README.md
+++ b/src/components/ebay-filter/README.md
@@ -24,4 +24,4 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`filter-click` | `{ originalEvent, selected }` | click or action key pressed (space and enter)
+`click` | `{ originalEvent, selected }` | click or action key pressed (space and enter)

--- a/src/components/ebay-filter/component.js
+++ b/src/components/ebay-filter/component.js
@@ -3,7 +3,7 @@ module.exports = {
         if (!this.input.disabled) {
             const selected = !this.state.selected;
             this.state.selected = selected;
-            this.emit('filter-click', {
+            this.emit('click', {
                 selected,
                 originalEvent
             });

--- a/src/components/ebay-filter/marko-tag.json
+++ b/src/components/ebay-filter/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-filter/migrator.js
+++ b/src/components/ebay-filter/migrator.js
@@ -1,0 +1,23 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-filter-click', 'on-click');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-filter/test/test.browser.js
+++ b/src/components/ebay-filter/test/test.browser.js
@@ -25,7 +25,7 @@ describe('given filter is enabled', () => {
         });
 
         it('then it emits the event with correct data', () => {
-            const clickEvents = component.emitted('filter-click');
+            const clickEvents = component.emitted('click');
             expect(clickEvents).has.length(1);
             const [[clickEventArg]] = clickEvents;
             expect(clickEventArg).has.property('originalEvent');
@@ -59,7 +59,7 @@ describe('given filter is disabled', () => {
         });
 
         it('then it does not emit the event', () => {
-            expect(component.emitted('filter-click')).has.length(0);
+            expect(component.emitted('click')).has.length(0);
         });
     });
 });

--- a/src/components/ebay-filter/test/test.server.js
+++ b/src/components/ebay-filter/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -56,4 +56,5 @@ describe('filter', () => {
             return component.getByRole('button');
         }
     });
+    testEventsMigrator(require('../migrator'), 'filter', ['click'], '../index.marko');
 });

--- a/src/components/ebay-infotip/README.md
+++ b/src/components/ebay-infotip/README.md
@@ -37,5 +37,5 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`tooltip-expand` | | overlay has been expanded
-`tooltip-collapse` | | overlay has been collapsed
+`expand` | | overlay has been expanded
+`collapse` | | overlay has been collapsed

--- a/src/components/ebay-infotip/component.js
+++ b/src/components/ebay-infotip/component.js
@@ -20,7 +20,7 @@ module.exports = {
 
     handleExpand() {
         this.setOpen(true);
-        this.emit('tooltip-expand');
+        this.emit('expand');
     },
 
     handleOverlayClose() {
@@ -31,6 +31,6 @@ module.exports = {
         this.setOpen(false);
 
         this.getEl('host').focus();
-        this.emit('tooltip-collapse');
+        this.emit('collapse');
     }
 };

--- a/src/components/ebay-infotip/migrator.js
+++ b/src/components/ebay-infotip/migrator.js
@@ -5,7 +5,6 @@ function migratorMarko4(el, context) {
     createIconFromAttribute(el, context, 'icon');
     setAttributeIfPresent(el, context, 'on-tooltip-expand', 'on-expand');
     setAttributeIfPresent(el, context, 'on-tooltip-collapse', 'on-collapse');
-
 }
 
 function migratorMarko5() {

--- a/src/components/ebay-infotip/test/test.browser.js
+++ b/src/components/ebay-infotip/test/test.browser.js
@@ -34,8 +34,8 @@ describe('given the default infotip', () => {
                 await fireEvent.click(component.getByLabelText(input.ariaLabel));
             });
 
-            it('then it emits the tooltip-expand event', () => {
-                expect(component.emitted('tooltip-expand')).has.length(1);
+            it('then it emits the expand event', () => {
+                expect(component.emitted('expand')).has.length(1);
             });
 
             it('then it is expanded', () => {
@@ -47,8 +47,8 @@ describe('given the default infotip', () => {
                     await fireEvent.click(component.getByLabelText(input.ariaLabel));
                 });
 
-                it('then it emits the tooltip-collapse event', () => {
-                    expect(component.emitted('tooltip-collapse')).has.length(1);
+                it('then it emits the collapse event', () => {
+                    expect(component.emitted('collapse')).has.length(1);
                 });
 
                 it('then it is collapsed', () => {
@@ -71,8 +71,8 @@ describe('given the modal infotip', () => {
             await fireEvent.click(component.getByLabelText(input.ariaLabel));
         });
 
-        it('then it emits the tooltip-expand event', async() => {
-            await wait(() => expect(component.emitted('tooltip-expand')).has.length(1));
+        it('then it emits the expand event', async() => {
+            await wait(() => expect(component.emitted('expand')).has.length(1));
         });
 
         it('then it is expanded', async() => {
@@ -96,8 +96,8 @@ describe('given the modal infotip opened', () => {
             await fireEvent.click(component.getByLabelText(input.ariaLabel));
         });
 
-        it('then it emits the tooltip-collapse event', async() => {
-            await wait(() => expect(component.emitted('tooltip-collapse')).has.length(1));
+        it('then it emits the collapse event', async() => {
+            await wait(() => expect(component.emitted('collapse')).has.length(1));
         });
 
         it('then it is collapsed', async() => {

--- a/src/components/ebay-infotip/test/test.server.js
+++ b/src/components/ebay-infotip/test/test.server.js
@@ -1,7 +1,7 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
 const assign = require('core-js-pure/features/object/assign');
-const { runTransformer } = require('../../../common/test-utils/server');
+const { runTransformer, testEventsMigrator } = require('../../../common/test-utils/server');
 const migrator = require('../migrator');
 const template = require('..');
 const mock = require('./mock');
@@ -66,4 +66,7 @@ describe('migrator', () => {
         const { body: { array: [iconEl] } } = el;
         expect(iconEl).to.equal(undefined);
     });
+
+    testEventsMigrator(require('../migrator'), { event: 'tooltip', component: 'infotip' },
+        ['expand', 'collapse'], '../index.marko');
 });

--- a/src/components/ebay-listbox-button/README.md
+++ b/src/components/ebay-listbox-button/README.md
@@ -42,9 +42,9 @@ Name | Type | Stateful | Required | Description
 
 Event | Data |  Description
 --- | --- | ---
-`listbox-collapse` | | collapse content
-`listbox-expand` | | expand content
-`listbox-change` | `{ el, index, selected }` | option selected
+`collapse` | | collapse content
+`expand` | | expand content
+`change` | `{ el, index, selected }` | option selected
 ---
 
 ## @option Tag

--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -5,11 +5,11 @@ const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 module.exports = {
     handleExpand() {
         this.getComponent('options').elementScroll();
-        this.emit('listbox-expand');
+        this.emit('expand');
     },
 
     handleCollapse() {
-        this.emit('listbox-collapse');
+        this.emit('collapse');
     },
 
     handleListboxChange(event) {
@@ -18,7 +18,7 @@ module.exports = {
         }
         const selectedIndex = event.index;
         this.state.selectedIndex = selectedIndex;
-        this.emit('listbox-change', event);
+        this.emit('change', event);
     },
 
     onCreate() {

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -44,7 +44,7 @@ $ var selectedText = selectedOption && selectedOption.text;
         class="listbox-button__listbox"
         name=input.name
         tabindex=-1
-        on-listbox-change("handleListboxChange")>
+        on-change("handleListboxChange")>
         <for|option| of=input.options>
             <@option ...option selected=(selectedOption === option) />
         </for>

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-listbox-button/migrator.js
+++ b/src/components/ebay-listbox-button/migrator.js
@@ -1,0 +1,25 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-listbox-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-listbox-expand', 'on-expand');
+    setAttributeIfPresent(el, context, 'on-listbox-collapse', 'on-collapse');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-listbox-button/test/test.browser.js
+++ b/src/components/ebay-listbox-button/test/test.browser.js
@@ -50,7 +50,7 @@ describe('given the listbox with 3 items', () => {
 
         describe('when the up arrow key is pressed', () => {
             beforeEach(async() => {
-                component.emitted('listbox-change');
+                component.emitted('change');
                 await pressKey(component.getByRole('button'), {
                     key: 'ArrowUp',
                     keyCode: 38
@@ -69,7 +69,7 @@ describe('given the listbox with 3 items', () => {
         });
 
         it('then it emits the event from expander-expand', () => {
-            expect(component.emitted('listbox-expand')).has.length(1);
+            expect(component.emitted('expand')).has.length(1);
         });
 
         it('then it has expanded the listbox', () => {
@@ -82,7 +82,7 @@ describe('given the listbox with 3 items', () => {
             });
 
             it('then it emits the event from expander-collapse', () => {
-                expect(component.emitted('listbox-collapse')).has.length(1);
+                expect(component.emitted('collapse')).has.length(1);
             });
 
             it('then it has collapsed the listbox', () => {
@@ -106,7 +106,7 @@ describe('given the listbox is in an expanded state', () => {
         });
 
         it('Should trigger listbox change change', () => {
-            const changeEvents = component.emitted('listbox-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[changeEvent]] = changeEvents;
@@ -123,8 +123,8 @@ describe('given the listbox is in an expanded state', () => {
             });
         });
 
-        it('then it emits the listbox-change event with the correct data', () => {
-            const changeEvents = component.emitted('listbox-change');
+        it('then it emits the change event with the correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[changeEvent]] = changeEvents;

--- a/src/components/ebay-listbox-button/test/test.server.js
+++ b/src/components/ebay-listbox-button/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -59,6 +59,8 @@ describe('listbox', () => {
             multiple: true
         }
     });
+    testEventsMigrator(require('../migrator'), { event: 'listbox', component: 'listbox-button' },
+        ['change', 'expand', 'collapse'], '../index.marko');
 });
 
 function isAriaSelected(el) {

--- a/src/components/ebay-listbox/README.md
+++ b/src/components/ebay-listbox/README.md
@@ -37,7 +37,7 @@ Name | Type | Stateful | Required | Description
 
 Event | Data |  Description
 --- | --- | ---
-`listbox-change` | `{ el, index, selected, wasClicked }` | option selected
+`change` | `{ el, index, selected, wasClicked }` | option selected
 ---
 
 ## @option Tag

--- a/src/components/ebay-listbox/component.js
+++ b/src/components/ebay-listbox/component.js
@@ -27,7 +27,7 @@ module.exports = {
         if (this.state.selectedIndex !== selectedIndex) {
             this.state.selectedIndex = selectedIndex;
             this.once('update', () => {
-                this.emit('listbox-change', {
+                this.emit('change', {
                     index: selectedIndex,
                     selected: [option.value],
                     el,

--- a/src/components/ebay-listbox/marko-tag.json
+++ b/src/components/ebay-listbox/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-listbox/migrator.js
+++ b/src/components/ebay-listbox/migrator.js
@@ -1,0 +1,23 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-listbox-change', 'on-change');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-listbox/test/test.browser.js
+++ b/src/components/ebay-listbox/test/test.browser.js
@@ -36,8 +36,8 @@ describe('given the listbox with 3 items', () => {
             });
         });
 
-        it('then it emits the listbox-change event with the correct data', () => {
-            const changeEvents = component.emitted('listbox-change');
+        it('then it emits the change event with the correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[changeEvent]] = changeEvents;
@@ -47,15 +47,15 @@ describe('given the listbox with 3 items', () => {
 
         describe('when the up arrow key is pressed', () => {
             beforeEach(async() => {
-                component.emitted('listbox-change');
+                component.emitted('change');
                 await pressKey(component.getAllByRole('listbox').find(isVisible), {
                     key: 'ArrowUp',
                     keyCode: 38
                 });
             });
 
-            it('then it emits the listbox-change event with the correct data', () => {
-                const changeEvents = component.emitted('listbox-change');
+            it('then it emits the change event with the correct data', () => {
+                const changeEvents = component.emitted('change');
                 expect(changeEvents).has.length(1);
 
                 const [[changeEvent]] = changeEvents;
@@ -78,8 +78,8 @@ describe('given the listbox is in an expanded state', () => {
             await fireEvent.click(component.getByText(input.options[1].text));
         });
 
-        it('then it emits the listbox-change event with correct data', () => {
-            const changeEvents = component.emitted('listbox-change');
+        it('then it emits the change event with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[changeEvent]] = changeEvents;
@@ -96,8 +96,8 @@ describe('given the listbox is in an expanded state', () => {
             });
         });
 
-        it('then it emits the listbox-change event with the correct data', () => {
-            const changeEvents = component.emitted('listbox-change');
+        it('then it emits the change event with the correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[changeEvent]] = changeEvents;
@@ -107,15 +107,15 @@ describe('given the listbox is in an expanded state', () => {
 
         describe('when the up arrow key is pressed', () => {
             beforeEach(async() => {
-                component.emitted('listbox-change');
+                component.emitted('change');
                 await pressKey(component.getAllByRole('listbox').find(isVisible), {
                     key: 'ArrowUp',
                     keyCode: 38
                 });
             });
 
-            it('then it emits the listbox-change event with the correct data', () => {
-                const changeEvents = component.emitted('listbox-change');
+            it('then it emits the change event with the correct data', () => {
+                const changeEvents = component.emitted('change');
                 expect(changeEvents).has.length(1);
 
                 const [[changeEvent]] = changeEvents;

--- a/src/components/ebay-listbox/test/test.server.js
+++ b/src/components/ebay-listbox/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -45,6 +45,7 @@ describe('listbox', () => {
             multiple: true
         }
     });
+    testEventsMigrator(require('../migrator'), 'listbox', ['change'], '../index.marko');
 });
 
 function isAriaSelected(el) {

--- a/src/components/ebay-menu-button/README.md
+++ b/src/components/ebay-menu-button/README.md
@@ -43,11 +43,11 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`menu-button-expand` |  | expand content
-`menu-button-collapse` |  | collapse content
-`menu-button-change` (radio) | `{ el, index, checked }` | item changed/checked
-`menu-button-change` (checkbox) | `{ el, [indexes], [checked] }` | items changed/checked
-`menu-button-select` (not radio or checkbox) | `{ el, index, checked }` | item clicked
+`expand` |  | expand content
+`collapse` |  | collapse content
+`change` (radio) | `{ el, index, checked }` | item changed/checked
+`change` (checkbox) | `{ el, [indexes], [checked] }` | items changed/checked
+`select` (not radio or checkbox) | `{ el, index, checked }` | item clicked
 
 ## @label Tag
 

--- a/src/components/ebay-menu-button/component.js
+++ b/src/components/ebay-menu-button/component.js
@@ -105,7 +105,7 @@ module.exports = assign({}, menuUtils, {
             });
         }
 
-        this.emit(`menu-button-${eventType}`, eventObj);
+        this.emit(`${eventType}`, eventObj);
     },
 
     onInput(input) {

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -82,9 +82,9 @@ $ var isOverflowVariant = input.variant === "overflow";
         reverse=(isOverflowVariant ? !input.reverse : input.reverse)
         fix-width=input.fixWidth
         tabindex=-1
-        onMenu-keydown("handleMenuKeydown")
-        onMenu-change("handleMenuChange")
-        onMenu-select("handleMenuSelect")
+        on-keydown("handleMenuKeydown")
+        on-change("handleMenuChange")
+        on-select("handleMenuSelect")
         key="content">
         <for|item,index| of=input.items>
             <@item  ...item checked=component.isChecked(index) />

--- a/src/components/ebay-menu-button/migrator.js
+++ b/src/components/ebay-menu-button/migrator.js
@@ -1,8 +1,13 @@
-const { createIconFromAttribute } = require('../../common/migrators');
+const { createIconFromAttribute, setAttributeIfPresent } = require('../../common/migrators');
 
 // Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
 function migratorMarko4(el, context) {
     createIconFromAttribute(el, context, 'icon');
+    setAttributeIfPresent(el, context, 'on-menu-button-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-menu-button-keydown', 'on-keydown');
+    setAttributeIfPresent(el, context, 'on-menu-button-select', 'on-select');
+    setAttributeIfPresent(el, context, 'on-menu-button-expand', 'on-expand');
+    setAttributeIfPresent(el, context, 'on-menu-button-collapse', 'on-collapse');
 }
 
 function migratorMarko5() {

--- a/src/components/ebay-menu-button/test/test.browser.js
+++ b/src/components/ebay-menu-button/test/test.browser.js
@@ -28,7 +28,7 @@ describe('given the menu is in the default state', () => {
         });
 
         it('then it emits the marko event from expander-expand', () => {
-            expect(component.emitted('menu-button-expand')).has.length(1);
+            expect(component.emitted('expand')).has.length(1);
         });
 
         describe('when it is clicked again', () => {
@@ -41,7 +41,7 @@ describe('given the menu is in the default state', () => {
             });
 
             it('then it emits the marko event from expander-collapse', () => {
-                expect(component.emitted('menu-button-collapse')).has.length(1);
+                expect(component.emitted('collapse')).has.length(1);
             });
         });
     });
@@ -57,7 +57,7 @@ describe('given the menu is in the default state', () => {
         it('then the new item is selected or something');
 
         it('then it uses the new input in event data', () => {
-            const selectEvents = component.emitted('menu-button-select');
+            const selectEvents = component.emitted('select');
             expect(selectEvents).has.length(1);
 
             const [[eventArg]] = selectEvents;
@@ -77,7 +77,7 @@ describe('given the menu is in the default state', () => {
         });
 
         it('then it doesn\'t emit the marko collapse event', () => {
-            expect(component.emitted('menu-button-collapse')).has.length(0);
+            expect(component.emitted('collapse')).has.length(0);
         });
     });
 
@@ -91,8 +91,8 @@ describe('given the menu is in the default state', () => {
             expect(component.getByRole('button')).to.have.attr('aria-expanded', 'true');
         });
 
-        it('then it emits the menu-button-expand event', () => {
-            expect(component.emitted('menu-button-expand')).has.length(1);
+        it('then it emits the expand event', () => {
+            expect(component.emitted('expand')).has.length(1);
         });
     });
 
@@ -109,7 +109,7 @@ describe('given the menu is in the expanded state', () => {
     beforeEach(async() => {
         component = await render(template, input);
         await fireEvent.click(component.getByRole('button'));
-        expect(component.emitted('menu-button-expand')).has.length(1);
+        expect(component.emitted('expand')).has.length(1);
     });
 
     // TODO: we should make the `expanded` property controllable via input.
@@ -123,7 +123,7 @@ describe('given the menu is in the expanded state', () => {
         });
 
         it('then it doesn\'t emit the marko expand event', () => {
-            expect(component.emitted('menu-button-expand')).has.length(0);
+            expect(component.emitted('expand')).has.length(0);
         });
     });
 
@@ -137,8 +137,8 @@ describe('given the menu is in the expanded state', () => {
             expect(component.getByRole('button')).to.have.attr('aria-expanded', 'false');
         });
 
-        it('then it emits the menu-button-expand event', () => {
-            expect(component.emitted('menu-button-collapse')).has.length(1);
+        it('then it emits the expand event', () => {
+            expect(component.emitted('collapse')).has.length(1);
         });
     });
 
@@ -148,8 +148,8 @@ describe('given the menu is in the expanded state', () => {
             await fireEvent.click(component.getByText(firstItemText));
         });
 
-        it('then it emits the menu-button-select event with correct data', () => {
-            const selectEvents = component.emitted('menu-button-select');
+        it('then it emits the select event with correct data', () => {
+            const selectEvents = component.emitted('select');
             expect(selectEvents).to.length(1);
 
             const [[eventArg]] = selectEvents;
@@ -158,7 +158,7 @@ describe('given the menu is in the expanded state', () => {
         });
 
         it('then it emits the mousedown event', () => {
-            expect(component.emitted('menu-button-mousedown')).has.length(1);
+            expect(component.emitted('mousedown')).has.length(1);
         });
     });
 
@@ -178,7 +178,7 @@ describe('given the menu is in the expanded state', () => {
         });
 
         it('then it emits the marko collapse event', () => {
-            expect(component.emitted('menu-button-collapse')).to.have.property('length', 1);
+            expect(component.emitted('collapse')).to.have.property('length', 1);
         });
     });
 
@@ -195,7 +195,7 @@ describe('given the menu is in the expanded state', () => {
         });
 
         it('then it emits the marko collapse event', () => {
-            expect(component.emitted('menu-button-collapse')).to.have.property('length', 1);
+            expect(component.emitted('collapse')).to.have.property('length', 1);
         });
     });
 });
@@ -214,8 +214,8 @@ describe('given the menu is in the expanded state with radio items', () => {
             await fireEvent.click(secondItem);
         });
 
-        it('then it emits the menu-button-change event with correct data', () => {
-            const changeEvents = component.emitted('menu-button-change');
+        it('then it emits the change event with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const [[eventData]] = changeEvents;
@@ -235,8 +235,8 @@ describe('given the menu is in the expanded state with radio items', () => {
             });
         });
 
-        it('then it emits the menu-button-change event with correct data', () => {
-            const changeEvents = component.emitted('menu-button-change');
+        it('then it emits the change event with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const [[eventData]] = changeEvents;
@@ -254,8 +254,8 @@ describe('given the menu is in the expanded state with radio items', () => {
             await fireEvent.click(secondItem);
         });
 
-        it('then it emits two menu-button-change events with correct data', () => {
-            const changeEvents = component.emitted('menu-button-change');
+        it('then it emits two change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [[firstEventData], [secondEventData]] = changeEvents;
@@ -276,8 +276,8 @@ describe('given the menu is in the expanded state with radio items', () => {
             await fireEvent.click(firstItem);
         });
 
-        it('then it emits only one menu-button-change event with correct data', () => {
-            const changeEvents = component.emitted('menu-button-change');
+        it('then it emits only one change event with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const [[eventData]] = changeEvents;
@@ -305,8 +305,8 @@ describe('given the menu is in the expanded state with checkbox items', () => {
             await fireEvent.click(secondItem);
         });
 
-        it('then it emits two menu-button-change events with correct data', () => {
-            const changeEvents = component.emitted('menu-button-change');
+        it('then it emits two change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [[firstEventData], [secondEventData]] = changeEvents;
@@ -326,8 +326,8 @@ describe('given the menu is in the expanded state with checkbox items', () => {
             await fireEvent.click(firstItem);
         });
 
-        it('then it emits the menu-button-change events with correct data', () => {
-            const changeEvents = component.emitted('menu-button-change');
+        it('then it emits the change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const [[firstEventData], [secondEventData]] = changeEvents;

--- a/src/components/ebay-menu-button/test/test.server.js
+++ b/src/components/ebay-menu-button/test/test.server.js
@@ -195,4 +195,7 @@ describe('migrator', () => {
         const { body: { array: [iconEl] } } = el;
         expect(iconEl).to.equal(undefined);
     });
+
+    testUtils.testEventsMigrator(migrator, 'menu-button',
+        ['keydown', 'change', 'select', 'expand', 'collapse'], '../index.marko');
 });

--- a/src/components/ebay-menu/README.md
+++ b/src/components/ebay-menu/README.md
@@ -24,10 +24,10 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`menu-keydown` | `{ el, index, checked }` |
-`menu-change` (radio) | `{ el, index, checked }` | item changed/checked
-`menu-change` (checkbox) | `{ el, [indexes], [checked] }` | items changed/checked
-`menu-select` (not radio or checkbox) | `{ el, index, checked }` | item clicked
+`keydown` | `{ el, index, checked }` |
+`change` (radio) | `{ el, index, checked }` | item changed/checked
+`change` (checkbox) | `{ el, [indexes], [checked] }` | items changed/checked
+`select` (not radio or checkbox) | `{ el, index, checked }` | item clicked
 
 ## @item Tag
 

--- a/src/components/ebay-menu/component.js
+++ b/src/components/ebay-menu/component.js
@@ -84,7 +84,7 @@ module.exports = assign({}, menuUtils, {
             });
         }
 
-        this.emit(`menu-${eventType}`, eventObj);
+        this.emit(`${eventType}`, eventObj);
     },
 
     onInput(input) {

--- a/src/components/ebay-menu/migrator.js
+++ b/src/components/ebay-menu/migrator.js
@@ -1,0 +1,25 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+/**
+ * @description
+ * Changes attribute of button events
+ */
+
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-menu-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-menu-keydown', 'on-keydown');
+    setAttributeIfPresent(el, context, 'on-menu-select', 'on-select');
+    return el;
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -24,8 +24,8 @@ describe('given the menu is in the default state', () => {
             await fireEvent.click(component.getByText(firstItemText));
         });
 
-        it('then it emits the menu-select event with correct data', () => {
-            const selectEvents = component.emitted('menu-select');
+        it('then it emits the select event with correct data', () => {
+            const selectEvents = component.emitted('select');
             expect(selectEvents).to.length(1);
 
             const [[eventArg]] = selectEvents;
@@ -45,7 +45,7 @@ describe('given the menu is in the default state', () => {
         });
 
         it('then it emits the marko keydown event', () => {
-            expect(component.emitted('menu-keydown')).to.have.property('length', 1);
+            expect(component.emitted('keydown')).to.have.property('length', 1);
         });
     });
 });
@@ -65,8 +65,8 @@ describe('given the menu has radio items', () => {
             await fireEvent.click(firstItem);
         });
 
-        it('then it emits the menu-change event with correct data', () => {
-            const changeEvents = component.emitted('menu-change');
+        it('then it emits the change event with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const eventData = changeEvents[0][0];
@@ -86,8 +86,8 @@ describe('given the menu has radio items', () => {
             });
         });
 
-        it('then it emits the menu-change event with correct data', () => {
-            const changeEvents = component.emitted('menu-change');
+        it('then it emits the change event with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const eventData = changeEvents[0][0];
@@ -105,8 +105,8 @@ describe('given the menu has radio items', () => {
             await fireEvent.click(secondItem);
         });
 
-        it('then it emits two menu-change events with correct data', () => {
-            const changeEvents = component.emitted('menu-change');
+        it('then it emits two change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const firstEventData = changeEvents[0][0];
@@ -128,8 +128,8 @@ describe('given the menu has radio items', () => {
             await fireEvent.click(firstItem);
         });
 
-        it('then it emits two menu-change events with correct data', () => {
-            const changeEvents = component.emitted('menu-change');
+        it('then it emits two change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(1);
 
             const eventData = changeEvents[0][0];
@@ -158,8 +158,8 @@ describe('given the menu has checkbox items', () => {
             await fireEvent.click(secondItem);
         });
 
-        it('then it emits two menu-change events with correct data', () => {
-            const changeEvents = component.emitted('menu-change');
+        it('then it emits two change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const firstEventData = changeEvents[0][0];
@@ -180,8 +180,8 @@ describe('given the menu has checkbox items', () => {
             await fireEvent.click(firstItem);
         });
 
-        it('then it emits the menu-change events with correct data', () => {
-            const changeEvents = component.emitted('menu-change');
+        it('then it emits the change events with correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).to.have.length(2);
 
             const firstEventData = changeEvents[0][0];

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -100,4 +100,6 @@ describe('menu', () => {
             multiple: true
         }
     });
+    testUtils.testEventsMigrator(require('../migrator'), 'menu',
+        ['change', 'select', 'keydown'], '../index.marko');
 });

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -28,9 +28,9 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`pagination-previous` | `{ originalEvent, el }`| clicked previous arrow button
-`pagination-next` | `{ originalEvent, el }` | clicked next arrow button
-`pagination-select` | `{ originalEvent, el, value }` | page selected clicked
+`previous` | `{ originalEvent, el }`| clicked previous arrow button
+`next` | `{ originalEvent, el }` | clicked next arrow button
+`select` | `{ originalEvent, el, value }` | page selected clicked
 
 ## @item Tag
 

--- a/src/components/ebay-pagination/component.js
+++ b/src/components/ebay-pagination/component.js
@@ -9,7 +9,7 @@ module.exports = {
      * @param {MouseEvent} originalEvent
      */
     handlePageNumberClick(originalEvent, el) {
-        this.emit('pagination-select', {
+        this.emit('select', {
             el,
             originalEvent,
             value: el.innerText
@@ -18,7 +18,7 @@ module.exports = {
 
     handleNextPageClick(originalEvent, el) {
         if (!el.hasAttribute('aria-disabled')) {
-            this.emit('pagination-next', {
+            this.emit('next', {
                 el,
                 originalEvent
             });
@@ -27,7 +27,7 @@ module.exports = {
 
     handlePreviousPageClick(originalEvent, el) {
         if (!el.hasAttribute('aria-disabled')) {
-            this.emit('pagination-previous', {
+            this.emit('previous', {
                 el,
                 originalEvent
             });

--- a/src/components/ebay-pagination/examples/06-buttons-interactive/template.marko
+++ b/src/components/ebay-pagination/examples/06-buttons-interactive/template.marko
@@ -16,9 +16,9 @@ class {
 }
 
 <ebay-pagination
-    on-pagination-previous("handlePrev")
-    on-pagination-next("handleNext")
-    on-pagination-select("handleSelect")>
+    on-next("handleNext")
+    on-previous("handlePrev")
+    on-select("handleSelect")>
     <@item type="previous" disabled=(state.current === 0)/>
     <for|i| from=0 to=SIZE>
         <@item current=(i === state.current)>${i}</@item>

--- a/src/components/ebay-pagination/marko-tag.json
+++ b/src/components/ebay-pagination/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-pagination/migrator.js
+++ b/src/components/ebay-pagination/migrator.js
@@ -1,0 +1,21 @@
+const { createIconFromAttribute, setAttributeIfPresent } = require('../../common/migrators');
+
+// Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
+function migratorMarko4(el, context) {
+    createIconFromAttribute(el, context, 'icon');
+    setAttributeIfPresent(el, context, 'on-pagination-next', 'on-next');
+    setAttributeIfPresent(el, context, 'on-pagination-previous', 'on-previous');
+    setAttributeIfPresent(el, context, 'on-pagination-select', 'on-select');
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -43,8 +43,8 @@ describe('given the pagination is rendered', () => {
             });
 
             function thenItEmittedThePaginationPreviousEvent() {
-                it('then it emits the pagination-previous event', () => {
-                    const previousEvents = component.emitted('pagination-previous');
+                it('then it emits the previous event', () => {
+                    const previousEvents = component.emitted('previous');
                     expect(previousEvents).has.length(1);
 
                     const [[eventArg]] = previousEvents;
@@ -66,8 +66,8 @@ describe('given the pagination is rendered', () => {
             });
 
             function thenItEmittedThePaginationNextEvent() {
-                it('then it emits the pagination-next event', () => {
-                    const nextEvents = component.emitted('pagination-next');
+                it('then it emits the next event', () => {
+                    const nextEvents = component.emitted('next');
                     expect(nextEvents).has.length(1);
 
                     const [[eventArg]] = nextEvents;
@@ -89,8 +89,8 @@ describe('given the pagination is rendered', () => {
             });
 
             function thenItEmittedThePaginationSelectEvent() {
-                it('then it emits the pagination-select event', () => {
-                    const selectEvents = component.emitted('pagination-select');
+                it('then it emits the select event', () => {
+                    const selectEvents = component.emitted('select');
                     expect(selectEvents).has.length(1);
 
                     const [[eventArg]] = selectEvents;
@@ -122,8 +122,8 @@ describe('given the pagination is rendered with disabled controls', () => {
         });
 
         function thenItDidNotEmitThePaginationPreviousEvent() {
-            it('then it does not emit the pagination-previous event', () => {
-                expect(component.emitted('pagination-previous')).has.length(0);
+            it('then it does not emit the previous event', () => {
+                expect(component.emitted('previous')).has.length(0);
             });
         }
     });
@@ -140,8 +140,8 @@ describe('given the pagination is rendered with disabled controls', () => {
         });
 
         function thenItDidNotEmitThePaginationNextEvent() {
-            it('then it does not emit the pagination-next event', () => {
-                expect(component.emitted('pagination-next')).has.length(0);
+            it('then it does not emit the next event', () => {
+                expect(component.emitted('next')).has.length(0);
             });
         }
     });

--- a/src/components/ebay-pagination/test/test.server.js
+++ b/src/components/ebay-pagination/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -77,6 +77,8 @@ describe('pagination', () => {
     });
 
     testPassThroughAttributes(template);
+    testEventsMigrator(require('../migrator'), 'pagination',
+        ['next', 'previous', 'select'], '../index.marko');
 });
 
 describe('pagination-item', () => {

--- a/src/components/ebay-radio/README.md
+++ b/src/components/ebay-radio/README.md
@@ -19,5 +19,5 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | --
-`radio-change` | `{ originalEvent, value }` | selected value
-`radio-focus` | `{ originalEvent, value }` |
+`change` | `{ originalEvent, value }` | selected value
+`focus` | `{ originalEvent, value }` |

--- a/src/components/ebay-radio/component-browser.js
+++ b/src/components/ebay-radio/component-browser.js
@@ -7,7 +7,7 @@ module.exports = {
 function forwardEvent(eventName) {
     return function(originalEvent, el) {
         if (!el.disabled) {
-            this.emit(`radio-${eventName}`, {
+            this.emit(eventName, {
                 originalEvent,
                 value: (el || this.el.querySelector('input')).value
             });

--- a/src/components/ebay-radio/marko-tag.json
+++ b/src/components/ebay-radio/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-radio/migrator.js
+++ b/src/components/ebay-radio/migrator.js
@@ -1,0 +1,19 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+// Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-radio-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-radio-focus', 'on-focus');
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-radio/test/test.browser.js
+++ b/src/components/ebay-radio/test/test.browser.js
@@ -19,7 +19,7 @@ describe('given radio button is enabled', () => {
         });
 
         it('then it emits the event', () => {
-            const changeEvents = component.emitted('radio-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const eventArgs = changeEvents[0];
@@ -41,7 +41,7 @@ describe('given radio button is disabled', () => {
         });
 
         it('then it doesn\'t emit the event', () => {
-            const changeEvents = component.emitted('radio-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(0);
         });
     });
@@ -54,7 +54,7 @@ describe('when native focus event is fired', () => {
     });
 
     it('then it emits the event', () => {
-        const events = component.emitted('radio-focus');
+        const events = component.emitted('focus');
         expect(events).has.length(1);
 
         const [[eventArg]] = events;

--- a/src/components/ebay-radio/test/test.server.js
+++ b/src/components/ebay-radio/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 
 use(require('chai-dom'));
@@ -25,3 +25,6 @@ testPassThroughAttributes(template, {
         return component.getByRole('radio').parentElement;
     }
 });
+
+testEventsMigrator(require('../migrator'), 'radio',
+    ['focus', 'change'], '../index.marko');

--- a/src/components/ebay-select/README.md
+++ b/src/components/ebay-select/README.md
@@ -41,7 +41,7 @@ Note: For this component, `class`/`style` are applied to the root tag, while all
 
 Event | Data |  Description
 --- | --- | ---
-`select-change` | `{ el, index, selected }` | option selected
+`change` | `{ el, index, selected }` | option selected
 ---
 
 ## @option Tag

--- a/src/components/ebay-select/component.js
+++ b/src/components/ebay-select/component.js
@@ -9,7 +9,7 @@ module.exports = {
         this.state.selectedIndex = selectedIndex;
 
         // TODO: we should not cast the selected value to a string here, but this is a breaking change.
-        this.emit('select-change', {
+        this.emit('change', {
             index: selectedIndex,
             selected: [String(option.value)],
             el

--- a/src/components/ebay-select/marko-tag.json
+++ b/src/components/ebay-select/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-select/migrator.js
+++ b/src/components/ebay-select/migrator.js
@@ -1,0 +1,18 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+// Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-select-change', 'on-change');
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-select/test/test.browser.js
+++ b/src/components/ebay-select/test/test.browser.js
@@ -28,8 +28,8 @@ describe('given the select with 3 options', () => {
             await fireEvent.change(combobox);
         });
 
-        it('then it emits the select-change event with the correct data', () => {
-            const changeEvents = component.emitted('select-change');
+        it('then it emits the change event with the correct data', () => {
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[eventArg]] = changeEvents;

--- a/src/components/ebay-select/test/test.server.js
+++ b/src/components/ebay-select/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -53,4 +53,5 @@ describe('select', () => {
             return component.getByRole('combobox').parentElement;
         }
     });
+    testEventsMigrator(require('../migrator'), 'select', ['change'], '../index.marko');
 });

--- a/src/components/ebay-switch/README.md
+++ b/src/components/ebay-switch/README.md
@@ -18,4 +18,4 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`switch-change` | `{ originalEvent, value, checked }` | selected value and checked status
+`change` | `{ originalEvent, value, checked }` | selected value and checked status

--- a/src/components/ebay-switch/component-browser.js
+++ b/src/components/ebay-switch/component-browser.js
@@ -1,7 +1,7 @@
 
 module.exports = {
     handleChange(originalEvent) {
-        this.emit('switch-change', {
+        this.emit('change', {
             originalEvent,
             value: originalEvent.target.value,
             checked: originalEvent.target.checked

--- a/src/components/ebay-switch/marko-tag.json
+++ b/src/components/ebay-switch/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-switch/migrator.js
+++ b/src/components/ebay-switch/migrator.js
@@ -1,0 +1,18 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+// Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-switch-change', 'on-change');
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-switch/test/test.browser.js
+++ b/src/components/ebay-switch/test/test.browser.js
@@ -20,7 +20,7 @@ describe('given switch button is enabled', () => {
         });
 
         it('then it emits the event', () => {
-            const changeEvents = component.emitted('switch-change');
+            const changeEvents = component.emitted('change');
             expect(changeEvents).has.length(1);
 
             const [[eventArg]] = changeEvents;
@@ -42,7 +42,7 @@ describe('given switch button is disabled', () => {
         });
 
         it('then it doesn\'t emit the event', () => {
-            expect(component.emitted('switch-change')).has.length(0);
+            expect(component.emitted('change')).has.length(0);
         });
     });
 });

--- a/src/components/ebay-switch/test/test.server.js
+++ b/src/components/ebay-switch/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 
 use(require('chai-dom'));
@@ -25,3 +25,5 @@ testPassThroughAttributes(template, {
         return component.getByRole('switch').parentElement;
     }
 });
+
+testEventsMigrator(require('../migrator'), 'switch', ['change'], '../index.marko');

--- a/src/components/ebay-tabs/README.md
+++ b/src/components/ebay-tabs/README.md
@@ -27,7 +27,7 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`tabs-select` | `{ index }` |
+`select` | `{ index }` |
 
 ## @heading Tag
 

--- a/src/components/ebay-tabs/component.js
+++ b/src/components/ebay-tabs/component.js
@@ -71,7 +71,7 @@ module.exports = {
 
         if (index !== state.index) {
             state.index = index;
-            this.emit('tabs-select', { index });
+            this.emit('select', { index });
         }
     },
 

--- a/src/components/ebay-tabs/marko-tag.json
+++ b/src/components/ebay-tabs/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-tabs/migrator.js
+++ b/src/components/ebay-tabs/migrator.js
@@ -1,0 +1,18 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+
+// Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-tabs-select', 'on-select');
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-tabs/test/test.browser.js
+++ b/src/components/ebay-tabs/test/test.browser.js
@@ -12,7 +12,7 @@ let component;
 
 function thenItHasMovedToTab(index) {
     it('then it emits the select event with correct data', () => {
-        const selectEvents = component.emitted('tabs-select');
+        const selectEvents = component.emitted('select');
         expect(selectEvents).has.length(1);
 
         const [[eventArg]] = selectEvents;
@@ -37,7 +37,7 @@ describe('given tabs with first heading selected', () => {
         });
 
         it('then it does not emit the select event', () => {
-            expect(component.emitted('tabs-select')).has.length(0);
+            expect(component.emitted('select')).has.length(0);
         });
     });
 
@@ -88,7 +88,7 @@ describe('given tabs with manual activation', () => {
         });
 
         it('then it does not emit the select event', () => {
-            expect(component.emitted('tabs-select')).has.length(0);
+            expect(component.emitted('select')).has.length(0);
         });
     });
 

--- a/src/components/ebay-tabs/test/test.server.js
+++ b/src/components/ebay-tabs/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -106,6 +106,8 @@ describe('tabs', () => {
     });
 
     testPassThroughAttributes(template);
+    testEventsMigrator(require('../migrator'), 'tabs',
+        ['select'], '../index.marko');
 });
 
 describe('tabs-heading', () => {

--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -27,12 +27,12 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`textbox-change` | `{ originalEvent, value }` |
-`textbox-input` | `{ originalEvent, value }` |
-`textbox-focus` | `{ originalEvent, value }` |
-`textbox-blur` | `{ originalEvent, value }` |
-`textbox-keydown` | `{ originalEvent, value }` |
-`textbox-keypress` | `{ originalEvent, value }` |
-`textbox-keyup` | `{ originalEvent, value }` |
-`textbox-floating-label-init` | `{ originalEvent: null, value: null }` |
-`textbox-button-click` | `{ originalEvent, value }` | Triggers when clicking on postfix-icon-button. Requires button-aria-label to be present in order to attach correctly
+`change` | `{ originalEvent, value }` |
+`input-change` | `{ originalEvent, value }` |
+`focus` | `{ originalEvent, value }` |
+`blur` | `{ originalEvent, value }` |
+`keydown` | `{ originalEvent, value }` |
+`keypress` | `{ originalEvent, value }` |
+`keyup` | `{ originalEvent, value }` |
+`floating-label-init` | `{ originalEvent: null, value: null }` |
+`button-click` | `{ originalEvent, value }` | Triggers when clicking on postfix-icon-button. Requires button-aria-label to be present in order to attach correctly

--- a/src/components/ebay-textbox/component-browser.js
+++ b/src/components/ebay-textbox/component-browser.js
@@ -6,7 +6,7 @@ module.exports = {
     handleKeypress: forwardEvent('keypress'),
     handleKeyup: forwardEvent('keyup'),
     handleChange: forwardEvent('change'),
-    handleInput: forwardEvent('input'),
+    handleInput: forwardEvent('input-change'),
     handleFocus: forwardEvent('focus'),
     handleBlur: forwardEvent('blur'),
     handleButtonClick: forwardEvent('button-click'),
@@ -46,7 +46,7 @@ module.exports = {
 
 function forwardEvent(eventName) {
     return function(originalEvent, el) {
-        this.emit(`textbox-${eventName}`, {
+        this.emit(eventName, {
             originalEvent,
             value: (el || this.el.querySelector('input, textarea')).value
         });

--- a/src/components/ebay-textbox/examples/19-both-icons/template.marko
+++ b/src/components/ebay-textbox/examples/19-both-icons/template.marko
@@ -5,7 +5,7 @@ class {
         };
     }
     change({ value }) {
-        this.state.value = value
+        this.state.value = value;
     }
     clear() {
         this.state.value = "";
@@ -17,8 +17,12 @@ class {
     value=state.value
     button-aria-label="Clear"
     placeholder="name"
-    on-textbox-change("change")
-    on-textbox-button-click("clear")>
-    <@postfix-icon><ebay-close-icon/></@postfix-icon>
-    <@prefix-icon><ebay-user-profile-icon/></@prefix-icon>
+    on-change("change")
+    on-button-click("clear")>
+    <@postfix-icon>
+        <ebay-close-icon/>
+    </@postfix-icon>
+    <@prefix-icon>
+        <ebay-user-profile-icon/>
+    </@prefix-icon>
 </ebay-textbox>

--- a/src/components/ebay-textbox/migrator.js
+++ b/src/components/ebay-textbox/migrator.js
@@ -1,4 +1,4 @@
-const { createIconFromAttribute } = require('../../common/migrators');
+const { createIconFromAttribute, setAttributeIfPresent } = require('../../common/migrators');
 
 // Transforms old icon to prefix or postfix icon
 function migratorMarko4(el, context) {
@@ -16,6 +16,16 @@ function migratorMarko4(el, context) {
 
     createIconFromAttribute(el, context, 'prefix-icon');
     createIconFromAttribute(el, context, 'postfix-icon');
+
+    setAttributeIfPresent(el, context, 'on-textbox-change', 'on-change');
+    setAttributeIfPresent(el, context, 'on-textbox-input', 'on-input-change');
+    setAttributeIfPresent(el, context, 'on-textbox-focus', 'on-focus');
+    setAttributeIfPresent(el, context, 'on-textbox-blur', 'on-blur');
+    setAttributeIfPresent(el, context, 'on-textbox-keydown', 'on-keydown');
+    setAttributeIfPresent(el, context, 'on-textbox-keypress', 'on-keypress');
+    setAttributeIfPresent(el, context, 'on-textbox-keyup', 'on-keyup');
+    setAttributeIfPresent(el, context, 'on-textbox-floating-label-init', 'on-floating-label-init');
+    setAttributeIfPresent(el, context, 'on-textbox-button-click', 'on-button-click');
 }
 
 function migratorMarko5() {

--- a/src/components/ebay-textbox/test/test.browser.js
+++ b/src/components/ebay-textbox/test/test.browser.js
@@ -25,7 +25,7 @@ describe('given an input textbox', () => {
             });
 
             it('then it emits the event', () => {
-                const events = component.emitted(`textbox-${eventName.toLowerCase()}`);
+                const events = component.emitted(eventName === 'input' ? 'input-change' : eventName.toLowerCase());
                 expect(events).has.length(1);
 
                 const [[eventArg]] = events;
@@ -82,7 +82,7 @@ describe('given an input textbox with floating label and no value', () => {
         });
 
         it('it should send a textbox floating label init event', () => {
-            expect(component.emitted('textbox-floating-label-init')).has.length(1);
+            expect(component.emitted('floating-label-init')).has.length(1);
         });
     });
 });
@@ -96,6 +96,6 @@ describe('when the component has a postfix button', () => {
     });
 
     it('it should trigger a postfix click event', () => {
-        expect(component.emitted('textbox-button-click')).has.length(1);
+        expect(component.emitted('button-click')).has.length(1);
     });
 });

--- a/src/components/ebay-textbox/test/test.server.js
+++ b/src/components/ebay-textbox/test/test.server.js
@@ -1,6 +1,10 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes, runTransformer } = require('../../../common/test-utils/server');
+const {
+    runTransformer,
+    testPassThroughAttributes,
+    testEventsMigrator
+} = require('../../../common/test-utils/server');
 const migrator = require('../migrator');
 const template = require('..');
 const mock = require('./mock');
@@ -150,4 +154,8 @@ describe('migrator', () => {
         expect(el.hasAttribute('icon')).to.equal(false);
         expect(el.hasAttribute('icon-position')).to.equal(false);
     });
+
+    testEventsMigrator(require('../migrator'), 'textbox',
+        ['change', { from: 'input', to: 'input-change' }, 'focus', 'blur', 'keydown', 'keypress',
+            'keyup', 'floating-label-init', 'button-click'], '../index.marko');
 });

--- a/src/components/ebay-toast/README.md
+++ b/src/components/ebay-toast/README.md
@@ -18,8 +18,8 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`toast-show` |  | toast opened
-`toast-close` |  | toast closed
+`open` |  | toast opened
+`close` |  | toast closed
 
 ## @header
 

--- a/src/components/ebay-toast/examples/01-default/template.marko
+++ b/src/components/ebay-toast/examples/01-default/template.marko
@@ -1,22 +1,22 @@
-<ebay-toast a11y-close-text="Close Toast" open=state.open on-toast-close('closeToast')>
+<ebay-toast a11y-close-text="Close Toast" open=state.open on-close("closeToast")>
     <@header>Heading</@header>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
-    <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-    <@footer><ebay-button accesskey="i" on-click('closeToast')>Close</ebay-button></@footer>
+    <p>
+        <a href="http://www.ebay.com">www.ebay.com</a>
+    </p>
+    <@footer>
+        <ebay-button accesskey="i" on-click("closeToast")>Close</ebay-button>
+    </@footer>
 </ebay-toast>
-
-<ebay-button on-click('openToast')>
-    Open Toast
-</ebay-button>
-
+<ebay-button on-click("openToast")>Open Toast</ebay-button>
 class {
-  onCreate() {
-    this.state = { open: false };
-  }
-  openToast() {
-    this.state.open = true;
-  }
-  closeToast() {
-    this.state.open = false;
-  }
+    onCreate() {
+        this.state = { open: false };
+    }
+    openToast() {
+        this.state.open = true;
+    }
+    closeToast() {
+        this.state.open = false;
+    }
 }

--- a/src/components/ebay-toast/index.marko
+++ b/src/components/ebay-toast/index.marko
@@ -9,8 +9,8 @@ $ var header = input.header || {};
     isModal=false
     classPrefix="toast"
     buttonPosition="right"
-    on-open("emit", "toast-show")
-    on-close("emit", "toast-close")
+    on-open("emit", "open")
+    on-close("emit", "close")
     class=[input.class, "toast--transition"]>
     <@header ...header class=[header.class, "toast__title"] />
     <${input.renderBody}/>

--- a/src/components/ebay-toast/marko-tag.json
+++ b/src/components/ebay-toast/marko-tag.json
@@ -1,5 +1,5 @@
 {
-  "migrator": "../components/ebay-dialog-base/migrator.js",
+  "migrator": "./migrator.js",
   "attribute-groups": [
     "html-attributes"
   ],

--- a/src/components/ebay-toast/migrator.js
+++ b/src/components/ebay-toast/migrator.js
@@ -1,0 +1,21 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
+const dialogBaseMigrator = require('../components/ebay-dialog-base/migrator');
+
+// Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
+function migratorMarko4(el, context) {
+    setAttributeIfPresent(el, context, 'on-toast-show', 'on-open');
+    setAttributeIfPresent(el, context, 'on-toast-close', 'on-close');
+    dialogBaseMigrator(el, context);
+}
+
+function migratorMarko5() {
+    return;
+}
+
+module.exports = function migrator(a, b) {
+    if (a.hub) {
+        return migratorMarko5(a, b);
+    }
+
+    return migratorMarko4(a, b);
+};

--- a/src/components/ebay-toast/test/test.browser.js
+++ b/src/components/ebay-toast/test/test.browser.js
@@ -30,7 +30,7 @@ describe('given a closed toast', () => {
         });
 
         it('then it is visible in the DOM', async() => {
-            await wait(() => expect(component.emitted('toast-show')).has.length(1));
+            await wait(() => expect(component.emitted('open')).has.length(1));
         });
     });
 });
@@ -48,7 +48,7 @@ describe('given an open toast', () => {
         });
 
         it('then it is closed in dom', async() => {
-            await wait(() => expect(component.emitted('toast-close')).has.length(1));
+            await wait(() => expect(component.emitted('close')).has.length(1));
         });
     });
 });

--- a/src/components/ebay-toast/test/test.server.js
+++ b/src/components/ebay-toast/test/test.server.js
@@ -1,6 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const { testPassThroughAttributes, testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -28,4 +28,6 @@ describe('toast', () => {
     });
 
     testPassThroughAttributes(template);
+    testEventsMigrator(require('../migrator'), 'toast',
+        [{ from: 'show', to: 'open' }, 'close'], '../index.marko');
 });

--- a/src/components/ebay-tooltip/README.md
+++ b/src/components/ebay-tooltip/README.md
@@ -37,5 +37,5 @@ Name | Type | Stateful | Required | Description
 
 Event | Data | Description
 --- | --- | ---
-`tooltip-expand` | | overlay has been expanded
-`tooltip-collapse` | | overlay has been collapsed
+`expand` | | overlay has been expanded
+`collapse` | | overlay has been collapsed

--- a/src/components/ebay-tooltip/index.marko
+++ b/src/components/ebay-tooltip/index.marko
@@ -22,8 +22,8 @@ $ var pointer = input.pointer || "bottom";
         style-right=input.styleRight
         style-bottom=input.styleBottom
         no-hover=input.noHover
-        onBase-expand("emit", "tooltip-expand")
-        onBase-collapse("emit", "tooltip-collapse")>
+        onBase-expand("emit", "expand")
+        onBase-collapse("emit", "collapse")>
         <span
             ...processHtmlAttributes(input, ignoredAttributes)
             class:no-update="tooltip">

--- a/src/components/ebay-tooltip/marko-tag.json
+++ b/src/components/ebay-tooltip/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": [
     "html-attributes"
   ],

--- a/src/components/ebay-tooltip/migrator.js
+++ b/src/components/ebay-tooltip/migrator.js
@@ -1,11 +1,9 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
 
-const { createIconFromAttribute, setAttributeIfPresent } = require('../../common/migrators');
-
+// Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
 function migratorMarko4(el, context) {
-    createIconFromAttribute(el, context, 'icon');
     setAttributeIfPresent(el, context, 'on-tooltip-expand', 'on-expand');
     setAttributeIfPresent(el, context, 'on-tooltip-collapse', 'on-collapse');
-
 }
 
 function migratorMarko5() {

--- a/src/components/ebay-tooltip/test/test.browser.js
+++ b/src/components/ebay-tooltip/test/test.browser.js
@@ -22,8 +22,8 @@ describe('given the default tooltip', () => {
             await fireEvent.mouseEnter(component.getByText(input.host.renderBody.text));
         });
 
-        it('then it emits the tooltip-expand event', () => {
-            expect(component.emitted('tooltip-expand')).has.length(1);
+        it('then it emits the expand event', () => {
+            expect(component.emitted('expand')).has.length(1);
         });
 
         describe('when the host element loses hover', () => {
@@ -31,8 +31,8 @@ describe('given the default tooltip', () => {
                 await fireEvent.mouseLeave(component.getByText(input.host.renderBody.text).parentElement);
             });
 
-            it('then it emits the tooltip-collapse event', async() => {
-                await wait(() => expect(component.emitted('tooltip-collapse')).has.length(1));
+            it('then it emits the collapse event', async() => {
+                await wait(() => expect(component.emitted('collapse')).has.length(1));
             });
         });
     });

--- a/src/components/ebay-tooltip/test/test.server.js
+++ b/src/components/ebay-tooltip/test/test.server.js
@@ -1,5 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
+const { testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -23,6 +24,8 @@ describe('tooltip', () => {
                 .with.class(`tooltip__pointer--${input.pointer}`);
         });
     });
+    testEventsMigrator(require('../migrator'), 'tooltip',
+        ['expand', 'collapse'], '../index.marko');
 
     // TODO: looks like class and style are not passed through to the tooltip.
     // testPassThroughAttributes(template);

--- a/src/components/ebay-tourtip/component-browser.js
+++ b/src/components/ebay-tourtip/component-browser.js
@@ -3,7 +3,7 @@ module.exports = {
     handleCollapse() {
         if (this._expander.isExpanded()) {
             this._expander.collapse();
-            this.emit('tooltip-collapse');
+            this.emit('collapse');
         }
     },
 

--- a/src/components/ebay-tourtip/marko-tag.json
+++ b/src/components/ebay-tourtip/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,

--- a/src/components/ebay-tourtip/migrator.js
+++ b/src/components/ebay-tourtip/migrator.js
@@ -1,11 +1,8 @@
+const { setAttributeIfPresent } = require('../../common/migrators');
 
-const { createIconFromAttribute, setAttributeIfPresent } = require('../../common/migrators');
-
+// Transforms an `icon` attribute into an `<ebay-menu:_icon>` tag
 function migratorMarko4(el, context) {
-    createIconFromAttribute(el, context, 'icon');
-    setAttributeIfPresent(el, context, 'on-tooltip-expand', 'on-expand');
     setAttributeIfPresent(el, context, 'on-tooltip-collapse', 'on-collapse');
-
 }
 
 function migratorMarko5() {

--- a/src/components/ebay-tourtip/test/test.browser.js
+++ b/src/components/ebay-tourtip/test/test.browser.js
@@ -43,8 +43,8 @@ describe('given the default tourtip', () => {
                 await fireEvent.click(component.getByLabelText(input.a11yCloseText));
             });
 
-            it('then it emits the tooltip-collapse event', () => {
-                expect(component.emitted('tooltip-collapse')).has.length(1);
+            it('then it emits the collapse event', () => {
+                expect(component.emitted('collapse')).has.length(1);
             });
 
             it('then it is closed', () => {

--- a/src/components/ebay-tourtip/test/test.server.js
+++ b/src/components/ebay-tourtip/test/test.server.js
@@ -1,5 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
+const { testEventsMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -14,6 +15,9 @@ describe('tourtip', () => {
         expect(getByText(input.content.renderBody.text)).has.class('tourtip__content');
         expect(getByText(input.heading.renderBody.text)).has.class('tourtip__heading');
     });
+    testEventsMigrator(require('../migrator'),
+        { event: 'tooltip', component: 'tourtip' },
+        ['collapse'], '../index.marko');
 
     // TODO: looks like class and style are not passed through to the tourtip.
     // testPassThroughAttributes(template);


### PR DESCRIPTION
## Description
* All events should have no more {component prefix} after the on
* Added migrators for all (and improved utilities for it, such as having migrators find onCamelCaseEvents as well)
* Added server tests to check the events are being migrated properly for each component (I had some typos so this helped to catch it, since this change is so large)

## Context
* Some events were not working, such as `update` and `input`. I changed `update`  to `move` (on carousel) and `input` to `input-change`. This is a marko limitation. 
* Ran migrator on all templates

## References
#976 
