### PR TITLE
fix(listbox): added listboxSelection option with auto/manual

### DIFF
--- a/src/components/ebay-listbox-button/README.md
+++ b/src/components/ebay-listbox-button/README.md
@@ -35,16 +35,17 @@ When a selected option is specified:
 
 ### ebay-listbox-button Attributes
 
-| Name           | Type    | Stateful | Required | Description                                                                                                         |
-| -------------- | ------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `name`         | String  | No       | Yes      | used for the `name` attribute of the native `<select>`                                                              |
-| `selected`     | Number  | Yes      | n/a      | allows you to set the selected index option to `selected`                                                           |
-| `borderless`   | Boolean | No       | No       | whether button has borders                                                                                          |
-| `fluid`        | Boolean | No       | No       | whether listbox width is 100%                                                                                       |
-| `buttonName`   | String  | No       | Yes      | used for the `name` attribute of the native `<button>`                                                              |
-| `truncate`     | Boolean | No       | No       | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows     |
-| `prefix-id`    | String  | No       | No       | The id of an external element to use as the prefix label for the listbox button. Cannot be used with `prefix-label` |
-| `prefix-label` | String  | No       | No       | The label to add before each selected item on the button. Cannot be used with `prefix-id`                           |
+| Name             | Type    | Stateful | Required | Description                                                                                                                                                             |
+| ---------------- | ------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`           | String  | No       | Yes      | used for the `name` attribute of the native `<select>`                                                                                                                  |
+| `selected`       | Number  | Yes      | n/a      | allows you to set the selected index option to `selected`                                                                                                               |
+| `borderless`     | Boolean | No       | No       | whether button has borders                                                                                                                                              |
+| `fluid`          | Boolean | No       | No       | whether listbox width is 100%                                                                                                                                           |
+| `buttonName`     | String  | No       | Yes      | used for the `name` attribute of the native `<button>`                                                                                                                  |
+| `truncate`       | Boolean | No       | No       | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows                                                         |
+| `prefix-id`      | String  | No       | No       | The id of an external element to use as the prefix label for the listbox button. Cannot be used with `prefix-label`                                                     |
+| `prefix-label`   | String  | No       | No       | The label to add before each selected item on the button. Cannot be used with `prefix-id`                                                                               |
+| `list-selection` | String  | Yes      | n/a      | either "auto" or "manual" (default). If auto when using up/down key automatically selects the item. If manual then you have to press enter/space key to select an item. |
 
 **Note:** For this component, `class` is applied to the root tag, while all other HTML attributes are applied to the `input` tag.
 

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -55,6 +55,7 @@ $ var labelId = input.prefixId && component.getElId("label");
         class="listbox-button__listbox"
         name=input.name
         tabindex=-1
+        list-selection=input.listSelection
         on-change("handleListboxChange")>
         <for|option| of=input.options>
             <@option ...option selected=(selectedOption === option)/>

--- a/src/components/ebay-listbox-button/listbox-button.stories.js
+++ b/src/components/ebay-listbox-button/listbox-button.stories.js
@@ -42,6 +42,17 @@ export default {
             description:
                 'will truncate the text of the button onto a single line, and adds an ellipsis, when the buttons text overflows',
         },
+        listSelection: {
+            table: {
+                defaultValue: {
+                    summary: 'manual',
+                },
+            },
+            description:
+                'If manual then user will need to press enter to select an item using keyboard. Otherwise auto will automatically select as the user presses up/down',
+            options: ['manual', 'auto'],
+            type: 'select',
+        },
         prefixId: {
             control: { type: 'text' },
             description:

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -13,6 +13,9 @@
   "@truncate": "boolean",
   "@prefix-id": "string",
   "@prefix-label": "string",
+  "@list-selection": {
+    "enum": ["manual", "auto"]
+  },
   "@name": "#html-name",
   "@button-name": "#html-name",
   "@disabled": "#html-disabled",

--- a/src/components/ebay-listbox-button/test/test.browser.js
+++ b/src/components/ebay-listbox-button/test/test.browser.js
@@ -19,7 +19,9 @@ describe('given the listbox with 3 items', () => {
     const input = mock.Basic_3Options;
 
     beforeEach(async () => {
-        component = await render(template, input, { container: form });
+        component = await render(template, Object.assign({}, input, { listSelection: 'auto' }), {
+            container: form,
+        });
     });
 
     it('then it should not be expanded', () => {
@@ -96,7 +98,9 @@ describe('given the listbox is in an expanded state', () => {
     const input = mock.Basic_3Options;
 
     beforeEach(async () => {
-        component = await render(template, input, { container: form });
+        component = await render(template, Object.assign({}, input, { listSelection: 'auto' }), {
+            container: form,
+        });
         await fireEvent.click(component.getByRole('button'));
     });
 
@@ -122,6 +126,53 @@ describe('given the listbox is in an expanded state', () => {
             await pressKey(component.getAllByRole('listbox').find(isVisible), {
                 key: 'ArrowDown',
                 keyCode: 40,
+            });
+        });
+
+        it('then it emits the change event with the correct data', () => {
+            const changeEvents = component.emitted('change');
+            expect(changeEvents).has.length(1);
+
+            const [[changeEvent]] = changeEvents;
+            expect(changeEvent).has.property('index', 1);
+            expect(changeEvent)
+                .has.property('selected')
+                .and.is.deep.equal([input.options[1].value]);
+        });
+    });
+});
+
+describe('given the listbox is in an expanded state with manual list-selection', () => {
+    const input = mock.Basic_3Options;
+
+    beforeEach(async () => {
+        component = await render(template, input, { container: form });
+        await fireEvent.click(component.getByRole('button'));
+    });
+
+    describe('when the down arrow key is pressed', () => {
+        beforeEach(async () => {
+            await pressKey(component.getAllByRole('listbox').find(isVisible), {
+                key: 'ArrowDown',
+                keyCode: 40,
+            });
+        });
+
+        it('then it does not emit the change event', () => {
+            const changeEvents = component.emitted('change');
+            expect(changeEvents).has.length(0);
+        });
+    });
+
+    describe('when the down arrow key is pressed with enter', () => {
+        beforeEach(async () => {
+            await pressKey(component.getAllByRole('listbox').find(isVisible), {
+                key: 'ArrowDown',
+                keyCode: 40,
+            });
+            await pressKey(component.getAllByRole('listbox').find(isVisible), {
+                key: '(Space character)',
+                keyCode: 32,
             });
         });
 

--- a/src/components/ebay-listbox/README.md
+++ b/src/components/ebay-listbox/README.md
@@ -35,10 +35,11 @@ When a selected option is specified:
 
 ### ebay-listbox Attributes
 
-| Name       | Type   | Stateful | Required | Description                                               |
-| ---------- | ------ | -------- | -------- | --------------------------------------------------------- |
-| `name`     | String | No       | Yes      | used for the `name` attribute of the native `<select>`    |
-| `selected` | Number | Yes      | n/a      | allows you to set the selected index option to `selected` |
+| Name             | Type   | Stateful | Required | Description                                                                                                                                                             |
+| ---------------- | ------ | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`           | String | No       | Yes      | used for the `name` attribute of the native `<select>`                                                                                                                  |
+| `selected`       | Number | Yes      | n/a      | allows you to set the selected index option to `selected`                                                                                                               |
+| `list-selection` | String | Yes      | n/a      | either "auto" or "manual" (default). If auto when using up/down key automatically selects the item. If manual then you have to press enter/space key to select an item. |
 
 ### ebay-listbox Events
 

