### PR TITLE
fix(dialog): added a check to remove traps only on modals

### DIFF
--- a/src/components/components/ebay-dialog-base/component.js
+++ b/src/components/components/ebay-dialog-base/component.js
@@ -236,9 +236,10 @@ module.exports = {
     /**
      * Releases the trap before each render and on destroy so
      * that Marko can update normally without the inserted dom nodes.
+     * Only releases on isModal dialogs
      */
     _release() {
-        if (this.isTrapped) {
+        if (this.isTrapped && this.input.isModal) {
             this.restoreTrap = this.state.open;
             screenReaderTrap.untrap(this.el);
             keyboardTrap.untrap(this.windowEl);


### PR DESCRIPTION
## Description
There's an issue with snackbar dialog, when it's on the page with another dialog and it gets rerendered, it will remove all the keyboard traps for other dialogs.
Added a fix for snackbar to NOT remove any traps since it is not a modal and does not add any traps
