### PR TITLE
<p> is no longer automatically added to Progress Stepper

### DIFF
--- a/src/components/ebay-progress-stepper/README.md
+++ b/src/components/ebay-progress-stepper/README.md
@@ -20,27 +20,28 @@
 
 ## ebay-progress-stepper Sub-tags
 
-Tag | Required | Description
---- | --- | ---
-`<@step>` | Yes | Each step to represented. The body will display as text next to the current state
+| Tag       | Required | Description                                                                       |
+| --------- | -------- | --------------------------------------------------------------------------------- |
+| `<@step>` | Yes      | Each step to represented. The body will display as text next to the current state |
 
 ## ebay-progress-stepper Attributes
 
-Name | Type | Stateful | Required | Description
---- | --- | --- | --- | ---
-`direction` | Enum | No | No | Either 'column' or 'row'. Will display stepper as a vertical column or horizontal row. Default is 'row'
-`default-state` | Enum | Yes | No | Either 'complete', 'upcoming' or 'active'. If complete, then all items will be in complete state by default. If upcoming, all items will be in upcoming state. Otherwise, the default (active), will change items based on the `current` item.
+| Name                    | Type    | Stateful | Required | Description                                                                                                                                                                                                                                    |
+| ----------------------- | ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `direction`             | Enum    | No       | No       | Either 'column' or 'row'. Will display stepper as a vertical column or horizontal row. Default is 'row'                                                                                                                                        |
+| `default-state`         | Enum    | Yes      | No       | Either 'complete', 'upcoming' or 'active'. If complete, then all items will be in complete state by default. If upcoming, all items will be in upcoming state. Otherwise, the default (active), will change items based on the `current` item. |
+| `no-wrap-paragraph-tag` | Boolean | No       | No       | If true, will not add <p> tag to render body. defaults to false.                                                                                                                                                                               |
 
 ## ebay-progress-stepper @step Sub-tags
 
-Tag | Required | Description
---- | --- | ---
-`<@title>` | No | The bolded title for each step. Will be rendered in an `h4` by default. In order to override, pass the `as` attribute. `<@title as="h3">Title</@title>`. All other attributes will be passed through to the header tag
+| Tag        | Required | Description                                                                                                                                                                                                            |
+| ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<@title>` | No       | The bolded title for each step. Will be rendered in an `h4` by default. In order to override, pass the `as` attribute. `<@title as="h3">Title</@title>`. All other attributes will be passed through to the header tag |
 
 ## ebay-progress-stepper @step Attributes
 
-Name | Type | Stateful | Required | Description
---- | --- | --- | --- | ---
-`current` | Boolean | No | No | The current step. Only first step that has this attribute will be considered current. All steps before will be rendered as complete, and all after will render as upcoming. If not present on any item, then will render based on `default-state` attribute
-`type` | Enumm | No | No | Either `attention`, `information`, or `complete`. This takes prescedence over current. Will render the current step with the given icon and color
-`number` | Number | No | No | Renders the current step with the given number. Overrides the default number counting for this step
+| Name      | Type    | Stateful | Required | Description                                                                                                                                                                                                                                                 |
+| --------- | ------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `current` | Boolean | No       | No       | The current step. Only first step that has this attribute will be considered current. All steps before will be rendered as complete, and all after will render as upcoming. If not present on any item, then will render based on `default-state` attribute |
+| `type`    | Enumm   | No       | No       | Either `attention`, `information`, or `complete`. This takes prescedence over current. Will render the current step with the given icon and color                                                                                                           |
+| `number`  | Number  | No       | No       | Renders the current step with the given number. Overrides the default number counting for this step                                                                                                                                                         |

--- a/src/components/ebay-progress-stepper/README.md
+++ b/src/components/ebay-progress-stepper/README.md
@@ -11,10 +11,22 @@
 
 ```marko
 <ebay-progress-stepper>
