### PR TITLE
Fake menu now uses list instead of div

### DIFF
--- a/src/components/ebay-fake-menu/index.marko
+++ b/src/components/ebay-fake-menu/index.marko
@@ -34,37 +34,41 @@ $ var baseClass = input.classPrefix || "fake-menu";
         input.class
     ]
     style=input.style>
-    <div
-        class=`${baseClass}__items`
+    <ul
+        class=`fake-menu__items`
         key="menu"
         tabindex="-1"
         id:scoped="menu">
         <for|item, index| of=input.items>
             $ var isDisabled = !item.href || item.disabled;
             <if (item._isSeparator)>
-                <hr class=`${baseClass}__separator` role="separator" />
+                <li>
+                    <hr class=`${baseClass}__separator` role="separator" />
+                </li>
             </if>
             <else>
-            <${item.type === "button" ? "button" : "a"}
-                ...processHtmlAttributes(item, itemIgnoredAttributes)
-                class=[`${baseClass}__item`, item.class]
-                style=item.style
-                aria-current=(item.current ? "page" : false)
-                aria-disabled=(item.disabled && "true")
-                href=(item.disabled ? null : item.href)
-                onKeydown("handleItemKeydown", index)
-                onClick("handleItemClick", index)
-                key="item[]">
-                <span>
-                    <${item.renderBody}/>
-                </span>
-                <if(item.badgeNumber)>
-                    <ebay-badge type="menu" number=item.badgeNumber/>
-                </if>
+                <li>
+                    <${item.type === "button" ? "button" : "a"}
+                        ...processHtmlAttributes(item, itemIgnoredAttributes)
+                        class=[`${baseClass}__item`, item.class]
+                        style=item.style
+                        aria-current=(item.current ? "page" : false)
+                        aria-disabled=(item.disabled && "true")
+                        href=(item.disabled ? null : item.href)
+                        onKeydown("handleItemKeydown", index)
+                        onClick("handleItemClick", index)
+                        key="item[]">
+                        <span>
+                            <${item.renderBody}/>
+                        </span>
+                        <if(item.badgeNumber)>
+                            <ebay-badge type="menu" number=item.badgeNumber/>
+                        </if>
 
-                <ebay-tick-small-icon />
-            </>
+                        <ebay-tick-small-icon />
+                    </>
+                </li>
             </else>
         </for>
-    </div>
+    </ul>
 </span>


### PR DESCRIPTION
## Description
Changes the structure of the ebay-fake-menu (which fake-menu-button uses) to use a list based structure instead of a div structure. 

## Context
Accessibility 

## References
closes #1316 

## Screenshots
<img width="414" alt="Screen Shot 2021-02-18 at 9 32 02 PM" src="https://user-images.githubusercontent.com/25092249/108462225-166ae400-7231-11eb-81e2-f18a17b8b958.png">

<img width="549" alt="Screen Shot 2021-02-18 at 9 32 20 PM" src="https://user-images.githubusercontent.com/25092249/108462230-1834a780-7231-11eb-8b39-89a9986afbb6.png">

<img width="545" alt="Screen Shot 2021-02-18 at 9 32 46 PM" src="https://user-images.githubusercontent.com/25092249/108462233-1965d480-7231-11eb-807f-a145ed4aec80.png">

