### PR TITLE
fix(button): removed span from icon-button

### DIFF
--- a/src/components/ebay-button/README.md
+++ b/src/components/ebay-button/README.md
@@ -13,6 +13,12 @@
 <ebay-button>text</ebay-button>
 ```
 
+## ebay-button (Icon variant) Usage
+
+```marko
+<ebay-button variant="icon" aria-label"Settings"><ebay-settings-icon/></ebay-button>
+```
+
 ## ebay-button Attributes
 
 | Name                 | Type    | Stateful | Required                               | Description                                                                                                     |

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -71,9 +71,7 @@ $ {
     type=(tag === "button" && (input.type || "button"))
     aria-disabled=(input.partiallyDisabled && "true")>
     $ var hasAriaLabel = Boolean(htmlAttributes["aria-label"]);
-    <${!hasAriaLabel ? null : "span"} aria-hidden="true">
-        <${input.renderBody}/>
-    </>
+    <${input.renderBody}/>
     <if(isBadged)>
         <ebay-badge
             number=input.badgeNumber


### PR DESCRIPTION
## Description
We had a span wrapper around the icon, which should not be there. Removed it since it serves no purpose.
Updated documentation for button

## References
https://github.com/eBay/skin/issues/1480

## Screenshots
<img width="302" alt="Screen Shot 2021-06-23 at 10 37 38 AM" src="https://user-images.githubusercontent.com/1755269/123143147-16f9ce00-d40f-11eb-8418-b4f479f3568b.png">
