### PR TITLE
feat(infotip): added programatic show/hide for infotip

### DIFF
--- a/src/components/components/ebay-tooltip-base/component-browser.js
+++ b/src/components/components/ebay-tooltip-base/component-browser.js
@@ -36,6 +36,10 @@ module.exports = {
         this._expander.expand();
     },
 
+    isExpanded() {
+        return this._expander.isExpanded();
+    },
+
     onDestroy() {
         this._cleanupMakeup();
     },

--- a/src/components/ebay-infotip/component.js
+++ b/src/components/ebay-infotip/component.js
@@ -20,6 +20,18 @@ module.exports = {
         this.getComponent('base').collapse();
     },
 
+    isExpanded() {
+        return this.getComponent('base').isExpanded();
+    },
+
+    expand() {
+        this.getComponent('base').expand();
+    },
+
+    collapse() {
+        this.getComponent('base').collapse();
+    },
+
     handleCollapse() {
         this.setOpen(false);
 

--- a/src/components/ebay-infotip/examples/06-infotip-programatic/template.marko
+++ b/src/components/ebay-infotip/examples/06-infotip-programatic/template.marko
@@ -1,0 +1,24 @@
+class {
+    toggle() {
+        const infotip = this.getComponent('infotip')
+        if (infotip.isExpanded()) {
+            infotip.collapse();
+        } else {
+
+            infotip.expand();
+        }
+
+    }
+}
+
+<ebay-infotip
+    key="infotip"
+    a11y-close-text="Dismiss infotip"
+    aria-label="Important information">
+    <@heading>Important</@heading>
+    <@content>
+        <p>This is some important info</p>
+    </@content>
+</ebay-infotip>
+
+<ebay-button on-click('toggle')>Toggle</>

--- a/src/components/ebay-infotip/examples/07-infotip-modal-programtic/template.marko
+++ b/src/components/ebay-infotip/examples/07-infotip-modal-programtic/template.marko
@@ -1,0 +1,24 @@
+class {
+    toggle() {
+        const infotip = this.getComponent('infotip')
+        if (!this.open) {
+            infotip.setOpen(true);
+            this.open = true;
+        } else {
+            infotip.setOpen(false);
+            this.open = false;
+        }
+    }
+}
+
+<ebay-infotip
+    key="infotip"
+    a11y-close-text="Dismiss infotip"
+    aria-label="Important information"
+    variant="modal">
+    <@content>This is some important info
+<ebay-button on-click('toggle')>Toggle</>
+    </@content>
+</ebay-infotip>
+
+<ebay-button on-click('toggle')>Toggle</>


### PR DESCRIPTION
## Description
Exposed `expander` methods in infotip. Change infotip base to support those.
Also added two examples (for expander and for modal versions). 
I think in the future we should add passing `open` as a param. The reason I didn't do it now is because it would be a much large change and potential regression

## References
https://github.com/eBay/ebayui-core/issues/1503
