### PR TITLE
feat: ds evo class name changes for confirm and alert dialogs

### DIFF
--- a/src/components/components/ebay-dialog-base/index.marko
+++ b/src/components/components/ebay-dialog-base/index.marko
@@ -37,6 +37,7 @@ $ var header = input.header;
 <macro name="header-content">
     <${header.as || "h2"}
         ...processHtmlAttributes(header, ignoredHeaderAttributes)
+        class=[header.class, `${input.classPrefix}__title`]
         id=(header.id || component.getElId("dialog-title"))>
         <${header.renderBody}/>
     </>

--- a/src/components/ebay-alert-dialog/index.marko
+++ b/src/components/ebay-alert-dialog/index.marko
@@ -4,16 +4,15 @@ $ var mainId = component.getElId("alert-dialog-main");
     ...input
     role="alertdialog"
     open=input.open
-    classPrefix="lightbox-dialog"
+    classPrefix="alert-dialog"
     ignore-escape=true
-    window-type="compact"
     main-id=mainId
     on-open("emit", "open")
     on-close("emit", "close")
     buttonPosition="hidden"
     focus=confirmId
-    class=[input.class, "lightbox-dialog--mask-fade"]
-    window-class=["lightbox-dialog__compact-window--fade"]>
+    class=[input.class, "alert-dialog--mask-fade"]
+    window-class=["alert-dialog__window--fade"]>
     <@footer>
         <ebay-button
             priority="primary"
@@ -21,7 +20,7 @@ $ var mainId = component.getElId("alert-dialog-main");
             on-click("emit", "confirm")
             key="confirm"
             id=confirmId
-            class="lightbox-dialog__confirm">
+            class="alert-dialog__acknowledge">
             ${input.confirmText}
         </ebay-button>
     </@footer>

--- a/src/components/ebay-alert-dialog/style.js
+++ b/src/components/ebay-alert-dialog/style.js
@@ -1,1 +1,1 @@
-require('@ebay/skin/lightbox-dialog');
+require('@ebay/skin/alert-dialog');

--- a/src/components/ebay-alert-dialog/test/test.server.js
+++ b/src/components/ebay-alert-dialog/test/test.server.js
@@ -13,9 +13,9 @@ describe('dialog', () => {
         const dialog = getByRole('alertdialog', { hidden: true });
 
         expect(dialog).has.attr('hidden');
-        expect(dialog).has.class('lightbox-dialog');
-        expect(getByText(input.confirmText)).has.class('lightbox-dialog__confirm');
-        expect(getByText(input.renderBody.text)).has.class('lightbox-dialog__main');
+        expect(dialog).has.class('alert-dialog');
+        expect(getByText(input.confirmText)).has.class('alert-dialog__acknowledge');
+        expect(getByText(input.renderBody.text)).has.class('alert-dialog__main');
     });
 
     it('renders in open state', async () => {

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -51,15 +51,15 @@ $ {
     onFocus('handleFocus')
     onBlur('handleBlur')
     class=[
-        input.class,
         baseClass,
+        (validPriorities.includes(priority) &&
+        `${baseClass}--${priority}`),
+        input.class,
         input.fluid && `${baseClass}--fluid`,
         truncateClass,
         fixedHeightClass,
         transparentClass,
         !truncateClass && !fixedHeightClass && sizeClass,
-        (validPriorities.includes(priority) &&
-        `${baseClass}--${priority}`)
     ]
     data-ebayui=true
     type=(tag === "button" && (input.type || "button"))

--- a/src/components/ebay-confirm-dialog/index.marko
+++ b/src/components/ebay-confirm-dialog/index.marko
@@ -8,13 +8,12 @@ $ var mainId = component.getElId("confirm-dialog-main");
     on-close("emit", "reject")
     main-id=mainId
     focus=confirmId
-    class-prefix="lightbox-dialog"
-    class=[input.class, "lightbox-dialog--mask-fade"]
-    window-class=["lightbox-dialog__compact-window--fade"]
-    window-type="compact"
+    class-prefix="confirm-dialog"
+    class=[input.class, "confirm-dialog--mask-fade"]
+    window-class=["confirm-dialog__window--fade"]
     button-position="hidden">
     <@footer>
-        <ebay-button on-click("emit", "reject") class="lightbox-dialog__reject">
+        <ebay-button priority="none" on-click("emit", "reject") class="confirm-dialog__reject">
             ${input.rejectText}
         </ebay-button>
         <ebay-button
@@ -22,7 +21,7 @@ $ var mainId = component.getElId("confirm-dialog-main");
             on-click("emit", "confirm")
             id=confirmId
             aria-describedby=mainId
-            class="lightbox-dialog__confirm">
+            class="confirm-dialog__confirm">
             ${input.confirmText}
         </ebay-button>
     </@footer>

--- a/src/components/ebay-confirm-dialog/style.js
+++ b/src/components/ebay-confirm-dialog/style.js
@@ -1,1 +1,1 @@
-require('@ebay/skin/lightbox-dialog');
+require('@ebay/skin/confirm-dialog');

--- a/src/components/ebay-confirm-dialog/test/test.server.js
+++ b/src/components/ebay-confirm-dialog/test/test.server.js
@@ -13,10 +13,10 @@ describe('dialog', () => {
         const dialog = getByRole('dialog', { hidden: true });
 
         expect(dialog).has.attr('hidden');
-        expect(dialog).has.class('lightbox-dialog');
-        expect(getByText(input.confirmText)).has.class('lightbox-dialog__confirm');
-        expect(getByText(input.rejectText)).has.class('lightbox-dialog__reject');
-        expect(getByText(input.renderBody.text)).has.class('lightbox-dialog__main');
+        expect(dialog).has.class('confirm-dialog');
+        expect(getByText(input.confirmText)).has.class('confirm-dialog__confirm');
+        expect(getByText(input.rejectText)).has.class('confirm-dialog__reject');
+        expect(getByText(input.renderBody.text)).has.class('confirm-dialog__main');
     });
 
     it('renders in open state', async () => {


### PR DESCRIPTION
## Description
Updated alert and confirm dialogs for EVO changes

## References
closes #1489 

## Screenshots

### Alert Dialog

![Screen Shot 2021-08-31 at 4 57 34 PM](https://user-images.githubusercontent.com/25092249/131592697-ea350a0a-473d-45c3-9cec-870160353b3a.png)
![Screen Shot 2021-08-31 at 4 58 01 PM](https://user-images.githubusercontent.com/25092249/131592699-f6dccfee-b54d-4b64-bdb3-cd4848d246af.png)
![Screen Shot 2021-08-31 at 5 00 07 PM](https://user-images.githubusercontent.com/25092249/131592784-6ac25ccc-d1ea-4c3e-9666-a24e97bbf138.png)



### Confirm Dialog
![Screen Shot 2021-08-31 at 4 57 42 PM](https://user-images.githubusercontent.com/25092249/131592719-a9f32e72-f33b-4e5e-954c-71d1fc1c6ecd.png)
![Screen Shot 2021-08-31 at 4 57 51 PM](https://user-images.githubusercontent.com/25092249/131592725-d2d54550-dcf2-4586-b797-011c37984d0f.png)
![Screen Shot 2021-08-31 at 5 00 59 PM](https://user-images.githubusercontent.com/25092249/131592701-91818dcd-490c-4953-86c7-99818fcee90d.png)

