### PR TITLE
feat: Added itemMatchesUrl to fake-menu, allows aria-current=true

### DIFF
--- a/src/components/ebay-fake-menu/README.md
+++ b/src/components/ebay-fake-menu/README.md
@@ -45,15 +45,16 @@
 
 ### @item Attributes
 
-| Name                          | Type    | Stateful | Required                               | Description                                                                 |
-| ----------------------------- | ------- | -------- | -------------------------------------- | --------------------------------------------------------------------------- |
-| `href` (fake menu)            | String  | No       | No                                     | for link that looks like a menu-item. If set to null then will disable item |
-| `type` (fake menu)            | String  | No       | No                                     | Set to "button" for fake menu-item `<button>`                               |
-| `value` (radio or checkbox)   | String  | No       | No                                     | the value to use with event responses for for the `checked` array           |
-| `checked` (radio or checkbox) | Boolean | No       | No                                     | whether or not the item is checked                                          |
-| `current` (fake menu)         | Boolean | No       | No                                     | whether or not the href is the current href of the page                     |
-| `badge-number`                | Number  | No       | No                                     | used as the number to be placed in the badge                                |
-| `badge-aria-label`            | String  | No       | Yes (only if badge number is provided) | passed as the `aria-label` directly to the badge                            |
+| Name                          | Type    | Stateful | Required                               | Description                                                                                                                                                                |
+| ----------------------------- | ------- | -------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `href`                        | String  | No       | No                                     | for link that looks like a menu-item. If set to null then will disable item                                                                                                |
+| `type`                        | String  | No       | No                                     | Set to "button" for fake menu-item `<button>`                                                                                                                              |
+| `value` (radio or checkbox)   | String  | No       | No                                     | the value to use with event responses for for the `checked` array                                                                                                          |
+| `checked` (radio or checkbox) | Boolean | No       | No                                     | whether or not the item is checked                                                                                                                                         |
+| `current`                     | Boolean | No       | No                                     | whether or not the href is the current href of the page                                                                                                                    |
+| `itemMatchesUrl`              | Boolean | No       | No                                     | used in conjunction with `current` -- This determines whether aria-current will be `'page'` or `'true'` -- Defaults to `true` which gives aria-current a value of `'page'` |
+| `badge-number`                | Number  | No       | No                                     | used as the number to be placed in the badge                                                                                                                               |
+| `badge-aria-label`            | String  | No       | Yes (only if badge number is provided) | passed as the `aria-label` directly to the badge                                                                                                                           |
 
 ## ebay-menu-separator
 

--- a/src/components/ebay-fake-menu/examples/06-item-matches-url/template.marko
+++ b/src/components/ebay-fake-menu/examples/06-item-matches-url/template.marko
@@ -1,0 +1,5 @@
+<ebay-fake-menu>
+    <@item href="#" current item-matches-url=false>item 1</@item>
+    <@item type="button">item 2</@item>
+    <@item href="#">item 3</@item>
+</ebay-fake-menu>

--- a/src/components/ebay-fake-menu/index.marko
+++ b/src/components/ebay-fake-menu/index.marko
@@ -41,6 +41,7 @@ $ var baseClass = input.classPrefix || "fake-menu";
         id:scoped="menu">
         <for|item, index| of=input.items>
             $ var isDisabled = !item.href || item.disabled;
+            $ var defaultAriaCurrent = item.itemMatchesUrl === false ? 'true' : 'page';
             <if (item._isSeparator)>
                 <li>
                     <hr class=`${baseClass}__separator` role="separator" />
@@ -52,7 +53,7 @@ $ var baseClass = input.classPrefix || "fake-menu";
                         ...processHtmlAttributes(item, itemIgnoredAttributes)
                         class=[`${baseClass}__item`, item.class]
                         style=item.style
-                        aria-current=(item.current ? "page" : false)
+                        aria-current=(item.current ? defaultAriaCurrent : false)
                         aria-disabled=(item.disabled && "true")
                         href=(item.disabled ? null : item.href)
                         onKeydown("handleItemKeydown", index)

--- a/src/components/ebay-fake-menu/marko-tag.json
+++ b/src/components/ebay-fake-menu/marko-tag.json
@@ -16,6 +16,7 @@
       "targetProperty": null,
       "type": "expression"
     },
+    "@item-matches-url": "boolean",
     "@html-attributes": "expression",
     "@class": "string",
     "@style": "string",

--- a/src/components/ebay-fake-menu/test/mock/index.js
+++ b/src/components/ebay-fake-menu/test/mock/index.js
@@ -15,6 +15,23 @@ exports.Basic_3Items = assign({}, exports.Basic_2Items, {
     })),
 });
 
+exports.A11y_Current_True = assign({}, exports.Basic_2Items, {
+    items: getNItems(3, (i) => {
+        if (i === 0) {
+            return {
+                current: 'true',
+                itemMatchesUrl: false,
+                value: `item ${i}`,
+                renderBody: createRenderBody(`Item text ${i}`),
+            };
+        }
+        return {
+            value: `item ${i}`,
+            renderBody: createRenderBody(`Item text ${i}`),
+        };
+    }),
+});
+
 exports.Separator_4Items = assign({}, exports.Basic_2Items, {
     items: getNItems(4, (i) => ({
         value: `item ${i}`,

--- a/src/components/ebay-fake-menu/test/test.server.js
+++ b/src/components/ebay-fake-menu/test/test.server.js
@@ -50,6 +50,15 @@ describe('fake-menu', () => {
         });
     });
 
+    it('renders with aria-current=true', async () => {
+        const input = mock.A11y_Current_True;
+        const { getByText } = await render(template, input);
+        const item = input.items[0];
+        const container = getByText(item.renderBody.text);
+        expect(container.parentElement).to.have.attribute('aria-current');
+        expect(container.parentElement).attr('aria-current', 'true');
+    });
+
     testUtils.testPassThroughAttributes(template);
     testUtils.testPassThroughAttributes(template, {
         child: {


### PR DESCRIPTION
## Description
Added itemMatchesUrl to the fake-menu @item, which allows the user to set aria-current to `true` instead of just page.


Right now it doesn't show the check mark when aria-current is set to `true` - @ianmcburnie is that the intention?

## References
closes #1395 

## Screenshots
![Screen Shot 2021-05-19 at 4 08 46 PM](https://user-images.githubusercontent.com/25092249/118896226-951cff00-b8bc-11eb-99f3-b6c3dd507379.png)
![Screen Shot 2021-05-19 at 4 09 05 PM](https://user-images.githubusercontent.com/25092249/118896228-95b59580-b8bc-11eb-8a1c-c07d4f6585bd.png)

