### PR TITLE
Storybook Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:ci": "npm run lint && node scripts/check-postpublish && npm test && npm run build",
     "build:readme": "node scripts/add-ds-version",
     "storybook:build": "DS=6 build-storybook -o ./docs && DS=4 build-storybook -o ./docs/ds4",
-    "storybook:start": "start-storybook -s demo/assets -p 6006",
+    "storybook:start": "start-storybook -p 6006",
     "importSVG": "node scripts/import-svg",
     "ts": "npm run test:server",
     "tb": "npm run test:browser",


### PR DESCRIPTION
## Description
There were issues running storybook, something related to webpack. 

I was unable to run storybook locally - it would crash. 

This adds a dependency, html-webpack-plugin, that was throwing out a warning, and now things work. 

Also checked - this works on safari and edge, code examples are working 👍 
