### PR TITLE
Added legacy floating label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17474,9 +17474,9 @@
       }
     },
     "makeup-floating-label": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.0.6.tgz",
-      "integrity": "sha512-mT6MbSCFblV2M55u9GM8tGj30SQc/kHJs+3U6SjNnI7rKxDhQfrE2vSrUsk/6ImfVkiDdhFnM5/QH7YtkhhwYg=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.1.2.tgz",
+      "integrity": "sha512-ovSdC2/ETVIskmy02B/XTR2VsrNCeJgCuHPc/Rmmp/PJNe4mmP3gY3QxcnVAjnhn/4fQUyaPvUbUqGpDMSVggg=="
     },
     "makeup-focusables": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "core-js-pure": "^3.4.1",
     "makeup-active-descendant": "0.3.9",
     "makeup-expander": "~0.8.6",
-    "makeup-floating-label": "~0.0.6",
+    "makeup-floating-label": "~0.1.2",
     "makeup-focusables": "~0.1.0",
     "makeup-key-emitter": "~0.1.3",
     "makeup-keyboard-trap": "~0.2.4",

--- a/src/components/ebay-legacy-floating-textbox/README.md
+++ b/src/components/ebay-legacy-floating-textbox/README.md
@@ -1,14 +1,15 @@
-# ebay-textbox
+# ebay-legacy-floating-textbox
 
-## ebay-textbox Usage
+## ebay-legacy-floating-textbox Usage
 
-Default input textbox:
+This is used to show the legacy version of the `ebay-textbox` with underline and floating label.
+This component **deprecated** and will be removed in the near future.
 
 ```marko
 <ebay-legacy-floating-textbox />
 ```
 
-## ebay-textbox Attributes
+## ebay-legacy-floating-textbox Attributes
 
 Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
@@ -16,7 +17,7 @@ Name | Type | Stateful | Required | Description
 `fluid` | Boolean | No | No |
 `invalid` | Boolean | No | No | indicates a field-level error with red border if true
 
-## ebay-textbox Events
+## ebay-legacy-floating-textbox Events
 
 Event | Data | Description
 --- | --- | ---

--- a/src/components/ebay-legacy-floating-textbox/README.md
+++ b/src/components/ebay-legacy-floating-textbox/README.md
@@ -1,0 +1,31 @@
+# ebay-textbox
+
+## ebay-textbox Usage
+
+Default input textbox:
+
+```marko
+<ebay-legacy-floating-textbox />
+```
+
+## ebay-textbox Attributes
+
+Name | Type | Stateful | Required | Description
+--- | --- | --- | --- | ---
+`floating-label` | String | No | Yes | The label part of the floating label
+`fluid` | Boolean | No | No |
+`invalid` | Boolean | No | No | indicates a field-level error with red border if true
+
+## ebay-textbox Events
+
+Event | Data | Description
+--- | --- | ---
+`change` | `{ originalEvent, value }` |
+`input-change` | `{ originalEvent, value }` |
+`focus` | `{ originalEvent, value }` |
+`blur` | `{ originalEvent, value }` |
+`keydown` | `{ originalEvent, value }` |
+`keypress` | `{ originalEvent, value }` |
+`keyup` | `{ originalEvent, value }` |
+`floating-label-init` | `{ originalEvent: null, value: null }` |
+`button-click` | `{ originalEvent, value }` | Triggers when clicking on postfix-icon-button. Requires button-aria-label to be present in order to attach correctly

--- a/src/components/ebay-legacy-floating-textbox/browser.json
+++ b/src/components/ebay-legacy-floating-textbox/browser.json
@@ -1,0 +1,7 @@
+{
+    "requireRemap": [{
+        "from": "./style.js",
+        "to": "../../common/empty.js",
+        "if-flag": "ebayui-no-skin"
+    }]
+}

