### PR TITLE
feat: renamed attributes and added migrators

### DIFF
--- a/src/common/migrators/index.js
+++ b/src/common/migrators/index.js
@@ -33,6 +33,19 @@ function setAttributeIfPresent(el, context, oldAttribute, newAttribute) {
     }
 }
 
+function setAttributeIfPresentV5(path, oldAttribute, newAttribute) {
+    const { node } = path;
+    const index = node.attributes.findIndex((a) => a.name === oldAttribute);
+
+    if (index !== -1) {
+        path.node.attributes[index].name = newAttribute;
+    }
+    if (oldAttribute.indexOf('-') > -1) {
+        // Convert on-something to onSomething
+        setAttributeIfPresentV5(path, convertToCamel(oldAttribute), convertToCamel(newAttribute));
+    }
+}
+
 function createIconFromAttribute(el, context, attribute) {
     if (el.hasAttribute(attribute) && typeof el.getAttributeValue(attribute).value === 'string') {
         context.deprecate(
@@ -49,5 +62,6 @@ function createIconFromAttribute(el, context, attribute) {
 
 module.exports = {
     setAttributeIfPresent,
+    setAttributeIfPresentV5,
     createIconFromAttribute,
 };

--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -3,6 +3,7 @@ import processHtmlAttributes from "../../../common/html-attributes"
 static var ignoredAttributes = [
     "status",
     "a11yText",
+    "a11yIconText",
     "icon",
     "iconClass",
     "class",
@@ -30,20 +31,20 @@ $ var prefixClass = input.prefixClass;
         <if(input.icon !== "none")>
             <if(status === "confirmation" || status === "celebration")>
                 <ebay-confirmation-filled-icon
-                    a11y-text=input.a11yText
+                    a11y-text=(input.a11yIconText || input.a11yText)
                     a11y-variant="label"
                     class=input.iconClass/>
             </if>
             <else-if(status === "attention")>
                 <ebay-attention-filled-icon
                     a11y-variant="label"
-                    a11y-text=input.a11yText
+                    a11y-text=(input.a11yIconText || input.a11yText)
                     class=input.iconClass/>
             </else-if>
             <else-if(status === "information")>
                 <ebay-information-filled-icon
                     a11y-variant="label"
-                    a11y-text=input.a11yText
+                    a11y-text=(input.a11yIconText || input.a11yText)
                     class=input.iconClass/>
             </else-if>
         </if>

--- a/src/components/ebay-details/README.md
+++ b/src/components/ebay-details/README.md
@@ -15,13 +15,13 @@
 
 ## Attributes
 
-| Name   | Type    | Stateful | Required | Description                                    |
-| ------ | ------- | -------- | -------- | ---------------------------------------------- |
-| `text` | String  | No       | No       | The text to display in the details toggle      |
-| `type` | String  | No       | No       | Can be "regular" / "center". Default "regular" |
-| `size` | String  | No       | No       | Can be "regular" / "small". Default "regular"  |
-| `open` | Boolean | No       | No       | Whether details is open.                       |
-| `as`   | String  | No       | No       | The root element. Defaults to `<p>`            |
+| Name        | Type    | Stateful | Required | Description                                    |
+| ----------- | ------- | -------- | -------- | ---------------------------------------------- |
+| `text`      | String  | No       | No       | The text to display in the details toggle      |
+| `alignment` | String  | No       | No       | Can be "regular" / "center". Default "regular" |
+| `size`      | String  | No       | No       | Can be "regular" / "small". Default "regular"  |
+| `open`      | Boolean | No       | No       | Whether details is open.                       |
+| `as`        | String  | No       | No       | The root element. Defaults to `<p>`            |
 
 ## Events
 

--- a/src/components/ebay-details/migrator.js
+++ b/src/components/ebay-details/migrator.js
@@ -1,4 +1,4 @@
-const { setAttributeIfPresent } = require('../../common/migrators');
+const { setAttributeIfPresent, setAttributeIfPresentV5 } = require('../../common/migrators');
 
 /**
  * @description
@@ -11,10 +11,7 @@ function migratorMarko4(el, context) {
 }
 
 function migratorMarko5(path) {
-    const index = path.node.attributes.findIndex((a) => a.name === 'type');
-    if (index !== -1) {
-        path.node.attributes[index].name = 'alignment';
-    }
+    setAttributeIfPresentV5(path, 'type', 'alignment');
 }
 
 module.exports = function migrator(a, b) {

--- a/src/components/ebay-fake-tabs/index.marko
+++ b/src/components/ebay-fake-tabs/index.marko
@@ -17,8 +17,7 @@ $ var tabAriaCurrent = input.tabMatchesCurrentUrl === false ? "true" : "page";
                 ...processHtmlAttributes(tab, itemAnchorIgnoredAttributes)
                 class=[
                     tab.class,
-                    "fake-tabs__item",
-                    isSelected && "fake-tabs__item--current"
+                    "fake-tabs__item"
                 ]>
                 <a aria-current=( isSelected && tabAriaCurrent) href=tab.href>
                     <${tab.renderBody}/>

--- a/src/components/ebay-infotip/README.md
+++ b/src/components/ebay-infotip/README.md
@@ -26,17 +26,17 @@
 
 ## ebay-infotip Attributes
 
-| Name              | Type    | Stateful | Required | Description                                                                                                                                                  |
-| ----------------- | ------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `variant`         | String  | No       | No       | Either modal or default. If modal will show the mobile version of infotip                                                                                    |
-| `pointer`         | String  | No       | No       | options are `top-left`, `top`, `top-right`, `right`, `right-bottom`, `right-top`, `bottom-left`, `bottom-right`, `bottom`, `left`, `left-bottom`, `left-top` |
-| `disabled`        | Boolean | Yes      | No       | adds a `disabled` attribute to the button                                                                                                                    |
-| `style-top`       | String  | No       | No       | a style property for the CSS `top` rule                                                                                                                      |
-| `style-left`      | String  | No       | No       | a style property for the CSS `left` rule                                                                                                                     |
-| `style-right`     | String  | No       | No       | a style property for the CSS `right` rule                                                                                                                    |
-| `style-bottom`    | String  | No       | No       | a style property for the CSS `bottom` rule                                                                                                                   |
-| `a11y-close-text` | String  | No       | Yes      | A11y text for close button                                                                                                                                   |
-| `aria-label`      | String  | No       | Yes      | A descriptive label of what the infotip button represents (e.g. "Important information")                                                                     |
+| Name                     | Type    | Stateful | Required | Description                                                                                                                                                  |
+| ------------------------ | ------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `variant`                | String  | No       | No       | Either modal or default. If modal will show the mobile version of infotip                                                                                    |
+| `pointer`                | String  | No       | No       | options are `top-left`, `top`, `top-right`, `right`, `right-bottom`, `right-top`, `bottom-left`, `bottom-right`, `bottom`, `left`, `left-bottom`, `left-top` |
+| `disabled`               | Boolean | Yes      | No       | adds a `disabled` attribute to the button                                                                                                                    |
+| `style-top`              | String  | No       | No       | a style property for the CSS `top` rule                                                                                                                      |
+| `style-left`             | String  | No       | No       | a style property for the CSS `left` rule                                                                                                                     |
+| `style-right`            | String  | No       | No       | a style property for the CSS `right` rule                                                                                                                    |
+| `style-bottom`           | String  | No       | No       | a style property for the CSS `bottom` rule                                                                                                                   |
+| `a11y-close-button-text` | String  | No       | Yes      | A11y text for close button                                                                                                                                   |
+| `aria-label`             | String  | No       | Yes      | A descriptive label of what the infotip button represents (e.g. "Important information")                                                                     |
 
 **IMPORTANT:** In order for the `ebay-infotip` type to meet accessibility standards you must supply an `aria-label` attribute.
 

--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -9,7 +9,7 @@ static var ignoredAttributes = [
     "styleRight",
     "styleBottom",
     "ariaLabel",
-    "a11yCloseText",
+    "a11yCloseButtonText",
     "host",
     "heading",
     "content",
@@ -59,7 +59,7 @@ $ var pointer = input.pointer || "bottom";
                     pointer=pointer
                     heading=input.heading
                     content=input.content
-                    a11y-close-text=input.a11yCloseText
+                    a11y-close-text=input.a11yCloseButtonText
                     onOverlay-close("handleOverlayClose")/>
             </if>
             <else>
@@ -67,7 +67,7 @@ $ var pointer = input.pointer || "bottom";
                     open=state.open
                     class=[`${classPrefix}__overlay`]
                     variant="_mini"
-                    a11y-close-text=input.a11yCloseText
+                    a11y-close-text=input.a11yCloseButtonText
                     on-open("handleExpand")
                     on-close("handleCollapse")
                     aria-label=input.ariaLabel>

--- a/src/components/ebay-infotip/marko-tag.json
+++ b/src/components/ebay-infotip/marko-tag.json
@@ -31,7 +31,7 @@
   "@style-bottom": "string",
   "@aria-label": "string",
   "@variant": "string",
-  "@a11y-close-text": "string",
+  "@a11y-close-button-text": "string",
   "@icon <icon>": {
     "attribute-groups": ["html-attributes"],
     "@*": {

--- a/src/components/ebay-infotip/test/mock/index.js
+++ b/src/components/ebay-infotip/test/mock/index.js
@@ -19,7 +19,7 @@ exports.Disabled = Object.assign({}, exports.WithContent, {
 
 exports.ModalWithContent = Object.assign({}, exports.WithContent, {
     variant: 'modal',
-    a11yCloseText: 'Close mini dialog',
+    a11yCloseButtonText: 'Close mini dialog',
 });
 
 exports.ModalDisabled = Object.assign({}, exports.ModalWithContent, {

--- a/src/components/ebay-infotip/test/test.browser.js
+++ b/src/components/ebay-infotip/test/test.browser.js
@@ -96,7 +96,7 @@ describe('given the modal infotip opened', () => {
 
     describe('when the host element is opened and then closed', () => {
         beforeEach(async () => {
-            await fireEvent.click(component.getByLabelText(input.a11yCloseText));
+            await fireEvent.click(component.getByLabelText(input.a11yCloseButtonText));
         });
 
         it('then it emits the collapse event', async () => {

--- a/src/components/ebay-infotip/test/test.server.js
+++ b/src/components/ebay-infotip/test/test.server.js
@@ -1,11 +1,6 @@
 const { expect, use } = require('chai');
 const { render } = require('@marko/testing-library');
-const {
-    runTransformer,
-    testEventsMigrator,
-    testAttributeRenameMigrator,
-} = require('../../../common/test-utils/server');
-const migrator = require('../migrator');
+const { testAttributeRenameMigrator } = require('../../../common/test-utils/server');
 const template = require('..');
 const mock = require('./mock');
 
@@ -41,7 +36,7 @@ describe('infotip modal', () => {
         const { getByLabelText, getAllByLabelText, getByText } = await render(template, input);
         expect(getAllByLabelText(input.ariaLabel)[0]).has.class('dialog--mini__host');
         expect(getByText(input.content.renderBody.text)).has.class('lightbox-dialog__main');
-        expect(getByLabelText(input.a11yCloseText)).has.class('lightbox-dialog__close');
+        expect(getByLabelText(input.a11yCloseButtonText)).has.class('lightbox-dialog__close');
     });
 
     it('renders modal infotip without header', async () => {
@@ -52,47 +47,11 @@ describe('infotip modal', () => {
 });
 
 describe('migrator', () => {
-    const componentPath = '../index.marko';
-
-    it('transforms an icon attribute into a tag', () => {
-        const tagString = '<ebay-infotip icon="settings"/>';
-        const { el } = runTransformer(migrator, tagString, componentPath);
-        const {
-            body: {
-                array: [iconEl],
-            },
-        } = el;
-        const {
-            body: {
-                array: [tag],
-            },
-        } = iconEl;
-        expect(iconEl.tagName).to.equal('@icon');
-        expect(tag.tagName).to.equal('ebay-settings-icon');
-    });
-
-    it('does not transform when icon attribute is missing', () => {
-        const tagString = '<ebay-infotip/>';
-        const { el } = runTransformer(migrator, tagString, componentPath);
-        const {
-            body: {
-                array: [iconEl],
-            },
-        } = el;
-        expect(iconEl).to.equal(undefined);
-    });
-
-    testEventsMigrator(
-        require('../migrator'),
-        { event: 'tooltip', component: 'infotip' },
-        ['expand', 'collapse'],
-        '../index.marko'
-    );
     testAttributeRenameMigrator(
         require('../migrator'),
         'infotip',
-        'modal',
-        'variant',
+        'a11yCloseText',
+        'a11yCloseButtonText',
         '../index.marko'
     );
 });

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -29,7 +29,6 @@ static var ignoredAttributes = [
 
 $ var isOverflowVariant = input.variant === "overflow";
 $ var labelId = input.prefixId && component.getElId("label");
-$ debugger;
 
 <span
     ...processHtmlAttributes(input, ignoredAttributes)

--- a/src/components/ebay-page-notice/README.md
+++ b/src/components/ebay-page-notice/README.md
@@ -36,8 +36,8 @@ The `<ebay-page-notice>` is a tag used to create a custom-designed notice elemen
 
 ## ebay-page-notice Attributes
 
-| Name        | Type   | Stateful | Required | Description                                                                                    |
-| ----------- | ------ | -------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `status`    | String | No       | No       | "attention" (default for "page" and "inline"), "confirmation" "information", or "celebration". |
-| `a11y-text` | String | No       | Yes      | adding description for the notice for a11y users                                               |
-| `icon`      | String | Yes      | No       | "default" (matches whatever is specified by the "status") or "none"                            |
+| Name             | Type   | Stateful | Required | Description                                                                                    |
+| ---------------- | ------ | -------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `status`         | String | No       | No       | "attention" (default for "page" and "inline"), "confirmation" "information", or "celebration". |
+| `a11y-icon-text` | String | No       | Yes      | adding description for the notice for a11y users                                               |
+| `icon`           | String | Yes      | No       | "default" (matches whatever is specified by the "status") or "none"                            |

--- a/src/components/ebay-page-notice/marko-tag.json
+++ b/src/components/ebay-page-notice/marko-tag.json
@@ -1,4 +1,5 @@
 {
+  "migrator": "./migrator.js",
   "attribute-groups": ["html-attributes"],
   "@*": {
     "targetProperty": null,
@@ -9,7 +10,7 @@
     "enum": ["attention", "confirmation", "information", "celebration"]
   },
   "@icon": "string",
-  "@a11y-text": "string",
+  "@a11y-icon-text": "string",
   "@title <title>": {
     "attribute-groups": ["html-attributes"],
     "@*": {

--- a/src/components/ebay-page-notice/migrator.js
+++ b/src/components/ebay-page-notice/migrator.js
@@ -1,11 +1,11 @@
 const { setAttributeIfPresent, setAttributeIfPresentV5 } = require('../../common/migrators');
 
 function migratorMarko4(el, context) {
-    setAttributeIfPresent(el, context, 'a11y-close-text', 'a11y-close-button-text');
+    setAttributeIfPresent(el, context, 'a11y-text', 'a11y-icon-text');
 }
 
 function migratorMarko5(path) {
-    setAttributeIfPresentV5(path, 'a11y-close-text', 'a11y-close-button-text');
+    setAttributeIfPresentV5(path, 'a11y-text', 'a11y-icon-text');
 }
 
 module.exports = function migrator(a, b) {

--- a/src/components/ebay-page-notice/page-notice.stories.js
+++ b/src/components/ebay-page-notice/page-notice.stories.js
@@ -46,8 +46,8 @@ export default {
             type: 'select',
             description: 'matches whatever is specified by the "status", or if none hides icon',
         },
-        a11yText: {
-            description: 'adding description for the notice for a11y users',
+        a11yIconText: {
+            description: 'adding description for the icon in the notice for a11y users',
         },
 
         title: {


### PR DESCRIPTION
## Description
* Changed infotip attribute: rename a11y-close-text to a11y-close-button-text
* Changed page-notice attribute: rename a11y-text to a11y-icon-text
* Removed `.fake-tabs__item--current`
* Added migrators and made a common migrator helper

## Context
I worked a bit trying to get some tests to work. Will revisit tests next week and get them to work before the final release (but not before prerelease)

## References
https://github.com/eBay/ebayui-core/issues/1233
