### PR TITLE
fix(fake-menu): deleted redundant aria-disabled

### DIFF
--- a/src/components/ebay-fake-menu/index.marko
+++ b/src/components/ebay-fake-menu/index.marko
@@ -54,7 +54,6 @@ $ var baseClass = input.classPrefix || "fake-menu";
                         class=[`${baseClass}__item`, item.class]
                         style=item.style
                         aria-current=(item.current ? defaultAriaCurrent : false)
-                        aria-disabled=(item.disabled && "true")
                         href=(item.disabled ? null : item.href)
                         onKeydown("handleItemKeydown", index)
                         onClick("handleItemClick", index)


### PR DESCRIPTION
## Description
The fake menu had a line that wasn't needed; it would set aria-disabled based on disabled.

## References
closes #1480 

