### PR TITLE
Added fix for video player runtime and with amd loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26947,8 +26947,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -28100,9 +28099,9 @@
       }
     },
     "shaka-player": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-3.0.8.tgz",
-      "integrity": "sha512-4nROuGUhmtOTERWVO31pp/hvtdCy/kW/Ys6KQwqRhFeCsZsU1/8768dJUyXKqNnbYybKIvuv6LqO8egkXy6TjA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-3.0.10.tgz",
+      "integrity": "sha512-kr1OFbihAmsmtsb/QhyDfxkt05wPAdreiW8vF86RN95zxpp+J/thEcTjRrH0E9dkBwPwS4HVv+mm096uqtEMvA==",
       "dev": true,
       "requires": {
         "eme-encryption-scheme-polyfill": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26947,7 +26947,8 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "pre-push": "^0.1.1",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
-    "shaka-player": "^3.0.8",
+    "shaka-player": "^3.0.10",
     "sinon": "^9.2.4",
     "storybook-readme": "^5.0.8",
     "style-loader": "^2.0.0",
@@ -152,7 +152,8 @@
     "makeup-roving-tabindex": "~0.3.7",
     "makeup-screenreader-trap": "~0.2.1",
     "makeup-typeahead": "^0.0.2",
-    "nodelist-foreach-polyfill": "^1.2.0"
+    "nodelist-foreach-polyfill": "^1.2.0",
+    "regenerator-runtime": "^0.13.7"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -152,8 +152,7 @@
     "makeup-roving-tabindex": "~0.3.7",
     "makeup-screenreader-trap": "~0.2.1",
     "makeup-typeahead": "^0.0.2",
-    "nodelist-foreach-polyfill": "^1.2.0",
-    "regenerator-runtime": "^0.13.7"
+    "nodelist-foreach-polyfill": "^1.2.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/scripts/generate-cdn.js
+++ b/scripts/generate-cdn.js
@@ -7,8 +7,6 @@ const path = require('path');
 const rimraf = require('rimraf');
 const rootDir = path.join(__dirname, '..');
 
-const amdCheck = /else if(typeof define=="function"&&define.amd)define(function(){return exportTo.shaka});/;
-
 function updateJsonFile(version) {
     const versionFile = path.join(rootDir, 'src/components/ebay-video/versions.json');
     const videoVersions = {

--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -1,6 +1,5 @@
 const loader = require('./loader');
 const versions = require('./versions.json');
-require('regenerator-runtime');
 const MAX_RETIRES = 3;
 
 module.exports = {
@@ -112,7 +111,7 @@ module.exports = {
             this.input.cdnUrl ||
             `https://ir.ebaystatic.com/cr/v/c1/ebayui/shaka/v${version}/shaka-player.compiled.js`;
         loader(cdnUrl)
-            .then(async () => {
+            .then(() => {
                 this.video = this.getEl('video');
                 // eslint-disable-next-line no-undef,new-cap
                 this.player = new shaka.Player(this.video);

--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -1,5 +1,6 @@
 const loader = require('./loader');
 const versions = require('./versions.json');
+require('regenerator-runtime');
 const MAX_RETIRES = 3;
 
 module.exports = {

--- a/src/components/ebay-video/versions.json
+++ b/src/components/ebay-video/versions.json
@@ -1,1 +1,1 @@
-{"//":"This is a generated file. Run script file to update","shaka":"3.0.8"}
+{"//":"This is a generated file. Run script file to update","shaka":"3.0.10"}


### PR DESCRIPTION
## Description
* ~~With the way we are doing babel bundling and we are using promises, we have to add a `regenrator-runtime` module to make it work with `commonjs`. Since video won't work without this, we need to add it as a dependency.~~ Removed not needed `async` function from client code. 
* There is an issue with loading with `define`, so in the minifed shaka code, I removed that check to always fail

