### PR TITLE
1477 breadcrumbs current item tab order

### DIFF
--- a/src/components/ebay-breadcrumbs/breadcrumbs.stories.js
+++ b/src/components/ebay-breadcrumbs/breadcrumbs.stories.js
@@ -2,6 +2,7 @@ import breadcrumb1 from './examples/01-breadcrumb-heading-level/template.marko';
 import breadcrumb2 from './examples/02-last-page-as-current/template.marko';
 import breadcrumb3 from './examples/03-last-page-as-parent/template.marko';
 import breadcrumb4 from './examples/04-page-with-custom-attributes/template.marko';
+import breadcrumb5 from './examples/05-buttons-breadcrumbs/template.marko';
 import Readme from './README.md';
 
 // const Template = (args) => ({ input: args });
@@ -42,5 +43,13 @@ export const pageCustomAttribute = () => ({
     component: breadcrumb4,
 });
 pageCustomAttribute.parameters = {
+    controls: { hideNoControlsWarning: true },
+};
+
+export const buttons = () => ({
+    component: breadcrumb5,
+});
+
+buttons.parameters = {
     controls: { hideNoControlsWarning: true },
 };

--- a/src/components/ebay-breadcrumbs/examples/02-last-page-as-current/template.marko
+++ b/src/components/ebay-breadcrumbs/examples/02-last-page-as-current/template.marko
@@ -2,5 +2,5 @@
     <@item href="http://www.ebay.com/">eBay</@item>
     <@item href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches & Accessories</@item>
     <@item href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</@item>
-    <@item href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906">Smart Watch Bands</@item>
+    <@item>Smart Watch Bands</@item>
 </ebay-breadcrumbs>

--- a/src/components/ebay-breadcrumbs/examples/03-last-page-as-parent/template.marko
+++ b/src/components/ebay-breadcrumbs/examples/03-last-page-as-parent/template.marko
@@ -2,5 +2,5 @@
     <@item href="http://www.ebay.com/">eBay</@item>
     <@item href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches & Accessories</@item>
     <@item href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</@item>
-    <@item>Smart Watch Bands</@item>
+    <@item href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906">Smart Watch Bands</@item>
 </ebay-breadcrumbs>

--- a/src/components/ebay-breadcrumbs/examples/05-buttons-breadcrumbs/template.marko
+++ b/src/components/ebay-breadcrumbs/examples/05-buttons-breadcrumbs/template.marko
@@ -1,0 +1,6 @@
+<ebay-breadcrumbs a11y-heading-text="Page navigation">
+    <@item>eBay</@item>
+    <@item>Cell Phones, Smart Watches & Accessories</@item>
+    <@item>Smart Watch Accessories</@item>
+    <@item>Smart Watch Bands</@item>
+</ebay-breadcrumbs>

--- a/src/components/ebay-breadcrumbs/index.marko
+++ b/src/components/ebay-breadcrumbs/index.marko
@@ -10,6 +10,7 @@ static var ignoredAttributes = [
 ];
 
 $ input.toJSON = noop;
+$ var anyHref = (input.items || []).some(element => element.href != null);
 <nav
     ...processHtmlAttributes(input, ignoredAttributes)
     aria-labelledby:scoped="breadcrumbs-heading"
@@ -23,7 +24,7 @@ $ input.toJSON = noop;
             <li>
                 $ var isLast = i === input.items.length - 1;
                 $ var current = !item.href && isLast;
-                <${item.href ? "a" : "button"}
+                <${anyHref ? "a" : "button"}
                     ...processHtmlAttributes(item)
                     aria-current=(current && "location")
                     onClick(!current && "handleClick")>

--- a/src/components/ebay-breadcrumbs/mock/index.js
+++ b/src/components/ebay-breadcrumbs/mock/index.js
@@ -12,10 +12,10 @@ exports.Buttons = {
         renderBody: createRenderBody(`Item Text ${i}`),
     })),
 };
