### PR TITLE
Added as argument to details to change root element

### DIFF
--- a/src/components/ebay-details/README.md
+++ b/src/components/ebay-details/README.md
@@ -21,6 +21,7 @@ Name | Type | Stateful | Required | Description
 `type` | String | No | No | Can be "regular" / "center". Default "regular"
 `size` | String | No | No | Can be "regular" / "small". Default "regular"
 `open` | Boolean | No | No | Whether details is open.
+`as` | String | No | No | The root element. Defaults to `<p>`
 
 ## Events
 

--- a/src/components/ebay-details/examples/06-div-root/template.marko
+++ b/src/components/ebay-details/examples/06-div-root/template.marko
@@ -1,0 +1,10 @@
+class {}
+
+<ebay-details text="details" as="div">
+    <div>
+        Block content
+    </div>
+    <div>
+        Another block content
+    </div>
+</ebay-details>

--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -16,7 +16,7 @@ $ input.toJSON = noop;
             <ebay-dropdown-icon />
         </span>
     </summary>
-    <p>
+    <${input.as || "p"}>
         <${input.renderBody}/>
-    </p>
+    </>
 </details>

--- a/src/components/ebay-details/marko-tag.json
+++ b/src/components/ebay-details/marko-tag.json
@@ -13,5 +13,6 @@
     "enum": ["regular", "small"]
   },
   "@text": "string",
+  "@as": "string",
   "@open": "boolean"
 }

--- a/src/components/ebay-details/test/test.server.js
+++ b/src/components/ebay-details/test/test.server.js
@@ -16,6 +16,13 @@ describe('details', () => {
         expect(getByText(input.renderBody.text).closest('details')).has.property('open', false);
     });
 
+    it('renders as div version', async() => {
+        const input = Object.assign({}, mock.Default_Details, { as: 'div' });
+        const { getByText } = await render(template, input);
+        expect(getByText(input.text)).has.class('details__label');
+        expect(getByText(input.renderBody.text)).has.property('tagName', 'DIV');
+    });
+
     it('renders in open state', async() => {
         const input = mock.Open_Details;
         const { getByText } = await render(template, input);


### PR DESCRIPTION
## Description
Added `as` and argument to details to allow a different root.
Also added a new example to showcase it.

## References
https://github.com/eBay/ebayui-core/issues/1331

