### PR TITLE
Fixed aria issues with notice and infotip mini

### DIFF
--- a/src/components/components/ebay-dialog-base/index.marko
+++ b/src/components/components/ebay-dialog-base/index.marko
@@ -30,7 +30,7 @@ $ var header = input.header;
 </macro>
 <${baseEl}
     ...processHtmlAttributes(input, ignoredAttributes)
-    aria-labelledby=(input.ariaLabelledby || component.getElId("dialog-title"))
+    aria-labelledby=(input.ariaLabelledby || (input.header && component.getElId("dialog-title")))
     aria-modal="true"
     role="dialog"
     class=[input.classPrefix, input.class]

--- a/src/components/components/ebay-tooltip-base/component-browser.js
+++ b/src/components/components/ebay-tooltip-base/component-browser.js
@@ -11,11 +11,15 @@ module.exports = {
     },
 
     onMount() {
-        this._setupMakeup();
+        if (this.input.type !== 'dialog--mini') {
+            this._setupMakeup();
+        }
     },
 
     onUpdate() {
-        this._setupMakeup();
+        if (this.input.type !== 'dialog--mini') {
+            this._setupMakeup();
+        }
     },
 
     onRender() {
@@ -41,7 +45,7 @@ module.exports = {
         const { type } = input;
         const container = this.getEl('container');
         const isTooltip = type === 'tooltip';
-        const isInfotip = type === 'infotip' || type === 'dialog--mini';
+        const isInfotip = type === 'infotip';
         const expanderEl = container.getElementsByClassName(type)[0];
 
         if (host) {

--- a/src/components/ebay-icon/index.marko
+++ b/src/components/ebay-icon/index.marko
@@ -11,6 +11,7 @@ static var ignoredAttributes = [
     "toJSON"
 ];
 
+$ var noTitle = input.a11yVariant === 'label';
 $ input.toJSON = noop;
 $ var lookup = isBrowser ? browserLookup : out.global;
 $ var a11yAttributes = input.a11yText ? { role: "img" } : { "aria-hidden": "true" }
@@ -20,7 +21,8 @@ $ var a11yAttributes = input.a11yText ? { role: "img" } : { "aria-hidden": "true
     ...processHtmlAttributes(input, ignoredAttributes)
     class=[input.class, !input.noSkinClasses && `icon icon--${input.name}`]
     focusable="false"
-    aria-labelledby=(input.a11yText && component.elId("text"))>
+    aria-labelledby=(input.a11yText && !noTitle && component.elId("text"))
+    aria-label=(noTitle && input.a11yText)>
     <!-- Here we check if we should render the inline svg symbol. -->
     <!-- Server side we store a flag in `out.global` to check if the symbol was rendered. -->
     <!-- Client side we check the `browserLookup` object to see if the symbol is already present in root svg. -->
@@ -52,7 +54,7 @@ $ var a11yAttributes = input.a11yText ? { role: "img" } : { "aria-hidden": "true
         </defs>
     </if>
 
-    <if(input.a11yText)>
+    <if(input.a11yText && !noTitle)>
         <title id:scoped="text">${input.a11yText}</title>
     </if>
 

--- a/src/components/ebay-icon/marko-tag.json
+++ b/src/components/ebay-icon/marko-tag.json
@@ -10,6 +10,7 @@
   "@html-attributes": "expression",
   "@name": "string",
   "@a11y-text": "string",
+  "@a11y-variant": "string",
   "@no-skin-classes": "boolean",
   "@_themes": "expression",
   "@role": "never",

--- a/src/components/ebay-infotip/component.js
+++ b/src/components/ebay-infotip/component.js
@@ -6,12 +6,6 @@ module.exports = {
         };
     },
 
-    onMount() {
-        if (this.state.open) {
-            this.getComponent('base').expand();
-        }
-    },
-
     setOpen(isOpen) {
         if (this.input.modal) {
             this.state.open = isOpen;

--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -25,8 +25,8 @@ $ var pointer = input.pointer || "bottom";
         type=classPrefix
         pointer=pointer
         overlay-id:scoped="overlay"
-        onBase-expand("handleExpand")
-        onBase-collapse("handleCollapse")>
+        onBase-expand(!input.modal && "handleExpand")
+        onBase-collapse(!input.modal && "handleCollapse")>
         <span
             ...processHtmlAttributes(input, ignoredAttributes)
             class:no-update=[
@@ -38,6 +38,7 @@ $ var pointer = input.pointer || "bottom";
                 key="host"
                 class=[`${classPrefix}__host`, "icon-btn"]
                 type="button"
+                on-click(input.modal && "handleExpand")
                 disabled=input.disabled
                 aria-label=input.ariaLabel>
                 <if(input.iconTag)>
@@ -69,8 +70,9 @@ $ var pointer = input.pointer || "bottom";
                     class=[`${classPrefix}__overlay`]
                     windowClass=["dialog__window--mini", "dialog__window--fade"]
                     a11y-close-text=input.a11yCloseText
+                    aria-label=input.ariaLabel
                     on-modal-show("handleExpand")
-                    on-modal-close("handleOverlayClose")>
+                    on-modal-close("handleCollapse")>
                     <${input.content}/>
                 </ebay-dialog-base>
             </else>

--- a/src/components/ebay-infotip/test/test.browser.js
+++ b/src/components/ebay-infotip/test/test.browser.js
@@ -31,7 +31,7 @@ describe('given the default infotip', () => {
     function thenItCanBeOpenAndClosed() {
         describe('when the host element is clicked', () => {
             beforeEach(async() => {
-                await fireEvent.click(component.getByLabelText(input.ariaLabel));
+                await fireEvent.click(component.getAllByLabelText(input.ariaLabel)[0]);
             });
 
             it('then it emits the tooltip-expand event', () => {
@@ -68,7 +68,7 @@ describe('given the modal infotip', () => {
 
     describe('when the host element is clicked', () => {
         beforeEach(async() => {
-            await fireEvent.click(component.getByLabelText(input.ariaLabel));
+            await fireEvent.click(component.getAllByLabelText(input.ariaLabel)[0]);
         });
 
         it('then it emits the tooltip-expand event', async() => {
@@ -77,7 +77,6 @@ describe('given the modal infotip', () => {
 
         it('then it is expanded', async() => {
             await wait(() => {
-                expect(component.getByLabelText(input.ariaLabel)).has.attr('aria-expanded', 'true');
                 expect(component.getByRole('dialog')).does.not.have.attr('hidden');
             });
         });
@@ -93,7 +92,7 @@ describe('given the modal infotip opened', () => {
 
     describe('when the host element is opened and then closed', () => {
         beforeEach(async() => {
-            await fireEvent.click(component.getByLabelText(input.ariaLabel));
+            await fireEvent.click(component.getByLabelText(input.a11yCloseText));
         });
 
         it('then it emits the tooltip-collapse event', async() => {
@@ -102,7 +101,6 @@ describe('given the modal infotip opened', () => {
 
         it('then it is collapsed', async() => {
             await wait(() => {
-                expect(component.getByLabelText(input.ariaLabel)).does.not.have.attr('aria-expanded', 'true');
                 expect(component.getByRole('dialog')).has.attr('hidden');
             });
         });

--- a/src/components/ebay-infotip/test/test.server.js
+++ b/src/components/ebay-infotip/test/test.server.js
@@ -35,8 +35,8 @@ describe('infotip', () => {
 describe('infotip modal', () => {
     it('renders modal infotip', async() => {
         const input = mock.ModalWithContent;
-        const { getByLabelText, getByText } = await render(template, input);
-        expect(getByLabelText(input.ariaLabel)).has.class('dialog--mini__host');
+        const { getByLabelText, getAllByLabelText, getByText } = await render(template, input);
+        expect(getAllByLabelText(input.ariaLabel)[0]).has.class('dialog--mini__host');
         expect(getByText(input.content.renderBody.text)).has.class('dialog__main');
         expect(getByLabelText(input.a11yCloseText)).has.class('dialog__close');
     });

--- a/src/components/ebay-notice/index.marko
+++ b/src/components/ebay-notice/index.marko
@@ -38,6 +38,7 @@ $ var isIconVisible = input.icon !== "none";
                     <ebay-icon
                         class="window-notice__icon"
                         name="confirmation-filled"
+                        a11y-variant="label"
                         a11y-text=input.a11yHeadingText/>
                 </if>
                 <span
@@ -48,13 +49,22 @@ $ var isIconVisible = input.icon !== "none";
             </if>
             <else>
                 <if(status === "confirmation" || status === "celebration")>
-                    <ebay-icon name="confirmation-filled" a11y-text=input.a11yHeadingText/>
+                    <ebay-icon
+                        name="confirmation-filled"
+                        a11y-variant="label"
+                        a11y-text=input.a11yHeadingText/>
                 </if>
                 <else if(status === "attention")>
-                    <ebay-icon name="attention-filled" a11y-text=input.a11yHeadingText/>
+                    <ebay-icon
+                        name="attention-filled"
+                        a11y-variant="label"
+                        a11y-text=input.a11yHeadingText/>
                 </else>
                 <else if(status === "information")>
-                    <ebay-icon name="information-filled" a11y-text=input.a11yHeadingText/>
+                    <ebay-icon
+                        name="information-filled"
+                        a11y-variant="label"
+                        a11y-text=input.a11yHeadingText/>
                 </else>
             </else>
         </>


### PR DESCRIPTION
## Description
This fixes three bugs
* Fixed notice icon to use `aria-label`. Added `a11y-variant="label"` which will allow this
* Fixed dialog-mini to not use expander (and won't have `aria-expanded`)
* Fixed dialog-mini to pass in `aria-label` from notice.

## References
#1218 
#1219 
#1198