--- a/src/components/ebay-legacy-floating-textbox/component-browser.js
+++ b/src/components/ebay-legacy-floating-textbox/component-browser.js
@@ -1,0 +1,58 @@
+const FloatingLabel = require('makeup-floating-label');
+
+module.exports = {
+    handleFloatingLabelInit: forwardEvent('floating-label-init'),
+    handleKeydown: forwardEvent('keydown'),
+    handleKeypress: forwardEvent('keypress'),
+    handleKeyup: forwardEvent('keyup'),
+    handleChange: forwardEvent('change'),
+    handleInput: forwardEvent('input-change'),
+    handleFocus: forwardEvent('focus'),
+    handleBlur: forwardEvent('blur'),
+    handleButtonClick: forwardEvent('button-click'),
+
+    onMount() {
+        this._setupMakeup();
+    },
+
+    onUpdate() {
+        this._setupMakeup();
+    },
+
+    focus() {
+        this.getEl('input').focus();
+    },
+
+    _setupMakeup() {
+        // TODO: makeup-floating-label should be updated so that we can remove the event listeners.
+        // It probably makes more sense to just move this functionality into Marko though.
+        if (this.input.floatingLabel) {
+            if (this._floatingLabel) {
+                this._floatingLabel.refresh();
+                this.handleFloatingLabelInit();
+            } else if (document.readyState === 'complete') {
+                if (this.el) {
+                    this._floatingLabel = new FloatingLabel(this.el, {
+                        labelElementInlineModifier: 'legacy-floating-label__label--inline',
+                        labelElementDisabledModifier: 'legacy-floating-label__label--disabled',
+                        labelElementAnimateModifier: 'legacy-floating-label__label--animate'
+                    });
+                    this.handleFloatingLabelInit();
+                }
+            } else {
+                this
+                    .subscribeTo(window)
+                    .once('load', this._setupMakeup.bind(this));
+            }
+        }
+    }
+};
+
+function forwardEvent(eventName) {
+    return function(originalEvent, el) {
+        this.emit(eventName, {
+            originalEvent,
+            value: (el || this.el.querySelector('input, textarea')).value
+        });
+    };
+}

--- a/src/components/ebay-legacy-floating-textbox/index.marko
+++ b/src/components/ebay-legacy-floating-textbox/index.marko
@@ -23,13 +23,13 @@ $ var hasIcon = (input.prefixIcon || isPostfix);
 $ var displayIcon = Boolean(!input.multiline && hasIcon);
 $ var id = input.id || component.getElId("textbox");
 $ var defaultTag = input.fluid ? "div" : "span";
-<${input.floatingLabel && defaultTag} class="floating-label">
+<${input.floatingLabel && defaultTag} class="legacy-floating-label">
     <if(input.floatingLabel)>
         <label
             for=id
             class=[
-                "floating-label__label",
-                input.disabled && "floating-label__label--disabled"
+                "legacy-floating-label__label",
+                input.disabled && "legacy-floating-label__label--disabled"
             ]>
             ${input.floatingLabel}
         </label>
@@ -51,6 +51,7 @@ $ var defaultTag = input.fluid ? "div" : "span";
             class=[
                 "textbox__control",
                 input.fluid && "textbox__control--fluid",
+                input.floatingLabel && "legacy-textbox-underline"
             ]
             type=(!input.multiline && (input.type || "text"))
             value=(!input.multiline && input.value)

--- a/src/components/ebay-legacy-floating-textbox/marko-tag.json
+++ b/src/components/ebay-legacy-floating-textbox/marko-tag.json
@@ -1,0 +1,56 @@
+{
+  "template": "./index.marko",
+  "attribute-groups": [
+    "html-attributes"
+  ],
+  "@*": {
+    "targetProperty": null,
+    "type": "expression"
+  },
+  "@html-attributes": "expression",
+  "@type": {
+    "enum": [
+      "text",
+      "password"
+    ]
+  },
+  "@invalid": "boolean",
+  "@fluid": "boolean",
+  "@floating-label": "string",
+  "@postfix-icon <postfix-icon>": {
+    "attribute-groups": [
+      "html-attributes"
+    ],
+    "@*": {
+      "targetProperty": null,
+      "type": "expression"
+    },
+    "@html-attributes": "expression"
+  },
+  "@prefix-icon <prefix-icon>": {
+    "attribute-groups": [
+      "html-attributes"
+    ],
+    "@*": {
+      "targetProperty": null,
+      "type": "expression"
+    },
+    "@html-attributes": "expression"
+  },
+  "@button-aria-label": "string",
+  "@autocomplete": "#html-autocomplete",
+  "@autofocus": "#html-autofocus",
+  "@dirname": "#html-dirname",
+  "@disabled": "#html-disabled",
+  "@form": "#html-form",
+  "@maxlength": "#html-maxlength",
+  "@minlength": "#html-minlength",
+  "@name": "#html-name",
+  "@pattern": "#html-pattern",
+  "@placeholder": "#html-placeholder",
+  "@readonly": "#html-readonly",
+  "@required": "#html-required",
+  "@size": "#html-size",
+  "@value": "#html-value",
+  "@aria-invalid": "never"
+}

--- a/src/components/ebay-legacy-floating-textbox/style.js
+++ b/src/components/ebay-legacy-floating-textbox/style.js
@@ -1,0 +1,2 @@
+require('@ebay/skin/textbox');
+require('@ebay/skin/legacy-textbox');

