### PR TITLE
Added truncated listbox button option

### DIFF
--- a/src/components/ebay-listbox-button/README.md
+++ b/src/components/ebay-listbox-button/README.md
@@ -42,6 +42,7 @@ Name | Type | Stateful | Required | Description
 `borderless` | Boolean | No | No | whether button has borders
 `fluid` | Boolean | No | No | whether listbox width is 100%
 `buttonName` | String | No | Yes | used for the `name` attribute of the native `<button>`
+`truncate` | Boolean | No | No | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows
 
 **Note:** For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 

--- a/src/components/ebay-listbox-button/examples/08-truncated/template.marko
+++ b/src/components/ebay-listbox-button/examples/08-truncated/template.marko
@@ -1,5 +1,5 @@
 <div style="max-width: 200px">
-    <ebay-listbox-button name="formFieldName" truncate>
+    <ebay-listbox-button name="formFieldName" truncate fluid>
         <@option
             value="1"
             text="Option with a lot of large text that would overflow to next line 1"/>

--- a/src/components/ebay-listbox-button/examples/08-truncated/template.marko
+++ b/src/components/ebay-listbox-button/examples/08-truncated/template.marko
@@ -1,0 +1,9 @@
+<div style="max-width: 200px">
+    <ebay-listbox-button name="formFieldName" truncate>
+        <@option
+            value="1"
+            text="Option with a lot of large text that would overflow to next line 1"/>
+        <@option value="2" text="Option 2"/>
+        <@option value="3" text="Option 3"/>
+    </ebay-listbox-button>
+</div>

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -8,13 +8,14 @@ static var ignoredAttributes = [
     "fluid",
     "invalid",
     "buttonName",
-    "options"
+    "options",
+    "truncate"
 ];
 
 $ var selectedOption = input.options[state.selectedIndex];
 $ var selectedText = selectedOption && selectedOption.text;
 
-<span
+<${input.truncate ? "div" : "span"}
     ...processHtmlAttributes(input, ignoredAttributes)
     key="container"
     class=["listbox-button", input.class, input.fluid && "listbox-button--fluid"]
@@ -26,7 +27,8 @@ $ var selectedText = selectedOption && selectedOption.text;
             "listbox-button__control",
             "expand-btn",
             "expand-btn--regular",
-            input.borderless && "expand-btn--borderless"
+            input.borderless && "expand-btn--borderless",
+            input.truncate && "expand-btn--truncated"
         ]
         value=selectedText
         type="button"
@@ -49,4 +51,4 @@ $ var selectedText = selectedOption && selectedOption.text;
             <@option ...option selected=(selectedOption === option) />
         </for>
     </ebay-listbox>
-</span>
+</>

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -15,7 +15,7 @@ static var ignoredAttributes = [
 $ var selectedOption = input.options[state.selectedIndex];
 $ var selectedText = selectedOption && selectedOption.text;
 
-<${input.truncate ? "div" : "span"}
+<${input.truncate && !input.fluid ? "div" : "span"}
     ...processHtmlAttributes(input, ignoredAttributes)
     key="container"
     class=["listbox-button", input.class, input.fluid && "listbox-button--fluid"]

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -10,6 +10,7 @@
   "@borderless": "boolean",
   "@fluid": "boolean",
   "@invalid": "boolean",
+  "@truncate": "boolean",
   "@name": "#html-name",
   "@button-name": "#html-name",
   "@disabled": "#html-disabled",

--- a/src/components/ebay-listbox-button/test/mock/index.js
+++ b/src/components/ebay-listbox-button/test/mock/index.js
@@ -15,6 +15,15 @@ exports.Basic_3Options_fluid = {
     }))
 };
 
+exports.Basic_3Options_truncated = {
+    name: 'listbox-name',
+    truncate: true,
+    options: getNItems(3, i => ({
+        value: String(i),
+        text: `option ${i}`
+    }))
+};
+
 exports.Basic_3Options = {
     name: 'listbox-name',
     buttonName: 'listbox-button-name',

--- a/src/components/ebay-listbox-button/test/test.server.js
+++ b/src/components/ebay-listbox-button/test/test.server.js
@@ -46,6 +46,14 @@ describe('listbox', () => {
         expect(getAllByRole('listbox')[0].parentNode).has.class('listbox-button--fluid');
     });
 
+    it('renders truncated layout', async() => {
+        const input = mock.Basic_3Options_truncated;
+        const { getAllByRole, getByRole } = await render(template, input);
+        expect(getAllByRole('button')).has.length(1);
+        expect(getByRole('button')).has.class('expand-btn--truncated');
+        expect(getAllByRole('listbox')[0].parentNode).has.tagName('DIV');
+    });
+
     it('renders with second item selected', async() => {
         const input = mock.Basic_3Options_1Selected;
         const { getAllByRole } = await render(template, input);


### PR DESCRIPTION
## Description
Added option to truncate. This is the same as the `ebay-button` one.
Also added example and test.
I had to made the listbox button to be a `div` instead of a `span` otherwise it would not truncate.

## References
#1301 


## Screenshots
<img width="575" alt="Screen Shot 2021-01-20 at 2 23 00 PM" src="https://user-images.githubusercontent.com/1755269/105248333-10e38680-5b2b-11eb-8fb5-4094d0d1e267.png">
