### PR TITLE
ebay-paginaton: added variant to allow users to force links or buttons

### DIFF
--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -46,6 +46,8 @@ Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
 `disabled` | Boolean | No | No | Previous/next button is disabled or not
 `href` | String | No | No | for link that looks like a menu-item; omitting the href will switch to a button
+`href` | String | No | No | for link that looks like a menu-item; omitting the href will switch to a button
+`variant` | String | No | No | "button" or "link". Will force an item to be a link if href is omitted. Defaults to button. If not specified, tag type will still be controlled by `href`
 `current` | Boolean | No | No | the current page
 `type` | String | No | No | "previous", "next" or "page"(default). To specify if the information entered is for the previous or next arrrow button or a page. If the `type='previous|next'` isn't provided the previous/next arrow buttons will be taken as `disabled`
 

--- a/src/components/ebay-pagination/component.js
+++ b/src/components/ebay-pagination/component.js
@@ -48,6 +48,13 @@ module.exports = {
             .on('resize', this._calculateMaxItems.bind(this));
     },
 
+    getItemTag(item) {
+        if (item.variant) {
+            return item.variant === 'link' ? 'a' : 'button';
+        }
+        return !!item.href ? 'a' : 'button';
+    },
+
     /**
      * Calculates the start and end offsets given the current maximum items
      * that can be displayed.

--- a/src/components/ebay-pagination/index.marko
+++ b/src/components/ebay-pagination/index.marko
@@ -38,7 +38,7 @@ $ var range = component._getVisibleRange(items);
         </h2>
     </span>
 
-    <${prevItem.href ? "a" : "button"}
+    <${component.getItemTag(prevItem)}
         ...processHtmlAttributes(prevItem, ignoredItemAttributes)
         class=["pagination__previous", prevItem.class]
         aria-disabled=(prevItem.disabled && "true")
@@ -53,7 +53,7 @@ $ var range = component._getVisibleRange(items);
         class="pagination__items">
         <for|item, i| of=items>
             <li hidden=(i < range.start || i > range.end)>
-                <${item.href ? "a" : "button"}
+                <${component.getItemTag(item)}
                     ...processHtmlAttributes(item, ignoredItemAttributes)
                     class=["pagination__item", item.class]
                     aria-current=(item.current && "page")
@@ -64,7 +64,7 @@ $ var range = component._getVisibleRange(items);
         </for>
     </ol>
 
-    <${nextItem.href ? "a" : "button"}
+    <${component.getItemTag(nextItem)}
         ...processHtmlAttributes(nextItem, ignoredItemAttributes)
         class=["pagination__next", nextItem.class]
         aria-disabled=(nextItem.disabled && "true")

--- a/src/components/ebay-pagination/test/mock/index.js
+++ b/src/components/ebay-pagination/test/mock/index.js
@@ -12,7 +12,7 @@ exports.Links_6Items_No_Selected = assign({}, exports.Base_0Items, {
     items: [].concat(
         {
             type: 'previous',
-            href: '#previous'
+            href: '#next'
         },
         getNItems(6, i => ({
             href: `#${i}`,
@@ -83,7 +83,7 @@ exports.Links_1Items_Navigation_Disabled = assign({}, exports.Base_0Items, {
     items: [
         {
             type: 'previous',
-            href: '#previous',
+            variant: 'link',
             disabled: true
         },
         {
@@ -110,7 +110,8 @@ exports.Links_1Items_No_Navigation = assign({}, exports.Base_0Items, {
 exports.Buttons_0Selected = assign({}, exports.Base_0Items, {
     items: [].concat(
         {
-            type: 'previous'
+            type: 'previous',
+            variant: 'button'
         },
         getNItems(6, i => ({
             current: i === 0,

--- a/src/components/ebay-pagination/test/test.server.js
+++ b/src/components/ebay-pagination/test/test.server.js
@@ -53,7 +53,9 @@ describe('pagination', () => {
         it('renders with aria-disabled when navigation is disabled', async() => {
             const input = mock.Links_1Items_Navigation_Disabled;
             const { getByLabelText } = await render(template, input);
+            expect(getByLabelText(input.a11yPreviousText)).has.property('tagName', 'A');
             expect(getByLabelText(input.a11yPreviousText)).has.attr('aria-disabled', 'true');
+            expect(getByLabelText(input.a11yNextText)).has.property('tagName', 'A');
             expect(getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
         });
 


### PR DESCRIPTION
## Description
Initial issue found when removing `href` for links, the link turns into a button. Added a `variant` (since type is taken) to pagination to allow it to force links or buttons. 

## References
#1265
