### PR TITLE
Menu Button Labeling

### DIFF
--- a/src/components/ebay-menu-button/README.md
+++ b/src/components/ebay-menu-button/README.md
@@ -20,41 +20,44 @@
     <@item>item 3</@item>
 </ebay-menu-button>
 ```
+
 ## ebay-menu-buton Sub-tags
 
-Tag | Required | Description
---- | --- | ---
-`@item` | No | All items to be displayed for menu-button
-`@icon` | No | An `<ebay-{name}-icon>` to show for the icon button
+| Tag     | Required | Description                                         |
+| ------- | -------- | --------------------------------------------------- |
+| `@item` | No       | All items to be displayed for menu-button           |
+| `@icon` | No       | An `<ebay-{name}-icon>` to show for the icon button |
 
 ### ebay-menu-button Attributes
 
-Name | Type | Stateful | Required | Description
---- | --- | --- | --- | ---
-`text` | String | Yes | Yes | button text
-`a11y-text` | String | No | No | a11y text for the button, especially for cases without text
-`no-toggle-icon` | Boolean | No | No | whether to hide the chevron toggle icon
-`expanded` | Boolean | Yes | No | whether content is expanded (Note: not supported as initial attribute)
-`type` | String | No | No | Can be "radio" / "checkbox"
-`reverse` | Boolean | No | No | expand menu flyout to the left
-`fix-width` | Boolean | No | No | constrain items container width to button width
-`borderless` | Boolean | No | No | whether button has borders
-`size` | String | No | No | button size, "large" (default: "none")
-`priority` | String | No | No | button priority, "primary" / "secondary" (default) / "none"
-`checked` (radio) | Number | Yes | No | will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup
-`disabled` | Boolean | Yes | No | Will disable the entire dropdown (disables the ebay-button label) if set to true
-`variant` | String | No | No | will change the button style, "overflow" / "default"
-`collapseOnSelect` | Boolean | Yes | No | Will collapse whole menu when an item is selected in menu. Typically used in `type="radio"`
+| Name               | Type    | Stateful | Required | Description                                                                                                      |
+| ------------------ | ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `text`             | String  | Yes      | Yes      | button text                                                                                                      |
+| `a11y-text`        | String  | No       | No       | a11y text for the button, especially for cases without text                                                      |
+| `no-toggle-icon`   | Boolean | No       | No       | whether to hide the chevron toggle icon                                                                          |
+| `expanded`         | Boolean | Yes      | No       | whether content is expanded (Note: not supported as initial attribute)                                           |
+| `type`             | String  | No       | No       | Can be "radio" / "checkbox"                                                                                      |
+| `reverse`          | Boolean | No       | No       | expand menu flyout to the left                                                                                   |
+| `fix-width`        | Boolean | No       | No       | constrain items container width to button width                                                                  |
+| `borderless`       | Boolean | No       | No       | whether button has borders                                                                                       |
+| `size`             | String  | No       | No       | button size, "large" (default: "none")                                                                           |
+| `priority`         | String  | No       | No       | button priority, "primary" / "secondary" (default) / "none"                                                      |
+| `checked` (radio)  | Number  | Yes      | No       | will set the corresponding index item to `checked` state and use the `aria-checked` attribute in markup          |
+| `disabled`         | Boolean | Yes      | No       | Will disable the entire dropdown (disables the ebay-button label) if set to true                                 |
+| `variant`          | String  | No       | No       | will change the button style, "overflow" / "default"                                                             |
+| `collapseOnSelect` | Boolean | Yes      | No       | Will collapse whole menu when an item is selected in menu. Typically used in `type="radio"`                      |
+| `prefix-id`        | String  | No       | No       | The id of an external element to use as the prefix label for the menu button. Cannot be used with `prefix-label` |
+| `prefix-label`     | String  | No       | No       | The label to add before each selected item on the button. Cannot be used with `prefix-id`                        |
 
 ### ebay-menu-button Events
 
-Event | Data | Description
---- | --- | ---
-`expand` |  | expand content
-`collapse` |  | collapse content
-`change` (radio) | `{ el, index, checked }` | item changed/checked
-`change` (checkbox) | `{ el, [indexes], [checked] }` | items changed/checked
-`select` (not radio or checkbox) | `{ el, index, checked }` | item clicked
+| Event                            | Data                           | Description           |
+| -------------------------------- | ------------------------------ | --------------------- |
+| `expand`                         |                                | expand content        |
+| `collapse`                       |                                | collapse content      |
+| `change` (radio)                 | `{ el, index, checked }`       | item changed/checked  |
+| `change` (checkbox)              | `{ el, [indexes], [checked] }` | items changed/checked |
+| `select` (not radio or checkbox) | `{ el, index, checked }`       | item clicked          |
 
 ## @label Tag
 
@@ -74,11 +77,11 @@ Event | Data | Description
 
 ### @item Attributes
 
-Name | Type | Stateful | Required | Description
---- | --- | --- | --- | ---
-`checked` (radio or checkbox) | Boolean | No | No | whether or not the item is checked
-`badge-number` | Number | No | No | used as the number to be placed in the badge
-`badge-aria-label` | String | No | Yes (only if badge number is provided) | passed as the `aria-label` directly to the badge
+| Name                          | Type    | Stateful | Required                               | Description                                      |
+| ----------------------------- | ------- | -------- | -------------------------------------- | ------------------------------------------------ |
+| `checked` (radio or checkbox) | Boolean | No       | No                                     | whether or not the item is checked               |
+| `badge-number`                | Number  | No       | No                                     | used as the number to be placed in the badge     |
+| `badge-aria-label`            | String  | No       | Yes (only if badge number is provided) | passed as the `aria-label` directly to the badge |
 
 ## ebay-menu-button-separator
 

--- a/src/components/ebay-menu-button/ebay-menu-button.css
+++ b/src/components/ebay-menu-button/ebay-menu-button.css
@@ -1,0 +1,3 @@
+.menu-button-prefix-label {
+    margin-right: 3px;
+}

--- a/src/components/ebay-menu-button/examples/19-prefix-label/template.marko
+++ b/src/components/ebay-menu-button/examples/19-prefix-label/template.marko
@@ -1,8 +1,20 @@
-<ebay-menu-button type="radio" prefix-label="Select From Menu">
+class {
+    onCreate() {
+        this.state = { labelText: 'label text', index: -1 };
+    }
+
+    handleChange(e) {
+        console.log(e);
+        this.state.labelText = e.el.textContent;
+        this.state.index = e.index;
+    }
+}
+
+<ebay-menu-button type="radio" prefix-label="Sort By:" on-change('handleChange')>
     <@label>
-        label text
+        ${state.labelText}
     </@label>
-    <@item checked>item 1 that has very long text</@item>
-    <@item>item 2</@item>
-    <@item>item 3</@item>
+    <@item checked=state.index==0>Color</@item>
+    <@item checked=state.index==1>Year</@item>
+    <@item checked=state.index==2>Mileage</@item>
 </ebay-menu-button>

--- a/src/components/ebay-menu-button/examples/19-prefix-label/template.marko
+++ b/src/components/ebay-menu-button/examples/19-prefix-label/template.marko
@@ -4,7 +4,6 @@ class {
     }
 
     handleChange(e) {
-        console.log(e);
         this.state.labelText = e.el.textContent;
         this.state.index = e.index;
     }

--- a/src/components/ebay-menu-button/examples/19-prefix-label/template.marko
+++ b/src/components/ebay-menu-button/examples/19-prefix-label/template.marko
@@ -1,6 +1,6 @@
 class {
     onCreate() {
-        this.state = { labelText: 'label text', index: -1 };
+        this.state = { labelText: 'Color', index: 0 };
     }
 
     handleChange(e) {

--- a/src/components/ebay-menu-button/examples/19-prefix-label/template.marko
+++ b/src/components/ebay-menu-button/examples/19-prefix-label/template.marko
@@ -1,0 +1,8 @@
+<ebay-menu-button type="radio" prefix-label="Select From Menu">
+    <@label>
+        label text
+    </@label>
+    <@item checked>item 1 that has very long text</@item>
+    <@item>item 2</@item>
+    <@item>item 3</@item>
+</ebay-menu-button>

--- a/src/components/ebay-menu-button/examples/20-prefix-id/template.marko
+++ b/src/components/ebay-menu-button/examples/20-prefix-id/template.marko
@@ -1,6 +1,6 @@
 class {
     onCreate() {
-        this.state = { buttonText: 'Select An Option' };
+        this.state = { buttonText: 'Name' };
     }
 
     handleSelect(e) {

--- a/src/components/ebay-menu-button/examples/20-prefix-id/template.marko
+++ b/src/components/ebay-menu-button/examples/20-prefix-id/template.marko
@@ -4,7 +4,6 @@ class {
     }
 
     handleSelect(e) {
-        console.log(e);
         this.state.buttonText = e.el.textContent;
     }
 }

--- a/src/components/ebay-menu-button/examples/20-prefix-id/template.marko
+++ b/src/components/ebay-menu-button/examples/20-prefix-id/template.marko
@@ -1,0 +1,8 @@
+<div id="custom-label">
+    Menu Label
+</div>
+<ebay-menu-button prefix-id="custom-label" text="eBay Menu">
+    <@item>item 1 that has very long text</@item>
+    <@item>item 2</@item>
+    <@item>item 3</@item>
+</ebay-menu-button>

--- a/src/components/ebay-menu-button/examples/20-prefix-id/template.marko
+++ b/src/components/ebay-menu-button/examples/20-prefix-id/template.marko
@@ -1,8 +1,19 @@
+class {
+    onCreate() {
+        this.state = { buttonText: 'Select An Option' };
+    }
+
+    handleSelect(e) {
+        console.log(e);
+        this.state.buttonText = e.el.textContent;
+    }
+}
+
 <div id="custom-label">
-    Menu Label
+    Sort By:
 </div>
-<ebay-menu-button prefix-id="custom-label" text="eBay Menu">
-    <@item>item 1 that has very long text</@item>
-    <@item>item 2</@item>
-    <@item>item 3</@item>
+<ebay-menu-button prefix-id="custom-label" text=state.buttonText on-select('handleSelect')>
+    <@item>Name</@item>
+    <@item>Year</@item>
+    <@item>Group</@item>
 </ebay-menu-button>

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -65,10 +65,13 @@ $ var labelId = input.prefixId && component.getElId("label");
                         <${input.label.renderBody}/>
                     </if>
                     <else >
-                        <${input.label.renderBody}/>
+                        <span id=labelId>
+                            <${input.label.renderBody}/>
+                        </span>
                     </else>
                 </if>
                 <else>
+                    <!-- TODO Cleanup -->
                     <!-- Convoluted markup to satisfy both Skin and Marko -->
                     <if(input.icon)>
                         <div no-update-body class="btn__icon">
@@ -76,7 +79,7 @@ $ var labelId = input.prefixId && component.getElId("label");
                         </div>
                     </if>
                     <if(input.text)>
-                        <span>${input.text}</span>
+                        <span id=labelId>${input.text}</span>
                     </if>
                 </else>
                 <if(!input.noToggleIcon)>

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -19,10 +19,14 @@ static var ignoredAttributes = [
     "variant",
     "items",
     "label",
-    "textAlign"
+    "textAlign",
+    "prefixLabel",
+    "prefixId"
 ];
 
 $ var isOverflowVariant = input.variant === "overflow";
+$ var labelId = input.prefixId && component.getElId("label");
+
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
     class=["menu-button", input.class]
@@ -30,7 +34,7 @@ $ var isOverflowVariant = input.variant === "overflow";
     onExpander-expand("handleExpand")
     onExpander-collapse("handleCollapse")
     onMousedown("handleMousedown")>
-    <ebay-button
+        <ebay-button
         class=[
             `menu-button__button`,
             input.borderless && !isOverflowVariant && "expand-btn--borderless"
@@ -42,6 +46,7 @@ $ var isOverflowVariant = input.variant === "overflow";
         aria-expanded="false"
         aria-haspopup="true"
         aria-label=input.a11yText
+        aria-labelledby=(labelId && `${input.prefixId} ${labelId}`)
         disabled=input.disabled
         on-escape("handleButtonEscape")
         key="button">
@@ -55,7 +60,13 @@ $ var isOverflowVariant = input.variant === "overflow";
                 input.textAlign === 'center' && "expand-btn__cell--center"
             ]>
                 <if(input.label)>
-                    <${input.label.renderBody}/>
+                    <if(input.prefixLabel)>
+                        <span class="menu-button-prefix-label">${input.prefixLabel}</span>
+                        <${input.label.renderBody}/>
+                    </if>
+                    <else >
+                        <${input.label.renderBody}/>
+                    </else>
                 </if>
                 <else>
                     <!-- Convoluted markup to satisfy both Skin and Marko -->

--- a/src/components/ebay-menu-button/marko-tag.json
+++ b/src/components/ebay-menu-button/marko-tag.json
@@ -21,6 +21,8 @@
   "@borderless": "boolean",
   "@size": "string",
   "@priority": "string",
+  "@prefix-id": "string",
+  "@prefix-label": "string",
   "@icon <icon>": {
     "@*": {
       "targetProperty": null,

--- a/src/components/ebay-menu-button/style.js
+++ b/src/components/ebay-menu-button/style.js
@@ -1,1 +1,2 @@
 require('@ebay/skin/menu-button');
+require('./ebay-menu-button.css');


### PR DESCRIPTION
## Description
Adds prefixLabel and prefix-id to the menu-button. 

## Context
These were added previously to listbox-button and are now being added to menu-button.

## References
closes #1350 

## Screenshots
<img width="745" alt="Screen Shot 2021-04-02 at 12 56 59 PM" src="https://user-images.githubusercontent.com/25092249/113460006-f9d6d580-93b2-11eb-8a0a-8560a250148a.png">
<img width="825" alt="Screen Shot 2021-04-02 at 12 57 09 PM" src="https://user-images.githubusercontent.com/25092249/113460010-fcd1c600-93b2-11eb-8293-803b74bfe11a.png">


