### PR TITLE
Added option to show dots on pagination module

### DIFF
--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -31,7 +31,6 @@ Name | Type | Stateful | Required | Description
 `a11y-next-text` | String | No | Yes | a11y text for next arrow button
 `a11y-current-text` | String | Yes | Yes | Description for the current page (e.g. Results of Page 1)
 `variant` | String | No | Yes | Either `show-last`, or `show-range`. If `show-last` then will show the last page always and will put `…` between the last visible range and the last page. `…` and the last page will take up two items in the range. `…` will be hidden when the range to the last item is fully visible.
-`a11y-dots-text` | String | No | Yes | a11y text for dots. Only required when `variant` is `show-last`
 
 ### ebay-pagination Events
 

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -30,6 +30,8 @@ Name | Type | Stateful | Required | Description
 `a11y-previous-text` | String | No | Yes | a11y text for previous arrow button
 `a11y-next-text` | String | No | Yes | a11y text for next arrow button
 `a11y-current-text` | String | Yes | Yes | Description for the current page (e.g. Results of Page 1)
+`variant` | String | No | Yes | Either `show-last`, or `show-range`. If `show-last` then will show the last page always and will put `…` between the last visible range and the last page. `…` and the last page will take up two items in the range. `…` will be hidden when the range to the last item is fully visible.
+`a11y-dots-text` | String | No | Yes | a11y text for dots. Only required when `variant` is `show-last`
 
 ### ebay-pagination Events
 
@@ -38,6 +40,7 @@ Event | Data | Description
 `previous` | `{ originalEvent, el }`| clicked previous arrow button
 `next` | `{ originalEvent, el }` | clicked next arrow button
 `select` | `{ originalEvent, el, value }` | page selected clicked
+`dots-click` | `{ originalEvent, el }` | when dots are clicked in `variant="show-last"`
 
 ## @item Tag
 

--- a/src/components/ebay-pagination/README.md
+++ b/src/components/ebay-pagination/README.md
@@ -40,7 +40,6 @@ Event | Data | Description
 `previous` | `{ originalEvent, el }`| clicked previous arrow button
 `next` | `{ originalEvent, el }` | clicked next arrow button
 `select` | `{ originalEvent, el, value }` | page selected clicked
-`dots-click` | `{ originalEvent, el }` | when dots are clicked in `variant="show-last"`
 
 ## @item Tag
 

--- a/src/components/ebay-pagination/component.js
+++ b/src/components/ebay-pagination/component.js
@@ -34,6 +34,13 @@ module.exports = {
         }
     },
 
+    handleDotsClick(originalEvent, el) {
+        this.emit('dots-click', {
+            el,
+            originalEvent
+        });
+    },
+
     onCreate() {
         this.state = { maxItems: 0 };
     },
