### PR TITLE
fix(progress-bar): min is an invalid attribute

### DIFF
--- a/src/components/ebay-progress-bar/README.md
+++ b/src/components/ebay-progress-bar/README.md
@@ -8,18 +8,16 @@
 </h1>
 
 ```marko
-<ebay-progress-bar value=50 min=0 max=100 />
+<ebay-progress-bar value=50 max=100 />
 ```
 
 ## Description
 
 The progress bar gives an immediate, real-time visualisation of the current task completion status.
-The progress bar's value does not include its min, so giving a value <= min will set the value to min + 1
 
 ## Attributes
 
 | Name    | Type    | Stateful | Required | Description                |
 | ------- | ------- | -------- | -------- | -------------------------- |
 | `value` | Integer | No       | No       | HTML value of progress bar |
-| `min`   | Integer | No       | No       | HTML min. Defaults to 0    |
 | `max`   | Integer | No       | No       | HTML max. Defaults to 100  |

--- a/src/components/ebay-progress-bar/component.js
+++ b/src/components/ebay-progress-bar/component.js
@@ -1,9 +1,0 @@
-module.exports = {
-    getValue(value, min) {
-        const parsedValue = parseInt(value, 10);
-        if (parsedValue <= min) {
-            return min + 1;
-        }
-        return parsedValue;
-    },
-};

--- a/src/components/ebay-progress-bar/examples/04-custom-max/template.marko
+++ b/src/components/ebay-progress-bar/examples/04-custom-max/template.marko
@@ -1,3 +1,3 @@
 <div style="background-color: white; padding: 8px;">
-    <ebay-progress-bar value=100 min=25 max=125/>
+    <ebay-progress-bar value=100 max=125/>
 </div>

--- a/src/components/ebay-progress-bar/index.marko
+++ b/src/components/ebay-progress-bar/index.marko
@@ -1,13 +1,11 @@
 import processHtmlAttributes from "../../common/html-attributes"
 
-static var ignoredAttributes = ["class", "min", "max", "value"];
+static var ignoredAttributes = ["class", "max", "value"];
 
-$ var min = input.min || 0;
+$ var value = input.value || 0;
 $ var max = input.max || 100;
-$ var value = component.getValue(input.value, min);
 <progress
     ...processHtmlAttributes(input, ignoredAttributes)
     class=["progress-bar", input.class]
-    min=min
     max=max
     value=value/>

--- a/src/components/ebay-progress-bar/marko-tag.json
+++ b/src/components/ebay-progress-bar/marko-tag.json
@@ -7,6 +7,5 @@
   "@html-attributes": "expression",
   "@role": "never",
   "@value": "#html-value",
-  "@min": "#html-min",
   "@max": "#html-max"
 }


### PR DESCRIPTION
## Description
This PR fixes the progress bar by removing the 'min' attribute, which is not a valid HTML `<progress/>` tag attribute. 

## Context
https://github.com/eBay/skin/issues/1514

## References
closes #1467 

## Screenshots
<img width="578" alt="Screen Shot 2021-07-19 at 4 38 44 PM" src="https://user-images.githubusercontent.com/25092249/126240858-88d7c09d-f949-4f0d-a822-85a0aff9181c.png">
<img width="543" alt="Screen Shot 2021-07-19 at 4 38 48 PM" src="https://user-images.githubusercontent.com/25092249/126240860-c03ed50f-e3ab-443d-b1b2-dc72ce103e38.png">
<img width="557" alt="Screen Shot 2021-07-19 at 4 38 53 PM" src="https://user-images.githubusercontent.com/25092249/126240863-e10a732d-011d-4966-bb30-b738c75b0cfb.png">