--- a/src/components/ebay-legacy-floating-textbox/test/mock/index.js
+++ b/src/components/ebay-legacy-floating-textbox/test/mock/index.js
@@ -1,0 +1,62 @@
+const assign = require('core-js-pure/features/object/assign');
+const { createRenderBody } = require('../../../../common/test-utils/shared');
+const iconBody = {
+    renderBody: createRenderBody(
+        '<svg class="icon" focusable="false" id="w11-w0" ' +
+        'aria-hidden="true"> <defs id="w11-w0-defs"></defs><use ' +
+        'xlink:href="#icon-profile"></use></svg>',
+        ''
+    )
+};
+
+exports.Basic = {
+    value: 'textbox value'
+};
+
+exports.Basic_With_ID = assign({}, exports.Basic, {
+    id: 'textbox-id'
+});
+
+exports.Fluid = assign({}, exports.Basic, {
+    fluid: true
+});
+
+exports.Disabled = assign({}, exports.Basic, {
+    disabled: true
+});
+
+exports.Invalid = assign({}, exports.Basic, {
+    invalid: true
+});
+
+exports.Multiline = assign({}, exports.Basic, {
+    multiline: true
+});
+
+exports.Prefix_Icon = assign({}, exports.Basic, {
+    prefixIcon: iconBody
+});
+
+exports.Postfix_Icon = assign({}, exports.Basic, {
+    postfixIcon: iconBody
+});
+
+exports.Postfix_Icon_Button = assign({}, exports.Postfix_Icon, {
+    buttonAriaLabel: 'search button'
+});
+
+exports.Floating_Label = assign({}, exports.Basic, {
+    floatingLabel: 'Email address'
+});
+
+exports.Floating_Label_No_Value = assign({}, exports.Floating_Label, {
+    value: undefined
+});
+
+exports.Floating_Label_With_ID = assign({}, exports.Floating_Label, {
+    id: 'textbox-id'
+});
+
+exports.Floating_Label_Disabled = assign({}, exports.Floating_Label, {
+    disabled: true
+});

--- a/src/components/ebay-legacy-floating-textbox/test/test.browser.js
+++ b/src/components/ebay-legacy-floating-textbox/test/test.browser.js
@@ -1,0 +1,102 @@
+const { expect, use } = require('chai');
+const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const { getComponentForEl } = require('marko/components');
+const template = require('..');
+const mock = require('./mock');
+
+require('../component-browser').renderer = template._; // Allow re-rendering the split component for testing.
+use(require('chai-dom'));
+afterEach(cleanup);
+
+/** @type import("@marko/testing-library").RenderResult */
+let component;
+
+describe('given an input textbox', () => {
+    const input = mock.Basic;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+    });
+
+    ['change', 'input', 'focus', 'blur', 'keyDown', 'keyPress', 'keyUp'].forEach(eventName => {
+        describe(`when native event is fired: ${eventName}`, () => {
+            beforeEach(async() => {
+                await fireEvent[eventName](component.getByRole('textbox'));
+            });
+
+            it('then it emits the event', () => {
+                const events = component.emitted(eventName === 'input' ? 'input-change' : eventName.toLowerCase());
+                expect(events).has.length(1);
+
+                const [[eventArg]] = events;
+                expect(eventArg).has.property('value', input.value);
+                expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+            });
+        });
+    });
+
+    it('focuses element on focus call', () => {
+        getComponentForEl(component.container.firstElementChild).focus();
+        expect(document.activeElement).to.equal(component.getByRole('textbox'));
+    });
+});
+
+describe('given an input textbox with floating label and no value', () => {
+    const input = mock.Floating_Label_No_Value;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+    });
+
+    it('then component is wrapped into floating label element', () => {
+        expect(component.container.firstElementChild).has.class('legacy-floating-label');
+    });
+
+    it('then is showing the label inline', () => {
+        expect(component.getByText(input.floatingLabel)).has.class('legacy-floating-label__label--inline');
+    });
+
+    describe('when the input is focused', () => {
+        beforeEach(async() => {
+            await fireEvent.focus(component.getByRole('textbox'));
+        });
+
+        it('then it is not showing the label inline', () => {
+            expect(component.getByText(input.floatingLabel))
+                .does.not.have.class('legacy-floating-label__label--inline');
+        });
+
+        describe('when the input is blurred', () => {
+            beforeEach(async() => {
+                await fireEvent.blur(component.getByRole('textbox'));
+            });
+
+            it('then is showing the label inline', () => {
+                expect(component.getByText(input.floatingLabel)).has.class('legacy-floating-label__label--inline');
+            });
+        });
+    });
+
+    describe('when the component is updated/re-rendered', () => {
+        beforeEach(async() => {
+            await component.rerender();
+        });
+
+        it('it should send a textbox floating label init event', () => {
+            expect(component.emitted('floating-label-init')).has.length(1);
+        });
+    });
+});
+
+describe('when the component has a postfix button', () => {
+    const input = mock.Postfix_Icon_Button;
+
+    beforeEach(async() => {
+        component = await render(template, input);
+        await fireEvent.click(component.getByLabelText(input.buttonAriaLabel));
+    });
+
+    it('it should trigger a postfix click event', () => {
+        expect(component.emitted('button-click')).has.length(1);
+    });
+});

