### PR TITLE
1295 pagination interactive story state

### DIFF
--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -29,7 +29,7 @@ Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
 `a11y-previous-text` | String | No | Yes | a11y text for previous arrow button
 `a11y-next-text` | String | No | Yes | a11y text for next arrow button
-`a11y-current-text` | String | No | Yes | Description for the current page (e.g. Results of Page 1)
+`a11y-current-text` | String | Yes | Yes | Description for the current page (e.g. Results of Page 1)
 
 ### ebay-pagination Events
 

--- a/src/components/ebay-pagination/examples/06-buttons-interactive/template.marko
+++ b/src/components/ebay-pagination/examples/06-buttons-interactive/template.marko
@@ -18,7 +18,8 @@ class {
 <ebay-pagination
     on-next("handleNext")
     on-previous("handlePrev")
-    on-select("handleSelect")>
+    on-select("handleSelect")
+    a11y-current-text=`Results Pagination - Page ${state.current}`>
     <@item type="previous" disabled=(state.current === 0)/>
     <for|i| from=0 to=SIZE>
         <@item current=(i === state.current)>${i}</@item>


### PR DESCRIPTION
## Description
Added a11y-current-text to the ebay-pagination component in the interactive buttons example. 
Closes #1295.


## Screenshots
![Screen Shot 2021-01-12 at 3 27 35 PM](https://user-images.githubusercontent.com/25092249/104387594-503b2300-54ec-11eb-8c22-604e4a93c2dc.png)
![Screen Shot 2021-01-12 at 3 27 40 PM](https://user-images.githubusercontent.com/25092249/104387596-516c5000-54ec-11eb-9869-59abe0f68a88.png)

