### PR TITLE
fix(video): ios spinner times out after two seconds

### DIFF
--- a/src/components/ebay-video/README.md
+++ b/src/components/ebay-video/README.md
@@ -31,6 +31,7 @@ For resizing, `ebay-video` supports fixed width or variable width. If no width i
 | `a11y-report-text` | String  | No       | Yes      | The text for screen readers for the report menu popup. Default is "Report"                                                  |
 | `report-text`      | String  | No       | Yes      | The text for report button. Default is "Report"                                                                             |
 | `volume-slider`    | Boolean | Yes      | No       | True/False to keep or remove volume slider. Default is False                                                                |
+| `spinner-timeout`  | Number  | Yes      | No       | Timeout provided to timeout the spinner on iOS. The default is 2000ms.                                                      |
 
 ## @source Tag (required)
 

--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -2,6 +2,7 @@ const loader = require('./loader');
 const { getElements, playIcon } = require('./elements');
 const versions = require('./versions.json');
 const MAX_RETRIES = 3;
+const DEFAULT_SPINNER_TIMEOUT = 2000;
 
 const videoConfig = {
     addBigPlayButton: false,
@@ -237,6 +238,13 @@ module.exports = {
             const playButton = this.el.querySelector('.shaka-play-button');
             playButton.removeAttribute('icon');
             playIcon.renderSync().appendTo(playButton);
+
+            const shakaSpinner = this.el.querySelector('.shaka-spinner');
+            if (shakaSpinner) {
+                setTimeout(() => {
+                    shakaSpinner.hidden = true;
+                }, this.input.spinnerTimeout || DEFAULT_SPINNER_TIMEOUT);
+            }
         }
     },
 
@@ -272,7 +280,6 @@ module.exports = {
         this.root = this.getEl('root');
         this.video = this.root.querySelector('video');
         this.containerEl = this.root.querySelector('.video-player__container');
-
         this.video.volume = this.input.volume || 1;
         this.video.muted = this.input.muted || false;
 

--- a/src/components/ebay-video/examples/02-ios/template.marko
+++ b/src/components/ebay-video/examples/02-ios/template.marko
@@ -1,6 +1,6 @@
 class {}
 
-<ebay-video width="600" height="400">
+<ebay-video width="600" height="400" spinner-timeout=4000>
     <@source src="https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8" type="hls"/>
     <@source src="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd" type="dash"/>
 </ebay-video>

--- a/src/components/ebay-video/marko-tag.json
+++ b/src/components/ebay-video/marko-tag.json
@@ -33,5 +33,6 @@
     "@src": "string",
     "@type": "string"
   },
-  "@volume-slider": "boolean"
+  "@volume-slider": "boolean",
+  "@spinner-timeout": "number"
 }


### PR DESCRIPTION
## Description
This adds a timeout to the iOS spinner, then adds the attribute `hidden` to it.

## References
closes https://github.com/eBay/ebayui-core/issues/1460

## Screenshots
![hide-spinner](https://user-images.githubusercontent.com/25092249/127723461-3c254207-14a2-4d49-af92-4f5ff3818a2e.gif)

