### PR TITLE
fix(details): changed type to be alignment and added migrator

### DIFF
--- a/src/components/ebay-details/details.stories.js
+++ b/src/components/ebay-details/details.stories.js
@@ -23,7 +23,7 @@ export default {
 
     argTypes: {
         renderBody: {},
-        type: {
+        alignment: {
             type: 'options',
             description: 'The position of the details',
             table: {

--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -2,7 +2,7 @@ import processHtmlAttributes from "../../common/html-attributes"
 
 static function noop() {}
 
-static var ignoredAttributes = ["class", "open", "type", "size", "text", "toJSON"];
+static var ignoredAttributes = ["class", "open", "alignment", "size", "text", "toJSON"];
 
 $ input.toJSON = noop;
 <details
@@ -15,7 +15,7 @@ $ input.toJSON = noop;
     <summary class=[
         "details__summary",
         input.size === "small" && "details__summary--small",
-        input.type === "center" && "details__summary--center"
+        input.alignment === "center" && "details__summary--center"
     ]>
         <span class="details__label">${input.text}</span>
         <span class="details__icon" hidden>

--- a/src/components/ebay-details/migrator.js
+++ b/src/components/ebay-details/migrator.js
@@ -6,13 +6,15 @@ const { setAttributeIfPresent } = require('../../common/migrators');
  */
 
 function migratorMarko4(el, context) {
-    setAttributeIfPresent(el, context, 'on-details-toggle', 'on-toggle');
-    setAttributeIfPresent(el, context, 'on-details-click', 'on-click');
+    setAttributeIfPresent(el, context, 'type', 'alignment');
     return el;
 }
 
-function migratorMarko5() {
-    return;
+function migratorMarko5(path) {
+    const index = path.node.attributes.findIndex((a) => a.name === 'type');
+    if (index !== -1) {
+        path.node.attributes[index].name = 'alignment';
+    }
 }
 
 module.exports = function migrator(a, b) {

--- a/src/components/ebay-details/test/test.server.js
+++ b/src/components/ebay-details/test/test.server.js
@@ -1,9 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const {
-    testPassThroughAttributes,
-    testEventsMigrator,
-} = require('../../../common/test-utils/server');
+const { testPassThroughAttributes } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -42,12 +39,10 @@ describe('details', () => {
     });
 
     it('renders center version', async () => {
-        const input = Object.assign({}, mock.Default_Details, { type: 'center' });
+        const input = Object.assign({}, mock.Default_Details, { alignment: 'center' });
         const { getByText } = await render(template, input);
         expect(getByText(input.text).closest('summary')).has.class('details__summary--center');
     });
 
     testPassThroughAttributes(template);
 });
-
-testEventsMigrator(require('../migrator'), 'details', ['toggle', 'click'], '../index.marko');


### PR DESCRIPTION
## Description
Changed details attribute and added migrator in marko 5
I removed the old migrators because teams should be already migrated at this point.

## Context
* Need to add tests, Dylan was going to let me know how to
* Need to add a message to show that this was migrated. In marko 5 it seems like `context` doesn't have `deprecate anymore. 

## References
#1233 
