### PR TITLE
Fixed check on fake-button to check for button before adding any type

### DIFF
--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -66,7 +66,7 @@ $ {
             `${baseClass}--${priority}`
     ]
     data-ebayui=true
-    type=((tag === "button" && input.type) || "button")
+    type=(tag === "button" && (input.type || "button"))
     aria-disabled=(input.partiallyDisabled && "true")>
     $ var hasAriaLabel = Boolean(htmlAttributes["aria-label"]);
     <${!hasAriaLabel ? null : "span"} aria-hidden="true">


### PR DESCRIPTION
## Description
Switched check for button `type` attribute to check for button before adding any default type.

## References
#1314 

## Screenshots
<img width="607" alt="Screen Shot 2021-01-26 at 3 09 01 PM" src="https://user-images.githubusercontent.com/1755269/105918697-32d87f80-5fe9-11eb-9e8b-365fe70c7ae3.png">
