### PR TITLE
fix for marko compile error. attribute tags must come before render body

### DIFF
--- a/src/components/ebay-snackbar-dialog/examples/02-action/template.marko
+++ b/src/components/ebay-snackbar-dialog/examples/02-action/template.marko
@@ -21,8 +21,8 @@ class {
     Open Action Snackbar
 </ebay-button>
 <ebay-snackbar-dialog open=state.open on-close('handleClose') on-action("handleAction")>
-    This is the action snackbar
     <@action access-key="U">
         Undo
     </@action>
+    This is the action snackbar
 </ebay-snackbar-dialog>

--- a/src/components/ebay-snackbar-dialog/examples/03-stacked/template.marko
+++ b/src/components/ebay-snackbar-dialog/examples/03-stacked/template.marko
@@ -21,8 +21,8 @@ class {
     Open Stacked Snackbar
 </ebay-button>
 <ebay-snackbar-dialog open=state.open layout="column" on-close("handleClose") on-action("handleAction")>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     <@action access-key="U">
         Undo
     </@action>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 </ebay-snackbar-dialog>

--- a/src/components/ebay-snackbar-dialog/index.marko
+++ b/src/components/ebay-snackbar-dialog/index.marko
@@ -2,7 +2,8 @@ import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = [
     "open",
-    "layout"
+    "layout",
+    "action"
 ];
 
 <ebay-dialog-base
@@ -17,11 +18,9 @@ static var ignoredAttributes = [
     windowClass=[input.layout === "column" && "snackbar-dialog__window--column"]
     buttonPosition="hidden"
     transitionEl="root">
-    <${input.renderBody}/>
     <if(input.action)>
         <@action>
             <ebay-button
-                ...input.action
                 variant="fake-link"
                 on-click("handleAction")
                 on-focus("handleFocus")
@@ -31,4 +30,6 @@ static var ignoredAttributes = [
             </ebay-button>
         </@action>
     </if>
+
+    <${input.renderBody}/>
 </ebay-dialog-base>


### PR DESCRIPTION
## Description
This fix lets the snackbar compile. Before it was having a few issues resulting in an error 
`cannot set property start of undefined`. 

This error was caused by the renderBody coming before attribute tags, which is apparently not allowed in Marko. 
(I filed an [issue](https://github.com/marko-js/marko/issues/1678) on Marko js to add this to the documentation).

With this fix, I think we could push the snackbar, with the caveat that the uncontrolled snackbar is still beta. 

As far as Deenash's [issue](https://github.com/eBay/ebayui-core/issues/1351), I am still working on a fix. I am not sure how to solve the issue where any rerender causes the uncontrolled snackbar to appear again. 


## Screenshots
No visual changes other than switching the line location of render body in the examples, which can be seen clearly in the code changes.