### PR TITLE
Updated expand-button to have icon-only class when no renderbody

### DIFF
--- a/src/components/ebay-expand-button/README.md
+++ b/src/components/ebay-expand-button/README.md
@@ -11,5 +11,4 @@
 Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
 `size` | String | No | No | Can be "large". If not set, defaults to default
-`icon-only` | Boolean | No | No | used to adjust padding for "expand" variant without text
 `disabled` | Boolean | Yes | No |

--- a/src/components/ebay-expand-button/examples/1-expand-no-text/template.marko
+++ b/src/components/ebay-expand-button/examples/1-expand-no-text/template.marko
@@ -1,1 +1,1 @@
-<ebay-expand-button icon-only/>
+<ebay-expand-button/>

--- a/src/components/ebay-expand-button/index.marko
+++ b/src/components/ebay-expand-button/index.marko
@@ -7,7 +7,6 @@ static function toJSON() {
 }
 static var ignoredAttributes = [
     "size",
-    "iconOnly",
     "fluid",
     "truncate",
     "fixedHeight",
@@ -21,7 +20,7 @@ $ var size = input.size || "default";
     ...processHtmlAttributes(input, ignoredAttributes)
     class=[
         "expand-btn",
-        input.iconOnly && "expand-btn--icon-only",
+        !input.renderBody && "expand-btn--icon-only",
         input.fluid && "expand-btn--fluid",
         input.truncate && `expand-btn--${size}-truncated`,
         input.fixedHeight && `expand-btn--${size}-fixed-height`,

--- a/src/components/ebay-expand-button/marko-tag.json
+++ b/src/components/ebay-expand-button/marko-tag.json
@@ -7,7 +7,6 @@
   },
   "@html-attributes": "expression",
   "@size": "size",
-  "@icon-only": "boolean",
   "@fluid": "boolean",
   "@truncate": "boolean",
   "@fixed-height": "boolean",

--- a/src/components/ebay-expand-button/migrator.js
+++ b/src/components/ebay-expand-button/migrator.js
@@ -1,4 +1,3 @@
-const { setAttributeIfPresent } = require('../../common/migrators');
 
 /**
  * @description
@@ -6,7 +5,11 @@ const { setAttributeIfPresent } = require('../../common/migrators');
  */
 
 function migratorMarko4(el, context) {
-    setAttributeIfPresent(el, context, 'no-text', 'icon-only');
+    if (el.hasAttribute('no-text')) {
+        context.deprecate('no-text has been deprecated from expand-button. Instead just dont include any body content');
+        el.removeAttribute('no-text');
+    }
+
     return el;
 }
 

--- a/src/components/ebay-expand-button/test/mock/index.js
+++ b/src/components/ebay-expand-button/test/mock/index.js
@@ -4,6 +4,4 @@ exports.Basic = {
     renderBody: createRenderBody('Expand Button Text')
 };
 
-exports.No_Text = {
-    iconOnly: true
-};
+exports.No_Text = {};

--- a/src/components/ebay-expand-button/test/test.server.js
+++ b/src/components/ebay-expand-button/test/test.server.js
@@ -1,9 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const {
-    testPassThroughAttributes,
-    testAttributeRenameMigrator
-} = require('../../../common/test-utils/server');
+const { testPassThroughAttributes } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -26,5 +23,3 @@ describe('expand-button', () => {
 
     testPassThroughAttributes(template);
 });
-
-testAttributeRenameMigrator(require('../migrator'), 'expand-button', 'no-text', 'icon-only', '../index.marko');


### PR DESCRIPTION
## Description
Changed the icon-only attribute to not exist anymore. Changed it to apply the icon-only class when there is no renderbody