### PR TITLE
feat(video): place report text and icon on main controls bar

### DIFF
--- a/src/components/ebay-video/README.md
+++ b/src/components/ebay-video/README.md
@@ -30,7 +30,7 @@ For resizing, `ebay-video` supports fixed width or variable width. If no width i
 | `error-text`       | String  | No       | Yes      | The content for error when an either the library or video cannot load. Default is "An error has occurred"                   |
 | `a11y-report-text` | String  | No       | Yes      | The text for screen readers for the report menu popup. Default is "Report"                                                  |
 | `report-text`      | String  | No       | Yes      | The text for report button. Default is "Report"                                                                             |
-| `volume-slider`    | Boolean | Yes      | No       | True/False to keep or remove volume slider. Default is true                                                                 |
+| `volume-slider`    | Boolean | Yes      | No       | True/False to keep or remove volume slider. Default is False                                                                |
 
 ## @source Tag (required)
 

--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -11,7 +11,6 @@ const videoConfig = {
         'time_and_duration',
         'spacer',
         'mute',
-        'volume',
         'report',
         'fullscreen',
     ],
@@ -78,10 +77,13 @@ module.exports = {
 
     showControls() {
         const copyConfig = Object.assign({}, videoConfig);
-        if (this.state.volumeSlider === false) {
-            copyConfig.controlPanelElements = videoConfig.controlPanelElements.filter(
-                (item) => item !== 'volume'
-            );
+        copyConfig.controlPanelElements = [...videoConfig.controlPanelElements];
+        if (this.state.volumeSlider === true) {
+            const insertAt =
+                copyConfig.controlPanelElements.length - 2 > 0
+                    ? copyConfig.controlPanelElements.length - 2
+                    : copyConfig.controlPanelElements.length;
+            copyConfig.controlPanelElements.splice(insertAt, 0, 'volume');
         }
         this.ui.configure(copyConfig);
         this.video.controls = false;
@@ -114,14 +116,14 @@ module.exports = {
             this.state.action = input.action;
             this.takeAction();
         }
-        if (input.volumeSlider === false) {
-            this.state.volumeSlider = false;
+        if (input.volumeSlider === true) {
+            this.state.volumeSlider = input.volumeSlider;
         }
     },
 
     onCreate() {
         this.state = {
-            volumeSlider: true,
+            volumeSlider: false,
             action: '',
             showLoading: false,
             isLoaded: true,

--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -1,5 +1,5 @@
 const loader = require('./loader');
-const { getElements, flagSmallIcon, playIcon } = require('./elements');
+const { getElements, playIcon } = require('./elements');
 const versions = require('./versions.json');
 const MAX_RETRIES = 3;
 
@@ -12,10 +12,9 @@ const videoConfig = {
         'spacer',
         'mute',
         'volume',
-        'overflow_menu',
+        'report',
         'fullscreen',
     ],
-    overflowMenuButtons: ['report'],
 };
 
 module.exports = {
@@ -85,13 +84,6 @@ module.exports = {
             );
         }
         this.ui.configure(copyConfig);
-
-        // Clear overflow button to make it look like a report button
-        const moreVertButton = this.el.querySelector('.shaka-overflow-menu-button');
-        moreVertButton.classList.remove('material-icons-round');
-        moreVertButton.removeChild(moreVertButton.firstChild);
-        moreVertButton.setAttribute('aria-label', this.input.a11yReportText || 'Report this video');
-        flagSmallIcon.renderSync().appendTo(moreVertButton);
         this.video.controls = false;
     },
     takeAction() {
@@ -227,7 +219,7 @@ module.exports = {
         );
 
         // eslint-disable-next-line no-undef,new-cap
-        shaka.ui.OverflowMenu.registerElement('report', new Report.Factory());
+        shaka.ui.Controls.registerElement('report', new Report.Factory());
 
         // eslint-disable-next-line no-undef,new-cap
         shaka.ui.Controls.registerElement('captions', new TextSelection.Factory());

--- a/src/components/ebay-video/elements.js
+++ b/src/components/ebay-video/elements.js
@@ -1,11 +1,9 @@
 /* eslint-disable no-undef,new-cap */
 const flagIconTemplate = require('../ebay-icon/icons/ebay-report-flag-icon/index.marko');
-const flagSmallIconTemplate = require('../ebay-icon/icons/ebay-report-flag-small-icon/index.marko');
 const playIconTemplate = require('../ebay-icon/icons/ebay-video-play-icon/index.marko');
 
 // Marko 4 workaround
 const flagIcon = flagIconTemplate.default || flagIconTemplate;
-const flagSmallIcon = flagSmallIconTemplate.default || flagSmallIconTemplate;
 const playIcon = playIconTemplate.default || playIconTemplate;
 
 // Have to contain in order to not execute until shaka is downloaded
@@ -16,6 +14,7 @@ function getElements(self) {
 
             // The actual button that will be displayed
             this.button_ = document.createElement('button');
+            this.button_.classList.add('video-player__report-button');
 
             this.button_.textContent = text || 'Report';
             flagIcon.renderSync().prependTo(this.button_);
@@ -23,11 +22,6 @@ function getElements(self) {
 
             this.eventManager.listen(this.button_, 'click', () => {
                 self.emit('report');
-                controls.hideSettingsMenus();
-                controls
-                    .getControlsContainer()
-                    .querySelector('.shaka-overflow-menu-button')
-                    .focus();
             });
         }
     };
@@ -49,4 +43,4 @@ function getElements(self) {
     return { Report, TextSelection };
 }
 
-module.exports = { getElements, flagSmallIcon, playIcon };
+module.exports = { getElements, playIcon };

--- a/src/components/ebay-video/examples/11-with-volume-slider/template.marko
+++ b/src/components/ebay-video/examples/11-with-volume-slider/template.marko
@@ -1,7 +1,7 @@
 class {}
 
 <ebay-video
-    volume-slider=false
+    volume-slider=true
     width="600"
     height="400"
     on-load-error(err => {


### PR DESCRIPTION
## Description
This PR puts the report text and icon on the main controls bar. 

This works for all cases that view item needs, except that the developer must now detect mobile devices and put `volume-slider=false` on `ebay-video` for mobile, because with the volume slider, a mobile device viewing a video in vertical mode won't be able to see all of the controls. I have talked with view item and this works for them. 

## Context
The VI team wants the video on the main controls bar. 

## Screenshots
![Screen Shot 2021-07-20 at 3 26 11 PM](https://user-images.githubusercontent.com/25092249/126545288-a8f8efe7-071f-43a0-82b0-294fdfdc1cfe.png)
![Screen Shot 2021-07-20 at 3 27 34 PM](https://user-images.githubusercontent.com/25092249/126545296-fbce424b-aed7-4ed4-9b04-8591faf5499e.png)
![Screen Shot 2021-07-20 at 3 28 06 PM](https://user-images.githubusercontent.com/25092249/126545299-1d462d95-a1ec-4c92-a4ec-ba204f21d13b.png)

