### PR TITLE
Added a check to apply all traps on rerender

### DIFF
--- a/src/components/components/ebay-dialog-base/component.js
+++ b/src/components/components/ebay-dialog-base/component.js
@@ -111,7 +111,7 @@ module.exports = {
 
         return () => {
             if (willTrap) {
-                screenReaderTrap.trap(this.windowEl, { useHiddenProperty });
+                screenReaderTrap.trap(this.el, { useHiddenProperty });
                 keyboardTrap.trap(this.windowEl);
             }
         };
@@ -194,6 +194,9 @@ module.exports = {
                     this.rootEl.setAttribute('hidden', '');
                 }
             }
+        } else if (restoreTrap) {
+            // In the case where the page rerendered, attach all traps again
+            runTraps();
         }
     },
 
@@ -204,7 +207,7 @@ module.exports = {
     _release() {
         if (this.isTrapped) {
             this.restoreTrap = this.state.open;
-            screenReaderTrap.untrap(this.windowEl);
+            screenReaderTrap.untrap(this.el);
             keyboardTrap.untrap(this.windowEl);
         } else {
             this.restoreTrap = false;


### PR DESCRIPTION
## Description
On update when the dom is rerenderd, destroy is called but on update the traps are not being applied again. This causes the dialog to exist in a partially opened state but not visible.
Added a check if the traps need to be reattached to reattach them.
Also added the screenreader trap to attach to `this.el`
