### PR TITLE
fix(ebay-video): fixed some async reloading problems

### DIFF
--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -3,6 +3,13 @@ const versions = require('./versions.json');
 const MAX_RETIRES = 3;
 
 module.exports = {
+    reattach(callback) {
+        if (this.isDetaching) {
+            setTimeout(() => this.reattach(callback), 10);
+        } else {
+            callback();
+        }
+    },
     isPlaylist(source) {
         const type = source.type && source.type.toLowerCase();
         const src = source.src;
@@ -88,10 +95,18 @@ module.exports = {
             .load(src.src)
             .then(() => {
                 this.state.isLoaded = true;
+                this.state.failed = false;
             })
-            .catch(() => {
+            .catch((err) => {
+                if (err.code === 7000) {
+                    // Load interrupted by another load, just return
+                    return;
+                } else if (err.code === 11) {
+                    // Retry, player is not loaded yet
+                    setTimeout(() => this._loadSrc(currentIndex), 0);
+                }
                 if (nextIndex) {
-                    this._loadSrc(nextIndex);
+                    setTimeout(() => this._loadSrc(nextIndex), 0);
                 } else {
                     this.state.failed = true;
                     this.state.isLoaded = true;
@@ -111,9 +126,11 @@ module.exports = {
                 shaka.polyfill.installAll();
 
                 this.video = this.getEl('video');
-                // eslint-disable-next-line no-undef,new-cap
-                this.player = new shaka.Player(this.video);
-                this._loadSrc();
+                this.reattach(() => {
+                    // eslint-disable-next-line no-undef,new-cap
+                    this.player = new shaka.Player(this.video);
+                    this._loadSrc();
+                });
             })
             .catch(() => {
                 clearTimeout(this.retryTimeout);
@@ -134,7 +151,10 @@ module.exports = {
 
     onDestroy() {
         if (this.player) {
-            this.player.destroy();
+            this.isDetaching = true;
+            this.player.destroy().then(() => {
+                this.isDetaching = false;
+            });
         }
     },
 

--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -1,6 +1,6 @@
 const loader = require('./loader');
 const versions = require('./versions.json');
-const MAX_RETIRES = 3;
+const MAX_RETRIES = 3;
 
 module.exports = {
     reattach(callback) {
@@ -135,7 +135,7 @@ module.exports = {
             .catch(() => {
                 clearTimeout(this.retryTimeout);
                 this.retryTimes += 1;
-                if (this.retryTimes < MAX_RETIRES) {
+                if (this.retryTimes < MAX_RETRIES) {
                     this.retryTimeout = setTimeout(() => this._loadCDN(cdnUrl), 2000);
                 } else {
                     this.state.failed = true;

--- a/src/components/ebay-video/index.marko
+++ b/src/components/ebay-video/index.marko
@@ -26,6 +26,7 @@ static var ignoredAttributes = [
         key="video"
         width=state.width
         controls
+        src:no-update
         on-playing(input.playView === "fullscreen" && "handleFullscreen")
         poster=input.thumbnail
         ...processHtmlAttributes(input, ignoredAttributes)


### PR DESCRIPTION
## Description
There is an issue on the examples when the component is rerendered it won't load the video anymore. This fixes it by retrying on error code 11 which is video not ready yet. 
Also added some other changes to check for retrying if the component is not destroyed yet since it uses an async way to do destroy. 