### PR TITLE
fix(menu-button): passed noToggleIcon down to expand button

### DIFF
--- a/src/components/ebay-expand-button/index.marko
+++ b/src/components/ebay-expand-button/index.marko
@@ -11,6 +11,7 @@ static var ignoredAttributes = [
     "truncate",
     "fixedHeight",
     "partiallyDisabled",
+    "noToggleIcon",
     "toJSON"
 ];
 
@@ -38,6 +39,6 @@ $ var isIconOnly = input.iconOnly || !input.renderBody
                 <${input.renderBody}/>
             </span>
         </if>
-        <ebay-dropdown-icon/>
+        <if(!input.noToggleIcon)><ebay-dropdown-icon/></if>
     </span>
 </button>

--- a/src/components/ebay-expand-button/marko-tag.json
+++ b/src/components/ebay-expand-button/marko-tag.json
@@ -15,5 +15,6 @@
   "@autofocus": "#html-autofocus",
   "@disabled": "#html-disabled",
   "@type": "never",
-  "@aria-disabled": "never"
+  "@aria-disabled": "never",
+  "@no-toggle-icon": "boolean"
 }

--- a/src/components/ebay-fake-menu-button/index.marko
+++ b/src/components/ebay-fake-menu-button/index.marko
@@ -43,6 +43,7 @@ $ var isOverflowVariant = input.variant === "overflow";
         aria-expanded="false"
         aria-label=input.a11yText
         disabled=input.disabled
+        no-toggle-icon=input.noToggleIcon
         on-escape("handleButtonEscape")
         key="button">
         <if(isOverflowVariant)>
@@ -65,9 +66,6 @@ $ var isOverflowVariant = input.variant === "overflow";
                         <span>${input.text}</span>
                     </if>
                 </else>
-                <if(!input.noToggleIcon)>
-                    <ebay-dropdown-icon/>
-                </if>
             </span>
         </else>
     </>

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -52,6 +52,7 @@ $ debugger;
         aria-label=input.a11yText
         aria-labelledby=(labelId && `${input.prefixId} ${labelId}`)
         disabled=input.disabled
+        no-toggle-icon=input.noToggleIcon
         on-escape("handleButtonEscape")
         key="button">
         <if(isOverflowVariant)>
@@ -82,9 +83,6 @@ $ debugger;
                         <span id=labelId>${input.text}</span>
                     </if>
                 </else>
-                <if(!input.noToggleIcon)>
-                    <ebay-dropdown-icon/>
-                </if>
             </span>
         </else>
     </>


### PR DESCRIPTION
## Description
noToggleIcon property now gets passed down to the expandButton, as Andrew mentioned in our conversation earlier.


## References
closes #1491 

## Screenshots (apply to menu-button as well as fake-menu-button)
![Screen Shot 2021-08-17 at 4 34 18 PM](https://user-images.githubusercontent.com/25092249/129814213-ee389090-bb27-462a-9afa-0011233a442a.png)

### noToggleIcon = true
![Screen Shot 2021-08-17 at 4 34 33 PM](https://user-images.githubusercontent.com/25092249/129814214-aac19161-558d-4ba2-8fc0-b80cbf497fc3.png)

