### PR TITLE
fix(section-notoce): moved aria-roledescription #1461

### DIFF
--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -21,10 +21,10 @@ $ var status = input.status;
 $ var prefixClass = input.prefixClass;
 <${input.root || "section"}
     aria-labelledby=(!input.noA11yLabel && component.elId('status'))
+    aria-roledescription=input.a11yRoleDescription
     class=[prefixClass, input.class]
     ...processHtmlAttributes(input, ignoredAttributes)>
     <${input.headerRoot || "div"} class=`${prefixClass}__header` id:scoped="status"
-        aria-roledescription=input.a11yRoleDescription
     >
 
         <if(input.icon !== "none")>

--- a/src/components/ebay-inline-notice/examples/knobs.js
+++ b/src/components/ebay-inline-notice/examples/knobs.js
@@ -3,5 +3,5 @@ const { text, select } = require('@storybook/addon-knobs');
 module.exports = () => ({
     status: select('status', [null, 'attention', 'confirmation', 'information'], null, 'Options'),
     icon: select('icon', ['default', 'none'], 'default', 'Options'),
-    a11yText: text('a11y-text', 'See this notice', 'Accessibility'),
+    a11yText: text('a11y-text', 'Attention', 'Accessibility'),
 });

--- a/src/components/ebay-page-notice/examples/knobs.js
+++ b/src/components/ebay-page-notice/examples/knobs.js
@@ -10,5 +10,5 @@ module.exports = () => ({
     icon: select('icon', ['default', 'none'], 'default', 'Options'),
     hasFooter: boolean('has footer?', false, 'Options'),
     hasTitle: boolean('has title?', false, 'Options'),
-    a11yText: text('a11y-text', 'See this notice', 'Accessibility'),
+    a11yText: text('a11y-text', 'Attention', 'Accessibility'),
 });

--- a/src/components/ebay-section-notice/examples/knobs.js
+++ b/src/components/ebay-section-notice/examples/knobs.js
@@ -4,6 +4,6 @@ module.exports = () => ({
     status: select('status', [null, 'attention', 'confirmation', 'information'], null, 'Options'),
     icon: select('icon', ['default', 'none'], 'default', 'Options'),
     hasFooter: boolean('has footer?', false, 'Options'),
-    a11yText: text('a11y-text', 'See this notice', 'Accessibility'),
-    a11yRoleDescription: text('a11y-role-description', '', 'Accessibility'),
+    a11yText: text('a11y-text', 'Attention', 'Accessibility'),
+    a11yRoleDescription: text('a11y-role-description', 'Notice', 'Accessibility'),
 });


### PR DESCRIPTION
Fixes #1461

Just a quick fix to move aria-roledescription to correct element (going forward I'm not sure `aria-roledescription` is something we want to keep, but at least it's on the right element now)

I also corrected a bad example label in the stories.