-    <@step>Started</@step>
-    <@step>Shipped</@step>
-    <@step current>Transit</@step>
-    <@step>Delivered</@step>
+    <@step>
+        <@title>Started</@title>
+        July 3rd
+    </@step>
+    <@step>
+        <@title>Shipped</@title>
+        July 4th
+    </@step>
+    <@step current>
+        <@title>Transit</@title>
+        July 5th
+    </@step>
+    <@step>
+        <@title>Delivered</@title>
+        July 6th
+    </@step>
 </ebay-progress-stepper>
 ```
 
@@ -26,11 +38,11 @@
 
 ## ebay-progress-stepper Attributes
 
-| Name                    | Type    | Stateful | Required | Description                                                                                                                                                                                                                                    |
-| ----------------------- | ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `direction`             | Enum    | No       | No       | Either 'column' or 'row'. Will display stepper as a vertical column or horizontal row. Default is 'row'                                                                                                                                        |
-| `default-state`         | Enum    | Yes      | No       | Either 'complete', 'upcoming' or 'active'. If complete, then all items will be in complete state by default. If upcoming, all items will be in upcoming state. Otherwise, the default (active), will change items based on the `current` item. |
-| `no-wrap-paragraph-tag` | Boolean | No       | No       | If true, will not add <p> tag to render body. defaults to false.                                                                                                                                                                               |
+| Name             | Type    | Stateful | Required | Description                                                                                                                                                                                                                                    |
+| ---------------- | ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `direction`      | Enum    | No       | No       | Either 'column' or 'row'. Will display stepper as a vertical column or horizontal row. Default is 'row'                                                                                                                                        |
+| `default-state`  | Enum    | Yes      | No       | Either 'complete', 'upcoming' or 'active'. If complete, then all items will be in complete state by default. If upcoming, all items will be in upcoming state. Otherwise, the default (active), will change items based on the `current` item. |
+| `auto-paragraph` | Boolean | No       | No       | Specify whether to auto wrap @step body text with a paragraph tag (default: true)                                                                                                                                                              |
 
 ## ebay-progress-stepper @step Sub-tags
 

--- a/src/components/ebay-progress-stepper/examples/01-direction/03-auto-paragraph-off/template.marko
+++ b/src/components/ebay-progress-stepper/examples/01-direction/03-auto-paragraph-off/template.marko
@@ -1,4 +1,4 @@
-<ebay-progress-stepper no-wrap-paragraph-tag=true direction="column">
+<ebay-progress-stepper auto-paragraph=false direction="column">
     <@step>
         <@title>Order placed</@title>
         <p>New Mens Addidas Ultra Boost</p>

--- a/src/components/ebay-progress-stepper/examples/01-direction/03-vertical-no-paragraph-tag/template.marko
+++ b/src/components/ebay-progress-stepper/examples/01-direction/03-vertical-no-paragraph-tag/template.marko
@@ -1,0 +1,15 @@
+<ebay-progress-stepper no-wrap-paragraph-tag=true direction="column">
+    <@step>
+        <@title>Order placed</@title>
+        <p>New Mens Addidas Ultra Boost</p>
+        <p>Order total $220</p>
+    </@step>
+    <@step current>
+        <@title>Preparing for shipment</@title>
+        <p>We will notify you once it ships.</p>
+    </@step>
+    <@step>
+        <@title>Delivered</@title>
+        <p>Guaranteed Wednesday, October 09.</p>
+    </@step>
+</ebay-progress-stepper>

--- a/src/components/ebay-progress-stepper/index.marko
+++ b/src/components/ebay-progress-stepper/index.marko
@@ -70,9 +70,14 @@ $ var current = findIndex(input.step || [], item => item.current);
                             <${item.title}/>
                         </>
                     </if>
-                    <p>
+                    <if(input.noWrapParagraphTag)>
                         <${item.renderBody}/>
-                    </p>
+                    </if>
+                    <else>
+                        <p>
+                            <${item.renderBody}/>
+                        </p>
+                    </else>
                 </span>
             </div>
         </for>

--- a/src/components/ebay-progress-stepper/index.marko
+++ b/src/components/ebay-progress-stepper/index.marko
@@ -70,13 +70,13 @@ $ var current = findIndex(input.step || [], item => item.current);
                             <${item.title}/>
                         </>
                     </if>
-                    <if(input.noWrapParagraphTag)>
-                        <${item.renderBody}/>
-                    </if>
-                    <else>
+                    <if(input.autoParagraph !== false)>
                         <p>
                             <${item.renderBody}/>
                         </p>
+                    </if>
+                    <else>
+                        <${item.renderBody}/>
                     </else>
                 </span>
             </div>

--- a/src/components/ebay-progress-stepper/marko-tag.json
+++ b/src/components/ebay-progress-stepper/marko-tag.json
@@ -8,7 +8,7 @@
   "@default-state": {
     "enum": ["upcoming", "complete", "active"]
   },
-  "@no-wrap-paragraph-tag": "boolean",
+  "@auto-paragraph": "boolean",
   "@direction": {
     "enum": ["row", "column"]
   },

--- a/src/components/ebay-progress-stepper/marko-tag.json
+++ b/src/components/ebay-progress-stepper/marko-tag.json
@@ -1,30 +1,19 @@
 {
-  "attribute-groups": [
-    "html-attributes"
-  ],
+  "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,
     "type": "expression"
   },
   "@html-attributes": "expression",
   "@default-state": {
-    "enum": [
-      "upcoming",
-      "complete",
-      "active"
-    ]
+    "enum": ["upcoming", "complete", "active"]
   },
-
+  "@no-wrap-paragraph-tag": "boolean",
   "@direction": {
-    "enum": [
-      "row",
-      "column"
-    ]
+    "enum": ["row", "column"]
   },
   "@step <step>[]": {
-    "attribute-groups": [
-      "html-attributes"
-    ],
+    "attribute-groups": ["html-attributes"],
     "@*": {
       "targetProperty": null,
       "type": "expression"
@@ -32,11 +21,7 @@
     "@html-attributes": "expression",
     "@current": "boolean",
     "@type": {
-      "enum": [
-        "attention",
-        "default",
-        "complete"
-      ]
+      "enum": ["attention", "default", "complete"]
     },
     "@number": "number"
   }


### PR DESCRIPTION
closes #1367 

## Description
<strike>This takes out the `<p>` tag from the progress stepper's index.marko file. 
Looking at the examples, it doesn't seem to break any. </strike>
<strike>This seemed like the best way to go. Giving more control to the user tends to work out pretty well. </strike>

Added ability to override auto paragraphing of @step body text.

## Screenshots

(old screenshot deleted)

![Screen Shot 2021-04-11 at 11 09 21 AM](https://user-images.githubusercontent.com/38065/114316003-75710a80-9ab6-11eb-868a-e3c0403af399.png)


