### PR TITLE
fix(textbox): added input-size attribute to control textbox size

### DIFF
--- a/src/components/ebay-textbox/README.md
+++ b/src/components/ebay-textbox/README.md
@@ -27,6 +27,7 @@ Default input textbox:
 | Name                | Type    | Stateful | Required | Description                                                                                                            |
 | ------------------- | ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `fluid`             | Boolean | No       | No       |
+| `input-size`        | String  | No       | No       | either "regular" or "large". If large, then renders larger sized textbox                                               |
 | `multiline`         | Boolean | No       | No       | renders a multi-line texbox if true                                                                                    |
 | `invalid`           | Boolean | No       | No       | indicates a field-level error with red border if true                                                                  |
 | `button-aria-label` | String  | No       | No       | aria-label for postfix. Required to be set in order to render postfix button and attach a `textbox-button-click event` |

--- a/src/components/ebay-textbox/examples/21-large/template.marko
+++ b/src/components/ebay-textbox/examples/21-large/template.marko
@@ -1,0 +1,1 @@
+<ebay-textbox value="ebay-textbox" input-size="large"/>

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -3,8 +3,9 @@ import processHtmlAttributes from "../../common/html-attributes"
 static function toJSON() {
     return {
         floatingLabel: this.floatingLabel
-    }
+    };
 }
+
 static var ignoredAttributes = [
     "class",
     "style",
@@ -19,7 +20,8 @@ static var ignoredAttributes = [
 
 $ input.toJSON = toJSON;
 $ var isPostfix = !!input.postfixIcon;
-$ var hasIcon = (input.prefixIcon || isPostfix);
+$ var hasIcon = input.prefixIcon || isPostfix;
+$ var isLarge = input.inputSize === "large";
 $ var displayIcon = Boolean(!input.multiline && hasIcon);
 $ var id = input.id || component.getElId("textbox");
 $ var defaultTag = input.fluid ? "div" : "span";
@@ -42,7 +44,7 @@ $ var defaultTag = input.fluid ? "div" : "span";
             displayIcon && isPostfix && "textbox--icon-end"
         ]>
         <if(displayIcon && input.prefixIcon)>
-            <${input.prefixIcon} />
+            <${input.prefixIcon}/>
         </if>
         <${input.multiline ? "textarea" : "input"}
             ...processHtmlAttributes(input, ignoredAttributes)
@@ -51,6 +53,7 @@ $ var defaultTag = input.fluid ? "div" : "span";
             class=[
                 "textbox__control",
                 input.fluid && "textbox__control--fluid",
+                isLarge && "textbox__control--large"
             ]
             type=(!input.multiline && (input.type || "text"))
             value=(!input.multiline && input.value)
@@ -66,8 +69,11 @@ $ var defaultTag = input.fluid ? "div" : "span";
             <if(input.multiline && input.value)>${input.value}</if>
         </>
         <if(displayIcon && input.postfixIcon)>
-            <${input.buttonAriaLabel && "button"} class="icon-btn" aria-label=input.buttonAriaLabel on-click("handleButtonClick") >
-                <${input.postfixIcon} />
+            <${input.buttonAriaLabel && "button"}
+                class="icon-btn"
+                aria-label=input.buttonAriaLabel
+                on-click("handleButtonClick")>
+                <${input.postfixIcon}/>
             </>
         </if>
     </>

--- a/src/components/ebay-textbox/marko-tag.json
+++ b/src/components/ebay-textbox/marko-tag.json
@@ -30,6 +30,7 @@
     },
     "@html-attributes": "expression"
   },
+  "@input-size": "string",
   "@button-aria-label": "string",
   "@autocomplete": "#html-autocomplete",
   "@autofocus": "#html-autofocus",


### PR DESCRIPTION

## Description
Added `input-size` attribute. 
`size` is a reserved textbox attribute, used for the length of the input https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/size
So I called it `input-size` instead.

## References
https://github.com/eBay/ebayui-core/issues/1413

## Screenshots
<img width="616" alt="Screen Shot 2021-06-21 at 10 12 18 AM" src="https://user-images.githubusercontent.com/1755269/122801597-2fd07b00-d279-11eb-8fcc-e51f93f83019.png">