--- a/src/components/ebay-listbox/component.js
+++ b/src/components/ebay-listbox/component.js
@@ -1,20 +1,49 @@
 const ActiveDescendant = require('makeup-active-descendant');
-const scrollKeyPreventer = require('makeup-prevent-scroll-keys');
 const elementScroll = require('../../common/element-scroll');
+const eventUtils = require('../../common/event-utils');
 
 module.exports = {
+    get isAutoSelection() {
+        return this.input.listSelection === 'auto';
+    },
+
     elementScroll() {
         elementScroll.scroll(this.getEls('option')[this.state.selectedIndex]);
+    },
+
+    handleChange(index, wasClicked) {
+        if (this.state.selectedIndex !== index) {
+            const option = this.input.options[index];
+            const el = this.getEls('option')[index];
+            this.state.selectedIndex = index;
+            this.once('update', () => {
+                this.emit('change', {
+                    index,
+                    selected: [option.value],
+                    el,
+                    wasClicked,
+                });
+            });
+        }
+    },
+
+    handleClick(index) {
+        this.handleChange(index, true);
     },
 
     handleMouseDown() {
         this.wasClicked = true;
     },
 
+    handleKeyDown(originalEvent) {
+        eventUtils.handleActionKeydown(originalEvent, () =>
+            this.handleChange(this._activeDescendant.index, false)
+        );
+    },
+
     handleListboxChange(event) {
         const selectedIndex = parseInt(event.detail.toIndex, 10);
         const el = this.getEls('option')[selectedIndex];
-        const option = this.input.options[selectedIndex];
         const wasClicked = this.wasClicked;
 
         elementScroll.scroll(el);
@@ -22,18 +51,7 @@ module.exports = {
         if (this.wasClicked) {
             this.wasClicked = false;
         }
-
-        if (this.state.selectedIndex !== selectedIndex) {
-            this.state.selectedIndex = selectedIndex;
-            this.once('update', () => {
-                this.emit('change', {
-                    index: selectedIndex,
-                    selected: [option.value],
-                    el,
-                    wasClicked,
-                });
-            });
-        }
+        this.handleChange(selectedIndex, wasClicked);
     },
 
     onCreate() {
@@ -84,10 +102,9 @@ module.exports = {
                     activeDescendantClassName: 'listbox__option--active',
                     autoInit: state.selectedIndex,
                     autoReset: null,
+                    autoScroll: !this.isAutoSelection,
                 }
             );
-
-            scrollKeyPreventer.add(optionsContainer);
         }
     },
 

