### PR TITLE
fix(video): default empty array for sources and track; fixed typo - BACKPORT

### DIFF
--- a/src/components/ebay-video/index.marko
+++ b/src/components/ebay-video/index.marko
@@ -29,10 +29,10 @@ static var ignoredAttributes = [
             on-playing(input.playView === "fullscreen" && "handleFullscreen")
             poster=input.thumbnail
             ...processHtmlAttributes(input, ignoredAttributes)>
-            <for|src| of=input.sources>
+            <for|src| of=input.sources || []>
                 <source ...src/>
             </for>
-            <for|track| of=input.tack>
+            <for|track| of=input.track || []>
                 <track ...src/>
             </for>
         </video>


### PR DESCRIPTION
## Description
This PR adds an empty array default in ebay-video so it doesn't break if sources or track are undefined. Also fixes typo of `tack` to `track`.

## References


## Screenshots
no visual changes
