### PR TITLE
fix(textbox): added large floating label

### DIFF
--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -25,7 +25,7 @@ $ var isLarge = input.inputSize === "large";
 $ var displayIcon = Boolean(!input.multiline && hasIcon);
 $ var id = input.id || component.getElId("textbox");
 $ var defaultTag = input.fluid ? "div" : "span";
-<${input.floatingLabel && defaultTag} class="floating-label">
+<${input.floatingLabel && defaultTag} class=["floating-label", isLarge && "floating-label--large"]>
     <if(input.floatingLabel)>
         <label
             for=id


### PR DESCRIPTION

## Description
Added large modifier for floating label on textbox.

## References
https://github.com/eBay/ebayui-core/issues/1416

## Screenshots
<img width="745" alt="Screen Shot 2021-06-22 at 9 07 17 AM" src="https://user-images.githubusercontent.com/1755269/122961493-4ccc8300-d339-11eb-9b05-9c313a65983e.png">
