### PR TITLE
Added prefix-id and prefix-label to listbox

### DIFF
--- a/src/components/ebay-listbox-button/README.md
+++ b/src/components/ebay-listbox-button/README.md
@@ -35,6 +35,8 @@ Name | Type | Stateful | Required | Description
 `borderless` | Boolean | No | No | whether button has borders
 `fluid` | Boolean | No | No | whether listbox width is 100%
 `buttonName` | String | No | Yes | used for the `name` attribute of the native `<button>`
+`prefix-id` | String | No | No | The id of an external element to use as the prefix label for the listbox button. Cannot be used with `prefix-label`
+`prefix-label` | String | No | No | The label to add before each selected item on the button. Cannot be used with `prefix-id`
 
 **Note:** For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 

--- a/src/components/ebay-listbox-button/examples/09-external-label/template.marko
+++ b/src/components/ebay-listbox-button/examples/09-external-label/template.marko
@@ -1,0 +1,8 @@
+<div id="labelid">
+    Select these items:
+</div>
+<ebay-listbox-button name="formFieldName" prefix-id="labelid">
+    <@option value="1" text="Option 1"/>
+    <@option value="2" text="Option 2"/>
+    <@option value="3" text="Option 3"/>
+</ebay-listbox-button>

--- a/src/components/ebay-listbox-button/examples/10-with-prefix/template.marko
+++ b/src/components/ebay-listbox-button/examples/10-with-prefix/template.marko
@@ -1,0 +1,5 @@
+<ebay-listbox-button name="formFieldName" prefix-label="Selected Item: ">
+    <@option value="1" text="Option 1"/>
+    <@option value="2" text="Option 2"/>
+    <@option value="3" text="Option 3"/>
+</ebay-listbox-button>

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -1,4 +1,4 @@
-import processHtmlAttributes from "../../common/html-attributes";
+import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = [
     "name",
@@ -8,12 +8,14 @@ static var ignoredAttributes = [
     "fluid",
     "invalid",
     "buttonName",
-    "options"
+    "options",
+    "prefixLabel",
+    "prefixId"
 ];
 
 $ var selectedOption = input.options[state.selectedIndex];
 $ var selectedText = selectedOption && selectedOption.text;
-
+$ var labelId = input.prefixId && component.getElId("label");
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
     key="container"
@@ -33,9 +35,15 @@ $ var selectedText = selectedOption && selectedOption.text;
         disabled=input.disabled
         name=input.buttonName
         aria-haspopup="listbox"
+        aria-labelledby=(labelId && `${input.prefixId} ${labelId}`)
         aria-invalid=(input.invalid && "true")>
         <span class="expand-btn__cell">
-            <span>${selectedText}</span>
+            <if (input.prefixLabel)>
+                <span>${input.prefixLabel} ${selectedText}</span>
+            </if>
+            <else>
+                <span id=labelId>${selectedText}</span>
+            </else>
             <ebay-dropdown-icon/>
         </span>
     </button>
@@ -46,7 +54,7 @@ $ var selectedText = selectedOption && selectedOption.text;
         tabindex=-1
         on-change("handleListboxChange")>
         <for|option| of=input.options>
-            <@option ...option selected=(selectedOption === option) />
+            <@option ...option selected=(selectedOption === option)/>
         </for>
     </ebay-listbox>
 </span>

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -10,6 +10,8 @@
   "@borderless": "boolean",
   "@fluid": "boolean",
   "@invalid": "boolean",
+  "@prefix-id": "string",
+  "@prefix-label": "string",
   "@name": "#html-name",
   "@button-name": "#html-name",
   "@disabled": "#html-disabled",

--- a/src/components/ebay-listbox-button/test/test.server.js
+++ b/src/components/ebay-listbox-button/test/test.server.js
@@ -52,6 +52,21 @@ describe('listbox', () => {
         expect(getAllByRole('option').filter(isVisible).findIndex(isAriaSelected)).is.equal(1);
     });
 
+    it('renders with prefix label', async() => {
+        const input = mock.Basic_3Options_1Selected;
+        const { getAllByText } = await render(template, Object.assign({}, input, { prefixLabel: 'prefix:' }));
+        expect(getAllByText('prefix: option 1')).has.length(1);
+    });
+
+    it('renders with prefix id', async() => {
+        const input = mock.Basic_3Options_1Selected;
+        const { getByRole, getAllByText } = await render(template, Object.assign({}, input, { prefixId: 'prefixId' }));
+        const btnEl = getByRole('button');
+        const label = getAllByText('option 1')[0];
+        expect(btnEl).has.attribute('aria-labelledby');
+        expect(btnEl.getAttribute('aria-labelledby')).to.equal(`prefixId ${label.getAttribute('id')}`);
+    });
+
     testPassThroughAttributes(template);
     testPassThroughAttributes(template, {
         child: {


### PR DESCRIPTION
## Description
Added both `prefix-label` and `prefix-id` to listbox button

## References
https://github.com/eBay/ebayui-core/issues/1320
https://github.com/eBay/ebayui-core/issues/1321

## Screenshots
<img width="485" alt="Screen Shot 2021-02-09 at 1 54 17 PM" src="https://user-images.githubusercontent.com/1755269/107433555-54a02f00-6ade-11eb-87bc-5bff04f0d5bd.png">
<img width="866" alt="Screen Shot 2021-02-09 at 1 54 21 PM" src="https://user-images.githubusercontent.com/1755269/107433557-5669f280-6ade-11eb-823f-f67fedcd830c.png">