--- a/src/components/ebay-listbox/index.marko
+++ b/src/components/ebay-listbox/index.marko
@@ -21,8 +21,9 @@ $ var selectedText = selectedOption && selectedOption.text;
     role="listbox"
     class=["listbox__options", input.class]
     tabindex:no-update=(input.tabindex || 0)
-    on-activeDescendantChange("handleListboxChange")>
-    <for|option| of=input.options>
+    on-activeDescendantChange(component.isAutoSelection && "handleListboxChange")
+    onKeydown(!component.isAutoSelection && "handleKeyDown")>
+    <for|option,index| of=input.options>
         <div
             ...processHtmlAttributes(option, itemIgnoredAttributes)
             key="option[]"
@@ -30,7 +31,8 @@ $ var selectedText = selectedOption && selectedOption.text;
             role="option"
             tabindex=(option.disabled ? -1 : option.tabindex)
             aria-selected=(selectedOption === option && "true")
-            onMousedown("handleMouseDown")>
+            onClick(!component.isAutoSelection && "handleClick", index)
+            onMousedown(component.isAutoSelection && "handleMouseDown")>
             <span class="listbox__value">${option.text}</span>
             <ebay-tick-small-icon/>
         </div>

--- a/src/components/ebay-listbox/listbox.stories.js
+++ b/src/components/ebay-listbox/listbox.stories.js
@@ -23,6 +23,17 @@ export default {
             control: { type: 'text' },
             description: 'used for the `name` attribute of the native `<select>`',
         },
+        listSelection: {
+            table: {
+                defaultValue: {
+                    summary: 'manual',
+                },
+            },
+            description:
+                'If manual then user will need to press enter to select an item using keyboard. Otherwise auto will automatically select as the user presses up/down',
+            options: ['manual', 'auto'],
+            type: 'select',
+        },
         selected: {
             description: 'allows you to set the selected index option to `selected`',
         },