-exports.Links_First_Without_HREF = {
+exports.Links_Last_Without_HREF = {
     a11yHeadingText: 'Page navigation',
     items: getNItems(3, (i) => ({
-        href: i === 0 || i === 2 ? undefined : '#',
+        href: i === 2 ? undefined : '#',
         renderBody: createRenderBody(`Item Text ${i}`),
     })),
 };

--- a/src/components/ebay-breadcrumbs/test/test.browser.js
+++ b/src/components/ebay-breadcrumbs/test/test.browser.js
@@ -12,7 +12,6 @@ let component;
 describe('given a basic breadcrumb', () => {
     const input = mock.Links;
     const firstItem = input.items[0];
-    const lastItem = input.items[input.items.length - 1];
 
     beforeEach(async () => {
         component = await render(template, input);
@@ -26,6 +25,15 @@ describe('given a basic breadcrumb', () => {
         it('then it emits the select event with correct data', () => {
             expect(component.emitted('select')).has.length(1);
         });
+    });
+});
+
+describe('button', () => {
+    const input = mock.Buttons;
+    const lastItem = input.items[input.items.length - 1];
+
+    beforeEach(async () => {
+        component = await render(template, input);
     });
 
     describe('when a <button> is clicked', () => {

--- a/src/components/ebay-breadcrumbs/test/test.server.js
+++ b/src/components/ebay-breadcrumbs/test/test.server.js
@@ -16,37 +16,25 @@ describe('breadcrumbs', () => {
 
         expect(getByLabelText(input.a11yHeadingText)).has.attr('role', 'navigation');
 
-        input.items
-            .slice(0, -1)
-            .forEach((item) =>
-                expect(getByText(item.renderBody.text)).has.property('tagName', 'A')
-            );
-
-        expect(getByText(input.items[input.items.length - 1].renderBody.text)).has.property(
-            'tagName',
-            'BUTTON'
-        );
-    });
-
-    it('renders buttons when hrefs are missing', async () => {
-        const input = mock.Buttons;
-        const { getByText } = await render(template, input);
         input.items.forEach((item) =>
-            expect(getByText(item.renderBody.text)).has.property('tagName', 'BUTTON')
+            expect(getByText(item.renderBody.text)).has.property('tagName', 'A')
         );
     });
 
-    it('renders <button> for missing input href item', async () => {
-        const input = mock.Links_First_Without_HREF;
+    it('renders aria-current as location for last item without href', async () => {
+        const input = mock.Links_Last_Without_HREF;
         const { getByText } = await render(template, input);
 
-        input.items.slice(0, -1).forEach((item) => {
+        input.items.forEach((item, i) => {
             const itemEl = getByText(item.renderBody.text);
+            expect(itemEl).has.property('tagName', 'A');
             if (item.href) {
-                expect(itemEl).has.property('tagName', 'A');
                 expect(itemEl).has.attr('href', item.href);
+            } else if (i === input.items.length - 1) {
+                expect(itemEl).attr('aria-current', 'location');
             } else {
-                expect(itemEl).has.property('tagName', 'BUTTON');
+                // error state, because for this test, each item should either have an href or aria-current for the last one
+                expect(true).to.equal(false);
             }
         });
     });
@@ -57,6 +45,14 @@ describe('breadcrumbs', () => {
         expect(getByText(input.a11yHeadingText)).has.property(
             'tagName',
             input.a11yHeadingTag.toUpperCase()
+        );
+    });
+
+    it('renders buttons when hrefs are missing', async () => {
+        const input = mock.Buttons;
+        const { getByText } = await render(template, input);
+        input.items.forEach((item) =>
+            expect(getByText(item.renderBody.text)).has.property('tagName', 'BUTTON')
         );
     });
 });


### PR DESCRIPTION
## Description
The last breadcrumb can no longer be tabbed if it doesn't have an href. Just had to get rid of the button - Ian said we should be consistent and only have buttons or anchor tags in the breadcrumbs, and not mix them.

## Context
had to delete some tests to make this work

## References
closes #1477 

## Screenshots

## anchor with no href on last item
![breadcrumbs-tab](https://user-images.githubusercontent.com/25092249/130877488-4590478d-64a3-44b7-8baa-dc2285154394.gif)

## buttons

![breadcrumbs-tab-buttons](https://user-images.githubusercontent.com/25092249/131040754-0a14874e-df67-4ce8-a9dc-ccb953b9220e.gif)


