### PR TITLE
fix: dont rely on sync document.body for scroll helper

### DIFF
--- a/src/components/ebay-carousel/utils/scroll-transition/index.js
+++ b/src/components/ebay-carousel/utils/scroll-transition/index.js
@@ -1,5 +1,5 @@
 const onScrollEnd = require('../on-scroll-end');
-const supportsScrollBehavior = typeof window !== 'undefined' && 'scrollBehavior' in document.body.style;
+const supportsScrollBehavior = typeof window !== 'undefined' && 'scrollBehavior' in document.documentElement.style;
 
 /**
  * Utility to animate scroll position of an element using an `ease-out` curve over 250ms.


### PR DESCRIPTION
## Description
Currently the scroll transition helper relies on `document.body` to be available synchronously which causes issues when this module is loaded and executed via an async script in `<head>`. This PR fixes the issue by switching to `document.activeElement` for the check (`<html>`) which is guaranteed to be there.

