### PR TITLE
fix(menu-button): added collapeseOnSelect option to handleMenuSelect

### DIFF
--- a/src/components/ebay-menu-button/component.js
+++ b/src/components/ebay-menu-button/component.js
@@ -75,6 +75,10 @@ module.exports = assign({}, menuUtils, {
     },
 
     handleMenuSelect({ el, originalEvent, index }) {
+        if (this.input.collapseOnSelect) {
+            this.expander.collapse();
+        }
+
         this.emitComponentEvent({ eventType: 'select', el, originalEvent, index });
     },
     handleMousedown({ el, originalEvent }) {

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -21,7 +21,8 @@ static var ignoredAttributes = [
     "label",
     "textAlign",
     "prefixLabel",
-    "prefixId"
+    "prefixId",
+    "collapseOnSelect"
 ];
 
 $ var isOverflowVariant = input.variant === "overflow";


### PR DESCRIPTION
## Description
Added `collapseOnSelect` when calling `handleMenuSelect`

## References
https://github.com/eBay/ebayui-core/issues/1391
