### PR TITLE
Added original event to tourtip collapse event

### DIFF
--- a/src/components/ebay-tourtip/component-browser.js
+++ b/src/components/ebay-tourtip/component-browser.js
@@ -1,9 +1,9 @@
 
 module.exports = {
-    handleCollapse() {
+    handleCollapse(originalEvent) {
         if (this._expander.isExpanded()) {
             this._expander.collapse();
-            this.emit('tooltip-collapse');
+            this.emit('tooltip-collapse', { originalEvent });
         }
     },
 


### PR DESCRIPTION
## Description
Added passthrough original event for tourtip close.

## Context
This is needed because the original page uses tourtip on a component. When it is clicked it also triggers a click event on the parent element which in turn opens a side panel. This is needed to prevent that side panel opening.

## References
#1275 

