### PR TITLE
Added carousel role description 

### DIFF
--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -28,7 +28,7 @@ Name | Type | Stateful | Required | Description
 
 Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
-`a11y-status-text` | String | No | Yes | status text (default: "Showing Slide {currentSlide} of {totalSlides} - Carousel")
+`a11y-status-text` | String | No | Yes | status text (default: "Showing Slide {currentSlide} of {totalSlides}")
 `a11y-status-tag` | String | No | Yes | use h1-h6 when there isn't a visible heading before the carousel (default: "span")
 `autoplay` | Boolean or Number | No | No | automatically slides the carousel on an interval. If a number is supplied that is used as the interval in ms, defaults to 4000ms.
 
@@ -36,8 +36,8 @@ Name | Type | Stateful | Required | Description
 
 Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
-`a11y-play-text` | String | No | Yes | autoplay play button text (default: "Play - Carousel")
-`a11y-pause-text` | String | No | Yes | autoplay pause button text (default: "Pause - Carousel")
+`a11y-play-text` | String | No | Yes | autoplay play button text (default: "Play")
+`a11y-pause-text` | String | No | Yes | autoplay pause button text (default: "Pause")
 `paused` | Boolean | Yes | No | pauses the autoplay carousel
 
 ## ebay-carousel Events

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -22,21 +22,13 @@ function getTemplateData(state) {
     let slide,
         itemWidth,
         totalSlides,
-        a11yStatusText,
-        a11yPreviousText = state.a11yPreviousText,
-        a11yNextText = state.a11yNextText;
+        a11yStatusText;
 
     if (itemsPerSlide) {
         const itemsInSlide = itemsPerSlide + state.peek;
         slide = getSlide(state);
         itemWidth = `calc(${100 / itemsInSlide}% - ${(itemsInSlide - 1) * gap / itemsInSlide}px)`;
         totalSlides = getSlide(state, items.length);
-        a11yPreviousText = a11yPreviousText
-            .replace('{currentSlide}', slide + 1)
-            .replace('{totalSlides}', totalSlides);
-        a11yNextText = a11yNextText
-            .replace('{currentSlide}', slide + 1)
-            .replace('{totalSlides}', totalSlides);
         a11yStatusText = state.a11yStatusText
             .replace('{currentSlide}', slide + 1)
             .replace('{totalSlides}', totalSlides);
@@ -70,8 +62,6 @@ function getTemplateData(state) {
         slide,
         offset: hasOverride ? config.offsetOverride : offset,
         disableTransition: hasOverride,
-        a11yNextText,
-        a11yPreviousText,
         totalSlides,
         a11yStatusText,
         prevControlDisabled,
@@ -453,10 +443,6 @@ module.exports = {
     togglePlay,
 
     onInput(input) {
-        let titleText = input.a11yHeadingText || input.a11yStatusText;
-        if (titleText) {
-            titleText = ` - ${titleText}`;
-        }
         const gap = parseInt(input.gap, 10);
 
         const state = {
@@ -486,8 +472,8 @@ module.exports = {
             gap: isNaN(gap) ? 16 : gap,
             index: parseInt(input.index, 10) || 0,
             itemsPerSlide: parseFloat(input.itemsPerSlide, 10) || undefined,
-            a11yPreviousText: input.a11yPreviousText || `'Previous Slide${titleText}`,
-            a11yNextText: input.a11yNextText || `Next Slide${titleText}`,
+            a11yPreviousText: input.a11yPreviousText || 'Previous Slide',
+            a11yNextText: input.a11yNextText || 'Next Slide',
             a11yStatusText: input.a11yStatusText || 'Showing Slide {currentSlide} of {totalSlides} - Carousel',
             a11yStatusTag: input.a11yStatusTag || 'span',
             a11yHeadingText: input.a11yHeadingText,

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -19,10 +19,7 @@ function getTemplateData(state) {
     const prevControlDisabled = isSingleSlide || !autoplayInterval && offset === 0;
     const nextControlDisabled = isSingleSlide || !autoplayInterval && offset === getMaxOffset(state);
     const bothControlsDisabled = prevControlDisabled && nextControlDisabled;
-    let slide,
-        itemWidth,
-        totalSlides,
-        a11yStatusText;
+    let slide, itemWidth, totalSlides, a11yStatusText;
 
     if (itemsPerSlide) {
         const itemsInSlide = itemsPerSlide + state.peek;
@@ -444,7 +441,6 @@ module.exports = {
 
     onInput(input) {
         const gap = parseInt(input.gap, 10);
-
         const state = {
             htmlAttributes: processHtmlAttributes(input, [
                 'class',

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -19,13 +19,24 @@ function getTemplateData(state) {
     const prevControlDisabled = isSingleSlide || !autoplayInterval && offset === 0;
     const nextControlDisabled = isSingleSlide || !autoplayInterval && offset === getMaxOffset(state);
     const bothControlsDisabled = prevControlDisabled && nextControlDisabled;
-    let slide, itemWidth, totalSlides, a11yStatusText;
+    let slide,
+        itemWidth,
+        totalSlides,
+        a11yStatusText,
+        a11yPreviousText = state.a11yPreviousText,
+        a11yNextText = state.a11yNextText;
 
     if (itemsPerSlide) {
         const itemsInSlide = itemsPerSlide + state.peek;
         slide = getSlide(state);
         itemWidth = `calc(${100 / itemsInSlide}% - ${(itemsInSlide - 1) * gap / itemsInSlide}px)`;
         totalSlides = getSlide(state, items.length);
+        a11yPreviousText = a11yPreviousText
+            .replace('{currentSlide}', slide + 1)
+            .replace('{totalSlides}', totalSlides);
+        a11yNextText = a11yNextText
+            .replace('{currentSlide}', slide + 1)
+            .replace('{totalSlides}', totalSlides);
         a11yStatusText = state.a11yStatusText
             .replace('{currentSlide}', slide + 1)
             .replace('{totalSlides}', totalSlides);
@@ -59,6 +70,8 @@ function getTemplateData(state) {
         slide,
         offset: hasOverride ? config.offsetOverride : offset,
         disableTransition: hasOverride,
+        a11yNextText,
+        a11yPreviousText,
         totalSlides,
         a11yStatusText,
         prevControlDisabled,
@@ -440,7 +453,12 @@ module.exports = {
     togglePlay,
 
     onInput(input) {
+        let titleText = input.a11yHeadingText || input.a11yStatusText;
+        if (titleText) {
+            titleText = ` - ${titleText}`;
+        }
         const gap = parseInt(input.gap, 10);
+
         const state = {
             htmlAttributes: processHtmlAttributes(input, [
                 'class',
@@ -468,8 +486,8 @@ module.exports = {
             gap: isNaN(gap) ? 16 : gap,
             index: parseInt(input.index, 10) || 0,
             itemsPerSlide: parseFloat(input.itemsPerSlide, 10) || undefined,
-            a11yPreviousText: input.a11yPreviousText || 'Previous Slide',
-            a11yNextText: input.a11yNextText || 'Next Slide',
+            a11yPreviousText: input.a11yPreviousText || `'Previous Slide${titleText}`,
+            a11yNextText: input.a11yNextText || `Next Slide${titleText}`,
             a11yStatusText: input.a11yStatusText || 'Showing Slide {currentSlide} of {totalSlides} - Carousel',
             a11yStatusTag: input.a11yStatusTag || 'span',
             a11yHeadingText: input.a11yHeadingText,

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -474,12 +474,12 @@ module.exports = {
             itemsPerSlide: parseFloat(input.itemsPerSlide, 10) || undefined,
             a11yPreviousText: input.a11yPreviousText || 'Previous Slide',
             a11yNextText: input.a11yNextText || 'Next Slide',
-            a11yStatusText: input.a11yStatusText || 'Showing Slide {currentSlide} of {totalSlides} - Carousel',
+            a11yStatusText: input.a11yStatusText || 'Showing Slide {currentSlide} of {totalSlides}',
             a11yStatusTag: input.a11yStatusTag || 'span',
             a11yHeadingText: input.a11yHeadingText,
             a11yHeadingTag: input.a11yHeadingTag || 'h2',
-            a11yPauseText: input.a11yPauseText || 'Pause - Carousel',
-            a11yPlayText: input.a11yPlayText || 'Play - Carousel'
+            a11yPauseText: input.a11yPauseText || 'Pause',
+            a11yPlayText: input.a11yPlayText || 'Play'
         };
 
         const itemSkippedAttributes = ['class', 'style'];

--- a/src/components/ebay-carousel/index.marko
+++ b/src/components/ebay-carousel/index.marko
@@ -8,8 +8,8 @@ $ var statusId = (discrete && "carousel-status-" + component.id) || (
     class=data.classes
     style=data.style
     aria-labelledby=statusId
-    role=(statusId && "group")
-    aria-roledescription=(statusId && "carousel")>
+    role="group"
+    aria-roledescription="carousel">
    <div
         class=[
             "carousel__container",

--- a/src/components/ebay-carousel/index.marko
+++ b/src/components/ebay-carousel/index.marko
@@ -1,9 +1,16 @@
 $ var data = component.getTemplateData(state, input);
-<div ...data.htmlAttributes class=data.classes style=data.style>
-    $ var config = data.config;
-    $ var discrete = data.totalSlides >= 1;
-    $ var statusId = discrete && "carousel-status-" + component.id;
-    <div
+$ var config = data.config;
+$ var discrete = data.totalSlides >= 1;
+$ var statusId = (discrete && "carousel-status-" + component.id) || (
+   data.a11yStatusText || data.a11yHeadingText && component.getElId("carousel"));
+
+<div ...data.htmlAttributes
+    class=data.classes
+    style=data.style
+    aria-labelledby=statusId
+    role=(statusId && "group")
+    aria-roledescription=(statusId && "carousel")>
+   <div
         class=[
             "carousel__container",
             data.bothControlsDisabled &&


### PR DESCRIPTION
## Description
Added role description. Will generate an ID used for `aria-labelledby` on the root. This ID is only available when there is a clipped text (`a11yStatusText or `a11yHeadingText`, or is `discrete`).
Added `role="group"` and `aria-roledescription="carousel"`
Also appended title of carousel to buttons. 

## References
#609
#1177
