### PR TITLE
Added default class to details

### DIFF
--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -1,11 +1,17 @@
 import processHtmlAttributes from "../../common/html-attributes"
 
 static function noop() {}
-static var ignoredAttributes = ["open", "type", "size", "text", "toJSON"];
+
+static var ignoredAttributes = ["class", "open", "type", "size", "text", "toJSON"];
 
 $ input.toJSON = noop;
-
-<details class="details" open=input.open key="root" on-toggle('toggleDetails') on-click('clickDetails') ...processHtmlAttributes(input, ignoredAttributes)>
+<details
+    ...processHtmlAttributes(input, ignoredAttributes)
+    class=["details", input.class]
+    open=input.open
+    key="root"
+    on-toggle("toggleDetails")
+    on-click("clickDetails")>
     <summary class=[
         "details__summary",
         input.size === "small" && "details__summary--small",
@@ -13,7 +19,7 @@ $ input.toJSON = noop;
     ]>
         <span class="details__label">${input.text}</span>
         <span class="details__icon" hidden>
-            <ebay-dropdown-icon />
+            <ebay-dropdown-icon/>
         </span>
     </summary>
     <${input.as || "p"}>


### PR DESCRIPTION
## Description
* Added a `class=["details", input.class]` to preserve the default class.
* Ran formatter

## References
#1335 
