### PR TITLE
fix(combobox): changed autocomplete to off

### DIFF
--- a/src/components/ebay-combobox/index.marko
+++ b/src/components/ebay-combobox/index.marko
@@ -64,7 +64,7 @@ $ var id = input.id || component.getElId("input")
             aria-autocomplete=component.autocomplete
             aria-roledescription=roledescription
             aria-haspopup="listbox"
-            autocomplete="new-password"
+            autocomplete="off"
             onBlur("handleComboboxBlur")
             onClick("handleComboboxClick")
             onKeydown("handleComboboxKeyDown")


### PR DESCRIPTION
## Description
This PR turns autocomplete to off for the combobox. This prevents autocomplete from appearing on top of our existing suggestions. 

## Context
This was an outstanding bug for a long time due to Chrome's refusal to respect `autocomplete="off"`. They made a change so that this seems to work now. Hopefully they don't change it back. 

## References
closes #819 

## Screenshots
![Screen Shot 2021-06-22 at 3 38 16 PM](https://user-images.githubusercontent.com/25092249/123008801-689f4b80-d370-11eb-9fd4-da9cb986f6fe.png)

