### PR TITLE
Updated fullscreen dialog to pass in useHiddenProperty argument

### DIFF
--- a/src/components/components/ebay-dialog-base/component.js
+++ b/src/components/components/ebay-dialog-base/component.js
@@ -115,9 +115,10 @@ module.exports = {
         const isFirstRender = (opts && opts.firstRender);
         const wasToggled = isTrapped !== wasTrapped;
         const focusEl = (this.input.focus && document.getElementById(this.input.focus)) || this.closeEl;
+        const useHiddenProperty = this.input.useHiddenProperty || false;
 
         if (this.input.isModal && (restoreTrap || (isTrapped && !wasTrapped))) {
-            screenReaderTrap.trap(this.windowEl);
+            screenReaderTrap.trap(this.windowEl, { useHiddenProperty });
             keyboardTrap.trap(this.windowEl);
         }
 

--- a/src/components/components/ebay-dialog-base/test/test.browser.js
+++ b/src/components/components/ebay-dialog-base/test/test.browser.js
@@ -240,3 +240,73 @@ describe('given an open dialog with no trap', () => {
         });
     });
 });
+
+describe('given a closed dialog with useHiddenProperty', () => {
+    const input = assign({}, mock.Fill_Dialog, { useHiddenProperty: true });
+    let sibling;
+
+    beforeEach(async() => {
+        sibling = document.body.appendChild(document.createElement('div'));
+        component = await render(template, input);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(sibling);
+    });
+
+    it('then it is hidden in the DOM', async() => {
+        await wait(() => expect(component.getByRole('dialog')).has.attr('hidden'));
+    });
+
+    it('then <body> is scrollable', () => {
+        expect(document.body).does.not.have.attr('style');
+    });
+
+    it('then it\'s siblings are visible', () => {
+        expect(sibling).does.not.have.attr('hidden');
+    });
+
+    it('then it does not trap focus', () => {
+        expect(component.getByRole('dialog').children[0]).does.not.have.class('keyboard-trap--active');
+    });
+
+    describe('when it is rerendered to be open', () => {
+        beforeEach(async() => {
+            await component.rerender(assign({}, input, { open: true }));
+        });
+
+        thenItIsOpen(true);
+    });
+
+    function thenItIsOpen(wasToggled) {
+        it('then it is visible in the DOM', async() => {
+            await wait(() => expect(component.getByRole('dialog')).does.not.have.attr('hidden'));
+        });
+
+        it('then <body> is not scrollable', () => {
+            expect(document.body).has.attr('style').contains('overflow:hidden');
+        });
+
+        it('then it\'s siblings are hidden', () => {
+            expect(sibling).has.attr('hidden');
+        });
+
+        if (wasToggled) {
+            it('then it traps focus', async() => {
+                await wait(() => {
+                    expect(component.getByRole('dialog').children[1]).has.class('keyboard-trap--active');
+                    expect(document.activeElement).has.class(component.getByLabelText(input.a11yCloseText).className);
+                });
+            });
+
+            it('then it emits the show event', async() => {
+                await wait(() => expect(component.emitted('modal-show')).has.length(1));
+            });
+
+            describe('when it is rerendered with the same input', () => {
+                beforeEach(async() => await component.rerender());
+                thenItIsOpen();
+            });
+        }
+    }
+});

--- a/src/components/components/ebay-dialog-base/test/test.browser.js
+++ b/src/components/components/ebay-dialog-base/test/test.browser.js
@@ -35,8 +35,8 @@ describe('given a closed dialog', () => {
         expect(document.body).does.not.have.attr('style');
     });
 
-    it('then it\'s siblings are visible', () => {
-        expect(sibling).does.not.have.attr('aria-hidden');
+    it('then it\'s siblings are visible', async() => {
+        await wait(() => expect(sibling).does.not.have.attr('aria-hidden'));
     });
 
     it('then it does not trap focus', () => {
@@ -60,8 +60,8 @@ describe('given a closed dialog', () => {
             expect(document.body).has.attr('style').contains('overflow:hidden');
         });
 
-        it('then it\'s siblings are hidden', () => {
-            expect(sibling).has.attr('aria-hidden', 'true');
+        it('then it\'s siblings are hidden', async() => {
+            await wait(() => expect(sibling).has.attr('aria-hidden', 'true'));
         });
 
         if (wasToggled) {
@@ -162,8 +162,8 @@ describe('given an open dialog', () => {
             expect(document.body).has.attr('style').contains('overflow:hidden');
         });
 
-        it('then it\'s siblings are hidden', () => {
-            expect(sibling).has.attr('aria-hidden', 'true');
+        it('then it\'s siblings are hidden', async() => {
+            await wait(() => expect(sibling).has.attr('aria-hidden', 'true'));
         });
 
         it('then it traps focus', async() => {
@@ -185,8 +185,8 @@ describe('given an open dialog', () => {
             });
         });
 
-        it('then it\'s siblings are visible', () => {
-            expect(sibling).does.not.have.attr('aria-hidden');
+        it('then it\'s siblings are visible', async() => {
+            await wait(() => expect(sibling).does.not.have.attr('aria-hidden'));
         });
 
         it('then it restores the previous focus', async() => {
@@ -229,8 +229,8 @@ describe('given an open dialog with no trap', () => {
         expect(document.body).does.not.have.attr('style');
     });
 
-    it('then it\'s siblings are not hidden', () => {
-        expect(sibling).does.not.have.attr('aria-hidden', 'true');
+    it('then it\'s siblings are not hidden', async() => {
+        await wait(() => expect(sibling).does.not.have.attr('aria-hidden'));
     });
 
     it('then it does not traps focus', async() => {
@@ -262,8 +262,8 @@ describe('given a closed dialog with useHiddenProperty', () => {
         expect(document.body).does.not.have.attr('style');
     });
 
-    it('then it\'s siblings are visible', () => {
-        expect(sibling).does.not.have.attr('hidden');
+    it('then it\'s siblings are visible', async() => {
+        await wait(() => expect(sibling).does.not.have.attr('hidden'));
     });
 
     it('then it does not trap focus', () => {
@@ -287,8 +287,8 @@ describe('given a closed dialog with useHiddenProperty', () => {
             expect(document.body).has.attr('style').contains('overflow:hidden');
         });
 
-        it('then it\'s siblings are hidden', () => {
-            expect(sibling).has.attr('hidden');
+        it('then it\'s siblings are hidden', async() => {
+            await wait(() => expect(sibling).has.attr('hidden'));
         });
 
         if (wasToggled) {

--- a/src/components/ebay-dialog/index.marko
+++ b/src/components/ebay-dialog/index.marko
@@ -8,6 +8,7 @@ $ var isDocked = input.type === "left" || input.type === "right";
     open=input.open
     classPrefix="dialog"
     button-position=(isCenter && "right")
+    use-hidden-property=isFull
     on-modal-show("emit", "dialog-show")
     on-modal-close("emit", "dialog-close")
     class=[


### PR DESCRIPTION


## Description
Added option of `useHiddenProperty`. (I had to set the default to false if null or undefined because it was failing due to the check being useHiddenProperty === false in makeup)
Added a test to check it is being set.
Set the attribute true for fullscreen dialog only

## References
#1229

## Screenshots
<img width="1919" alt="Screen Shot 2020-09-10 at 9 41 46 AM" src="https://user-images.githubusercontent.com/1755269/92765060-daf6f000-f349-11ea-938c-95d9dc3d13e3.png">