--- a/src/components/ebay-legacy-floating-textbox/test/test.server.js
+++ b/src/components/ebay-legacy-floating-textbox/test/test.server.js
@@ -1,0 +1,104 @@
+const { expect, use } = require('chai');
+const { render } = require('@marko/testing-library');
+const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+const template = require('..');
+const mock = require('./mock');
+
+use(require('chai-dom'));
+
+describe('ebay-textbox', () => {
+    it('renders default input textbox', async() => {
+        const input = mock.Basic;
+        const { getByRole } = await render(template, input);
+        const textboxEl = getByRole('textbox');
+        expect(textboxEl).has.value(input.value);
+        expect(textboxEl).has.class('textbox__control');
+        expect(textboxEl).has.property('tagName', 'INPUT');
+        expect(textboxEl)
+            .has.property('parentElement')
+            .with.class('textbox');
+    });
+
+    it('renders default input textbox with an id', async() => {
+        const input = mock.Basic_With_ID;
+        const { getByRole } = await render(template, input);
+        expect(getByRole('textbox')).contains.id(input.id);
+    });
+
+    it('renders fluid input textbox', async() => {
+        const input = mock.Fluid;
+        const { getByRole } = await render(template, input);
+        expect(getByRole('textbox')).has.class('textbox__control--fluid');
+    });
+
+    it('renders a disabled input textbox', async() => {
+        const input = mock.Disabled;
+        const { getByRole } = await render(template, input);
+        expect(getByRole('textbox')).has.property('disabled', true);
+    });
+
+    it('renders a input textbox with invalid/error state', async() => {
+        const input = mock.Invalid;
+        const { getByRole } = await render(template, input);
+        expect(getByRole('textbox')).has.attr('aria-invalid', 'true');
+    });
+
+    it('renders a textarea element', async() => {
+        const input = mock.Multiline;
+        const { getByRole } = await render(template, input);
+        const textboxEl = getByRole('textbox');
+        expect(textboxEl).has.property('tagName', 'TEXTAREA');
+        expect(textboxEl).has.text(input.value);
+        expect(textboxEl).has.value(input.value);
+    });
+
+    it('renders a textarea element with prefix icon', async() => {
+        const input = mock.Prefix_Icon;
+        const { getByRole } = await render(template, input);
+        expect(getByRole('textbox'))
+            .has.property('previousElementSibling')
+            .with.class('icon');
+    });
+
+    it('renders a textarea element with postfix icon', async() => {
+        const input = mock.Postfix_Icon;
+        const { getByRole } = await render(template, input);
+        expect(getByRole('textbox'))
+            .has.property('nextElementSibling')
+            .with.class('icon');
+    });
+
+    it('renders a textarea element with postfix icon button', async() => {
+        const input = mock.Postfix_Icon_Button;
+        const { getByLabelText } = await render(template, input);
+        expect(getByLabelText('search button'))
+            .has.class('icon-btn');
+        expect(getByLabelText('search button').firstElementChild)
+            .has.class('icon');
+    });
+
+    it('renders an input textbox with inline floating label', async() => {
+        const input = mock.Floating_Label;
+        const { getByRole, getByLabelText, getByText } = await render(template, input);
+        expect(getByRole('textbox')).to.equal(getByLabelText(input.floatingLabel));
+        expect(getByText(input.floatingLabel)).has.class('legacy-floating-label__label');
+    });
+
+    it('renders an input textbox with inline floating label and an id', async() => {
+        const input = mock.Floating_Label_With_ID;
+        const { getByLabelText } = await render(template, input);
+        expect(getByLabelText(input.floatingLabel)).has.id(input.id);
+    });
+
+    it('renders a disabled input textbox with disabled floating label', async() => {
+        const input = mock.Floating_Label_Disabled;
+        const { getByText } = await render(template, input);
+        expect(getByText(input.floatingLabel)).has.class('legacy-floating-label__label--disabled');
+    });
+
+    testPassThroughAttributes(template, {
+        getClassAndStyleEl(component) {
+            return component.getByRole('textbox').parentElement;
+        }
+    });
+});


### PR DESCRIPTION
## Description
Added ebay-legacy-floating-textbox which should use the old floating label syntax and underline.

## References
#1273

## Screenshots
<img width="310" alt="Screen Shot 2020-12-09 at 3 28 09 PM" src="https://user-images.githubusercontent.com/1755269/101706656-7299d680-3a3e-11eb-94e1-f40a9dfa89cc.png">

<img width="645" alt="Screen Shot 2020-12-09 at 3 27 57 PM" src="https://user-images.githubusercontent.com/1755269/101706707-8a715a80-3a3e-11eb-9c3d-bb65fd296e58.png">
