### PR TITLE
fix(lightbox-dialog): made close button show in footer for infotip

### DIFF
--- a/src/components/ebay-lightbox-dialog/index.marko
+++ b/src/components/ebay-lightbox-dialog/index.marko
@@ -1,5 +1,5 @@
 $ var isMini = input.variant === "_mini";
-$ var buttonPosition = (isMini && "bottom") || input.buttonPosition || 'right';
+$ var buttonPosition = input.buttonPosition || 'right';
 
 <ebay-dialog-base
     ...input


### PR DESCRIPTION

## Description
There was a check to put infotip dialog close in footer. Removed that check since it's not needed

## References
https://github.com/eBay/ebayui-core/issues/1496

## Screenshots
<img width="1391" alt="Screen Shot 2021-08-23 at 2 55 20 PM" src="https://user-images.githubusercontent.com/1755269/130525132-ad465e57-78fd-4992-8d12-def628d3bb8e.png">
