### PR TITLE
Update Progress Spinner

### DIFF
--- a/src/components/ebay-progress-spinner/index.marko
+++ b/src/components/ebay-progress-spinner/index.marko
@@ -4,5 +4,5 @@ static var ignoredAttributes = ["class", "size"];
 
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
-    class=["spinner", input.size === "large" && "spinner--large", input.class]
+    class=["progress-spinner", input.size === "large" && "progress-spinner--large", input.class]
     role="img"/>

--- a/src/components/ebay-progress-spinner/style.js
+++ b/src/components/ebay-progress-spinner/style.js
@@ -1,1 +1,1 @@
-require('@ebay/skin/spinner');
+require('@ebay/skin/progress-spinner');


### PR DESCRIPTION
## Description
Updates the Progress Spinner's class from spinner to progress-spinner. 

## Context
Prepares us for deprecating the spinner class in skin. However, the spinner will still be updated even if we don't merge this PR, as skin still supports the `spinner` class for now. 

## Screenshots
<img width="552" alt="Screen Shot 2021-03-09 at 1 46 15 PM" src="https://user-images.githubusercontent.com/25092249/110542514-fca91800-80dd-11eb-9b1f-0220e3f53843.png">
