### PR TITLE
feat(video): removed thumbnail gradient, but kept it on video

### DIFF
--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -53,6 +53,7 @@ module.exports = {
         if (this.input.playView === 'fullscreen') {
             this.video.requestFullscreen();
         }
+        this.state.played = true;
         this.emit('play', { originalEvent, player: this.player });
     },
 
@@ -123,6 +124,7 @@ module.exports = {
             showLoading: false,
             isLoaded: true,
             failed: false,
+            played: false,
         };
     },
 

--- a/src/components/ebay-video/index.marko
+++ b/src/components/ebay-video/index.marko
@@ -17,7 +17,7 @@ static var ignoredAttributes = [
     "muted"
 ];
 
-<div key="root" class="video-player">
+<div key="root" class=["video-player", !state.played && input.thumbnail !== "" && "video-player--poster"]>
     <if(isBrowser && !input.width)>
         <subscribe
             to=window


### PR DESCRIPTION
## Description
This PR removes the thumbnail gradient, but keeps it on video.
For screenshots see accompanying skin PR [here](https://github.com/eBay/skin/pull/1513).

## References
closes #1458 