@@ -56,12 +63,16 @@ module.exports = {
      * that can be displayed.
      */
     _getVisibleRange(items) {
-        const { state } = this;
+        const { state, input } = this;
         const { maxItems } = state;
+        const { variant } = input;
+        const hasDots = variant === 'show-last';
         const lastIndex = items.length - 1;
+        const dotsIndex = hasDots ? lastIndex : -1;
+        let hideDots = false;
 
         if (!maxItems) {
-            return { start: 0, end: lastIndex };
+            return { start: 0, end: lastIndex, hideDots: true, dotsIndex };
         }
 
         const i = findIndex(items, item => item.current);
@@ -79,7 +90,18 @@ module.exports = {
             start++;
         }
 
-        return { start, end };
+        if (hasDots) {
+            if (i + range >= lastIndex) {
+                hideDots = true;
+            } else if (i <= end - 2) {
+                end -= 2;
+            } else {
+                start += 1;
+                end -= 1;
+            }
+        }
+
+        return { start, end, hideDots, dotsIndex };
     },
 
     _calculateMaxItems() {

--- a/src/components/ebay-pagination/component.js
+++ b/src/components/ebay-pagination/component.js
@@ -34,13 +34,6 @@ module.exports = {
         }
     },
 
-    handleDotsClick(originalEvent, el) {
-        this.emit('dots-click', {
-            el,
-            originalEvent
-        });
-    },
-
     onCreate() {
         this.state = { maxItems: 0 };
     },

--- a/src/components/ebay-pagination/examples/07-hidden-pages/template.marko
+++ b/src/components/ebay-pagination/examples/07-hidden-pages/template.marko
@@ -1,0 +1,29 @@
+static const SIZE = 15;
+
+class {
+    onCreate() {
+        this.state = { current: 0 };
+    }
+    handlePrev() {
+        this.state.current = Math.max(this.state.current - 1, 0);
+    }
+    handleNext() {
+        this.state.current = Math.min(this.state.current + 1, SIZE);
+    }
+    handleSelect({ value }) {
+        this.state.current = parseInt(value, 10);
+    }
+}
+
+<ebay-pagination
+    on-next("handleNext")
+    on-previous("handlePrev")
+    on-select("handleSelect")
+    variant="show-last"
+    a11y-current-text=`Results Pagination - Page ${state.current}`>
+    <@item type="previous" disabled=(state.current === 0)/>
+    <for|i| from=0 to=SIZE>
+        <@item current=(i === state.current)>${i}</@item>
+    </for>
+    <@item type="next" disabled=(state.current === SIZE)/>
+</ebay-pagination>

--- a/src/components/ebay-pagination/index.marko
+++ b/src/components/ebay-pagination/index.marko
@@ -55,13 +55,12 @@ $ var range = component._getVisibleRange(items);
         <for|item, i| of=items>
             <if(range.dotsIndex === i)>
                 <li hidden=(range.hideDots)>
-                    <button
+                    <span
                         aria-label=input.a11yDotsText
-                        onClick("handleDotsClick")
                         class=["pagination__item", item.class]
                         >
                         …
-                    </>
+                    </span>
                 </li>
             </if>
             <li hidden=((i < range.start || i > range.end) && range.dotsIndex !== i)>

--- a/src/components/ebay-pagination/index.marko
+++ b/src/components/ebay-pagination/index.marko
@@ -53,7 +53,18 @@ $ var range = component._getVisibleRange(items);
         key="items"
         class="pagination__items">
         <for|item, i| of=items>
-            <li hidden=(i < range.start || i > range.end)>
+            <if(range.dotsIndex === i)>
+                <li hidden=(range.hideDots)>
+                    <button
+                        aria-label=input.a11yDotsText
+                        onClick("handleDotsClick")
+                        class=["pagination__item", item.class]
+                        >
+                        …
+                    </>
+                </li>
+            </if>
+            <li hidden=((i < range.start || i > range.end) && range.dotsIndex !== i)>
                 <${component.getItemTag(item)}
                     ...processHtmlAttributes(item, ignoredItemAttributes)
                     class=["pagination__item", item.class]

--- a/src/components/ebay-pagination/index.marko
+++ b/src/components/ebay-pagination/index.marko
@@ -55,10 +55,7 @@ $ var range = component._getVisibleRange(items);
         <for|item, i| of=items>
             <if(range.dotsIndex === i)>
                 <li hidden=(range.hideDots)>
-                    <span
-                        aria-label=input.a11yDotsText
-                        class=["pagination__item", item.class]
-                        >
+                    <span class=["pagination__item", item.class]>
                         …
                     </span>
                 </li>

--- a/src/components/ebay-pagination/marko-tag.json
+++ b/src/components/ebay-pagination/marko-tag.json
@@ -11,6 +11,10 @@
   "@a11y-current-text": "string",
   "@role": "never",
   "@aria-labelledby": "never",
+  "@variant": {
+    "enum": ["show-last", "show-range"]
+  },
+  "@a11y-dots-text": "string",
   "@items <item>[]": {
     "attribute-groups": ["html-attributes"],
     "@*": {

--- a/src/components/ebay-pagination/marko-tag.json
+++ b/src/components/ebay-pagination/marko-tag.json
@@ -14,7 +14,6 @@
   "@variant": {
     "enum": ["show-last", "show-range"]
   },
-  "@a11y-dots-text": "string",
   "@items <item>[]": {
     "attribute-groups": ["html-attributes"],
     "@*": {

--- a/src/components/ebay-pagination/test/mock/index.js
+++ b/src/components/ebay-pagination/test/mock/index.js
@@ -34,23 +34,6 @@ exports.Links_6Items_No_Selected = assign({}, exports.Base_0Items, {
     )
 });
 
-exports.Links_6Items_No_Selected_Dots = assign({}, exports.Base_0Items_Dots, {
-    items: [].concat(
-        {
-            type: 'previous',
-            href: '#next'
-        },
-        getNItems(6, i => ({
-            href: `#${i}`,
-            renderBody: createRenderBody(`P${i}`)
-        })),
-        {
-            type: 'next',
-            href: '#next'
-        }
-    )
-});
-
 exports.Links_9Items_1Selected = assign({}, exports.Base_0Items, {
     items: [].concat(
         {

--- a/src/components/ebay-pagination/test/mock/index.js
+++ b/src/components/ebay-pagination/test/mock/index.js
@@ -8,7 +8,33 @@ exports.Base_0Items = {
     items: []
 };
 
+exports.Base_0Items_Dots = {
+    a11yPreviousText: 'Previous page',
+    a11yNextText: 'Next page',
+    a11yCurrentText: 'Results Pagination - Page 2',
+    a11yDotsText: 'dot dot dot',
+    items: [],
+    variant: 'show-last'
+};
+
 exports.Links_6Items_No_Selected = assign({}, exports.Base_0Items, {
+    items: [].concat(
+        {
+            type: 'previous',
+            href: '#next'
+        },
+        getNItems(6, i => ({
+            href: `#${i}`,
+            renderBody: createRenderBody(`P${i}`)
+        })),
+        {
+            type: 'next',
+            href: '#next'
+        }
+    )
+});
+
+exports.Links_6Items_No_Selected_Dots = assign({}, exports.Base_0Items_Dots, {
     items: [].concat(
         {
             type: 'previous',
@@ -70,6 +96,78 @@ exports.Links_9Items_7Selected = assign({}, exports.Base_0Items, {
         getNItems(9, i => ({
             href: `#${i}`,
             current: i === 7,
+            renderBody: createRenderBody(`P${i}`)
+        })),
+        {
+            type: 'next',
+            href: '#next'
+        }
+    )
+});
+
+exports.Links_16ItemsDots_1Selected = assign({}, exports.Base_0Items_Dots, {
+    items: [].concat(
+        {
+            type: 'previous',
+            href: '#previous'
+        },
+        getNItems(16, i => ({
+            href: `#${i}`,
+            current: i === 1,
+            renderBody: createRenderBody(`P${i}`)
+        })),
+        {
+            type: 'next',
+            href: '#next'
+        }
+    )
+});
+
+exports.Links_16ItemsDots_7Selected = assign({}, exports.Base_0Items_Dots, {
+    items: [].concat(
+        {
+            type: 'previous',
+            href: '#previous'
+        },
+        getNItems(16, i => ({
+            href: `#${i}`,
+            current: i === 7,
+            renderBody: createRenderBody(`P${i}`)
+        })),
+        {
+            type: 'next',
+            href: '#next'
+        }
+    )
+});
+
+exports.Links_16ItemsDots_13Selected = assign({}, exports.Base_0Items_Dots, {
+    items: [].concat(
+        {
+            type: 'previous',
+            href: '#previous'
+        },
+        getNItems(16, i => ({
+            href: `#${i}`,
+            current: i === 13,
+            renderBody: createRenderBody(`P${i}`)
+        })),
+        {
+            type: 'next',
+            href: '#next'
+        }
+    )
+});
+
+exports.Links_16ItemsDots_15Selected = assign({}, exports.Base_0Items_Dots, {
+    items: [].concat(
+        {
+            type: 'previous',
+            href: '#previous'
+        },
+        getNItems(16, i => ({
+            href: `#${i}`,
+            current: i === 15,
             renderBody: createRenderBody(`P${i}`)
         })),
         {

--- a/src/components/ebay-pagination/test/mock/index.js
+++ b/src/components/ebay-pagination/test/mock/index.js
@@ -8,14 +8,9 @@ exports.Base_0Items = {
     items: []
 };
 
-exports.Base_0Items_Dots = {
-    a11yPreviousText: 'Previous page',
-    a11yNextText: 'Next page',
-    a11yCurrentText: 'Results Pagination - Page 2',
-    a11yDotsText: 'dot dot dot',
-    items: [],
+exports.Base_0Items_Dots = assign({}, exports.Base_0Items, {
     variant: 'show-last'
-};
+});
 
 exports.Links_6Items_No_Selected = assign({}, exports.Base_0Items, {
     items: [].concat(

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -280,7 +280,7 @@ describe('given the pagination is rendered at various sizes', () => {
                     });
                     if (typeof dots === 'boolean') {
                         it(`should ${dots ? 'show' : 'hide'} the dots`, () => {
-                            const dotsEl = component.getByLabelText(input.a11yDotsText);
+                            const dotsEl = component.getByText('…');
                             const isHidden = Boolean(dotsEl.closest('[hidden]'));
                             expect(isHidden).to.equal(
                                 !dots,

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -30,6 +30,30 @@ describe('given the pagination is rendered', () => {
         thenItCanBeInteractedWith();
     });
 
+    describe('with dots', () => {
+        beforeEach(async() => {
+            input = mock.Links_6Items_No_Selected_Dots;
+            component = await render(template, input);
+        });
+
+        describe('when the dots button is activated', () => {
+            describe('via click', () => {
+                beforeEach(async() => {
+                    await fireEvent.click(component.getByLabelText(input.a11yDotsText));
+                });
+
+                it('then it emits the dots-click event', () => {
+                    const previousEvents = component.emitted('dots-click');
+                    expect(previousEvents).has.length(1);
+
+                    const [[eventArg]] = previousEvents;
+                    expect(eventArg).has.property('originalEvent').instanceOf(Event);
+                    expect(eventArg).has.property('el').instanceOf(HTMLElement);
+                });
+            });
+        });
+    });
+
     function thenItCanBeInteractedWith() {
         describe('when the previous button is activated', () => {
             describe('via click', () => {
@@ -191,14 +215,73 @@ describe('given the pagination is rendered at various sizes', () => {
                 width: 640,
                 expect: [0, 9]
             }]
+        }, {
+            name: 'first item and dots',
+            input: mock.Links_16ItemsDots_1Selected,
+            cases: [{
+                width: 400,
+                expect: [0, 3, 15]
+            }, {
+                width: 540,
+                expect: [0, 5, 15]
+            }, {
+                width: 640,
+                expect: [0, 7, 15]
+            }],
+            dots: true
+        }, {
+            name: 'with the seventh item selected and dots',
+            input: mock.Links_16ItemsDots_7Selected,
+            cases: [{
+                width: 400,
+                expect: [5, 8, 15]
+            }, {
+                width: 440,
+                expect: [5, 9, 15]
+            }, {
+                width: 540,
+                expect: [4, 9, 15]
+            }, {
+                width: 640,
+                expect: [3, 10, 15]
+            }],
+            dots: true
+        }, {
+            name: 'with the 3rd to last item selected and hidden dots',
+            input: mock.Links_16ItemsDots_13Selected,
+            cases: [{
+                width: 400,
+                expect: [11, 16]
+            }, {
+                width: 540,
+                expect: [9, 16]
+            }, {
+                width: 640,
+                expect: [7, 16]
+            }],
+            dots: false
+        }, {
+            name: 'with the last item selected and hidden dots',
+            input: mock.Links_16ItemsDots_15Selected,
+            cases: [{
+                width: 400,
+                expect: [11, 16]
+            }, {
+                width: 540,
+                expect: [9, 16]
+            }, {
+                width: 640,
+                expect: [7, 16]
+            }],
+            dots: false
         }
-    ].forEach(({ name, input, cases }) => {
+    ].forEach(({ name, input, cases, dots }) => {
         describe(name, () => {
             beforeEach(async() => {
                 component = await render(template, input);
             });
 
-            cases.forEach(({ width, expect: [from, to] }) => {
+            cases.forEach(({ width, expect: [from, to, last] }) => {
                 describe(`when it is ${width} wide`, () => {
                     beforeEach(async() => {
                         component.container.style.width = `${width}px`;
@@ -214,11 +297,20 @@ describe('given the pagination is rendered at various sizes', () => {
                             const itemEl = component.getByText(itemData.renderBody.text);
                             const isHidden = Boolean(itemEl.closest('[hidden]'));
                             expect(isHidden).to.equal(
-                                i < from || i >= to,
+                                (i < from || i >= to) && last !== i,
                                 `item ${i} should be ${isHidden ? 'visible' : 'hidden'}`
                             );
                         });
                     });
+                    if (typeof dots === 'boolean') {
+                        it(`should ${dots ? 'show' : 'hide'} the dots`, () => {
+                            const dotsEl = component.getByLabelText(input.a11yDotsText);
+                            const isHidden = Boolean(dotsEl.closest('[hidden]'));
+                            expect(isHidden).to.equal(
+                                !dots,
+                                `dots should be ${isHidden ? 'visible' : 'hidden'}`);
+                        });
+                    }
                 });
             });
         });

--- a/src/components/ebay-pagination/test/test.browser.js
+++ b/src/components/ebay-pagination/test/test.browser.js
@@ -30,30 +30,6 @@ describe('given the pagination is rendered', () => {
         thenItCanBeInteractedWith();
     });
 
-    describe('with dots', () => {
-        beforeEach(async() => {
-            input = mock.Links_6Items_No_Selected_Dots;
-            component = await render(template, input);
-        });
-
-        describe('when the dots button is activated', () => {
-            describe('via click', () => {
-                beforeEach(async() => {
-                    await fireEvent.click(component.getByLabelText(input.a11yDotsText));
-                });
-
-                it('then it emits the dots-click event', () => {
-                    const previousEvents = component.emitted('dots-click');
-                    expect(previousEvents).has.length(1);
-
-                    const [[eventArg]] = previousEvents;
-                    expect(eventArg).has.property('originalEvent').instanceOf(Event);
-                    expect(eventArg).has.property('el').instanceOf(HTMLElement);
-                });
-            });
-        });
-    });
-
     function thenItCanBeInteractedWith() {
         describe('when the previous button is activated', () => {
             describe('via click', () => {


### PR DESCRIPTION
## Description
* Added `variant` option to allow pagination with dots. 
* Made dots show up and force 2 less items (so that `...` will take up and item and last page)
* Added <strike>`a11yDotsText`</strike> and `onDotsClick` in case those events and labels are needed
* Added tests for dots

## References
#1317 

## Screenshots
![pagination](https://user-images.githubusercontent.com/1755269/106192024-7efa0000-6160-11eb-8525-7e1b8a8d4041.gif)