--- a/src/components/ebay-listbox/marko-tag.json
+++ b/src/components/ebay-listbox/marko-tag.json
@@ -11,6 +11,9 @@
   "@fluid": "boolean",
   "@invalid": "boolean",
   "@name": "#html-name",
+  "@list-selection": {
+    "enum": ["manual", "auto"]
+  },
   "@button-name": "#html-name",
   "@disabled": "#html-disabled",
   "@options <option>[]": {

--- a/src/components/ebay-listbox/test/test.browser.js
+++ b/src/components/ebay-listbox/test/test.browser.js
@@ -19,7 +19,9 @@ describe('given the listbox with 3 items', () => {
     const input = mock.Basic_3Options;
 
     beforeEach(async () => {
-        component = await render(template, input, { container: form });
+        component = await render(template, Object.assign({}, input, { listSelection: 'auto' }), {
+            container: form,
+        });
     });
 
     it('then the native select should be initialized to the first option value', () => {
@@ -74,7 +76,9 @@ describe('given the listbox is in an expanded state', () => {
     const input = mock.Basic_3Options;
 
     beforeEach(async () => {
-        component = await render(template, input, { container: form });
+        component = await render(template, Object.assign({}, input, { listSelection: 'auto' }), {
+            container: form,
+        });
     });
 
     describe('when an option is clicked', () => {
@@ -132,6 +136,69 @@ describe('given the listbox is in an expanded state', () => {
                     .has.property('selected')
                     .and.is.deep.equal([input.options[0].value]);
             });
+        });
+    });
+});
+
+describe('given the listbox is in an expanded state with manual selection', () => {
+    const input = mock.Basic_3Options;
+
+    beforeEach(async () => {
+        component = await render(template, input, { container: form });
+    });
+
+    describe('when an option is clicked', () => {
+        beforeEach(async () => {
+            await fireEvent.click(component.getByText(input.options[1].text));
+        });
+
+        it('then it emits the change event with correct data', () => {
+            const changeEvents = component.emitted('change');
+            expect(changeEvents).has.length(1);
+
+            const [[changeEvent]] = changeEvents;
+            expect(changeEvent).has.property('index', 1);
+            expect(changeEvent)
+                .has.property('selected')
+                .and.is.deep.equal([input.options[1].value]);
+        });
+    });
+
+    describe('when the down arrow key is pressed', () => {
+        beforeEach(async () => {
+            await pressKey(component.getAllByRole('listbox').find(isVisible), {
+                key: 'ArrowDown',
+                keyCode: 40,
+            });
+        });
+
+        it('then it does not emit the change event', () => {
+            const changeEvents = component.emitted('change');
+            expect(changeEvents).has.length(0);
+        });
+    });
+
+    describe('when the down arrow key is pressed with space', () => {
+        beforeEach(async () => {
+            await pressKey(component.getAllByRole('listbox').find(isVisible), {
+                key: 'ArrowDown',
+                keyCode: 40,
+            });
+            await pressKey(component.getAllByRole('listbox').find(isVisible), {
+                key: '(Space character)',
+                keyCode: 32,
+            });
+        });
+
+        it('then it emits the change event with the correct data', () => {
+            const changeEvents = component.emitted('change');
+            expect(changeEvents).has.length(1);
+
+            const [[changeEvent]] = changeEvents;
+            expect(changeEvent).has.property('index', 1);
+            expect(changeEvent)
+                .has.property('selected')
+                .and.is.deep.equal([input.options[1].value]);
         });
     });
 });

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -29,7 +29,6 @@ static var ignoredAttributes = [
 
 $ var isOverflowVariant = input.variant === "overflow";
 $ var labelId = input.prefixId && component.getElId("label");
-$ debugger;
 
 <span
     ...processHtmlAttributes(input, ignoredAttributes)


### PR DESCRIPTION

## Description
Changed listbox to support `listboxSelection` either `auto` or `manual`

## Context
* For auto will use `activeDescendantChange` as it was before
* For manual will hook into `keydown` and `click`. 
* Added checks to not listen to the events when not in use.  

## References
https://github.com/eBay/ebayui-core/issues/1337