### PR TITLE
ci: add browserstack

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,6 @@
 name: eBay UI CI
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   build:
@@ -13,7 +13,11 @@ jobs:
         node-version: '12.x'
     - run: npm install
     - run: npm run build:ci
-      # run: cat ./.coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+      env:
+        BROWSERSTACK_USER: ${{ secrets.BROWSERSTACK_USERNAME }}
+        BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        BUILD_NUMBER: CI
+        REPO_SLUG: ebay/ebayui-core
     - uses: coverallsapp/github-action@master
       if: ${{ success() }}
       with:

--- a/marko-cli.js
+++ b/marko-cli.js
@@ -1,76 +1,41 @@
 'use strict';
 
-const isTravis = require('is-travis');
-const buildID = `${process.env.TRAVIS_BUILD_NUMBER}.${process.env.TRAVIS_JOB_NUMBER}`;
-
 module.exports = ({ config }) => {
     config.mochaOptions = { timeout: 60000 };
+
     config.lassoOptions = {
         flags: [],
-        plugins: ['lasso-less']
+        plugins: ['lasso-less'],
     };
 
     config.wdioOptions = {
-        idleTimeout: 60000, // Automatically disconnect after 1min of inactivity by default.
+        idleTimeout: 60000,
         timeout: 60000,
-        browserstackOpts: {
-            force: true,
-            onlyAutomate: isTravis,
-            localIdentifier: buildID
-        },
-        capabilities: [{
-            browser: 'Chrome',
-            os: 'Windows',
-            os_version: '10'
-        // }, {
-        //     browser: 'Firefox',
-        //     os: 'Windows',
-        //     os_version: '10'
-        // }, {
-        //     browser: 'Firefox',
-        //     browser_version: '48.0',
-        //     os: 'Windows',
-        //     os_version: '7'
-        }, {
-            browser: 'Safari',
-            os: 'OS X',
-            os_version: 'Catalina'
-        // }, {
-        //     // Doesn't seem to be supporting timeouts?
-        //     browser: 'Safari',
-        //     browser_version: '6.0',
-        //     os: 'OS X',
-        //     os_version: 'Lion'
-        // }, {
-        //     browser: 'Edge',
-        //     os: 'Windows',
-        //     os_version: '10'
-        // }, {
-        //     // Various issues.
-        //     browser: 'Edge',
-        //     browser_version: '14.0',
-        //     os: 'Windows',
-        //     os_version: '10'
-        // }, {
-        //     // Not compiling properly.
-        //     browser: 'IE',
-        //     os: 'Windows',
-        //     os_version: '10'
-        // }, {
-        //     // Does not support custom viewport sizing.
-        //     browser: 'Opera',
-        //     browser_version: '12.16',
-        //     os: 'Windows',
-        //     os_version: '7'
-        }].map(capability => {
-            capability.build = buildID;
-            capability.project = 'ebayui-core';
+        capabilities: [
+            {
+                browser: 'Chrome',
+                os: 'Windows',
+                os_version: '10',
+            },
+            {
+                browser: 'Chrome',
+                os: 'OS X',
+                os_version: 'Big Sur',
+            },
+            {
+                browser: 'Safari',
+                os: 'OS X',
+                os_version: 'Big Sur',
+            },
+            {
+                browser: 'Safari',
+                os: 'OS X',
+                os_version: 'Catalina',
+            },
+        ].map((capability) => {
             capability['browserstack.local'] = true;
-            capability['browserstack.debug'] = true;
-            capability['browserstack.localIdentifier'] = buildID;
-            capability['browserstack.console'] = 'verbose';
-            capability['browserstack.networkLogs'] = true;
+
             return capability;
-        })
+        }),
     };
 };


### PR DESCRIPTION
Adds browserstack support to our github actions. Marko-test and WebDriverIO do all the heavy lifting here. We just have to set the correct env vars.

Also fixed broken config in `marko-cli.js`. After much head scratching the offending line of code was the `localIdentifier` param. It was causing issues with the browserstack local connection. I just removed it and a bunch of other config which seems superfluous now.

Browserstack is now again working from CLI and CI. I updated the CI to only trigger on pull requests. We can fine tune this later if desired.

I cleaned up the list of browsers. There still seems to be an issue with carousel in Firefox (#967) so it remains omitted.

![Screen Shot 2021-02-23 at 5 02 42 PM](https://user-images.githubusercontent.com/38065/108931620-c7d89380-75fc-11eb-8802-77b6114db66d.png)

![Screen Shot 2021-02-23 at 5 05 18 PM](https://user-images.githubusercontent.com/38065/108931610-c5763980-75fc-11eb-9af7-d921128b52ee.png)



