### PR TITLE
fix: issue with video tag losing event handlers after re-render

### DIFF
--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -270,6 +270,11 @@ module.exports = {
         this.video.volume = this.input.volume || 1;
         this.video.muted = this.input.muted || false;
 
+        this.subscribeTo(this.video)
+            .on('playing', this.handlePlaying.bind(this))
+            .on('pause', this.handlePause.bind(this))
+            .on('volumechange', this.handleVolumeChange.bind(this));
+
         this._loadVideo();
     },
 

--- a/src/components/ebay-video/index.marko
+++ b/src/components/ebay-video/index.marko
@@ -32,10 +32,6 @@ static var ignoredAttributes = [
         }>
         <video
             no-controls
-            src:no-update
-            on-playing("handlePlaying")
-            on-pause("handlePause")
-            on-volumechange("handleVolumeChange")
             poster=input.thumbnail
             ...processHtmlAttributes(input, ignoredAttributes)>
             <for|src| of=(input.sources || [])>


### PR DESCRIPTION
## Description
When an element under a `no-update` section re-renders, any event handlers are not re-attached.
This PR switches to manual subscriptions for the video tag events since it is under a `no-update` section.
