### PR TITLE
feat: added open attribute to tourtip, tooltip, and infotip

### DIFF
--- a/src/components/components/ebay-tooltip-base/component-browser.js
+++ b/src/components/components/ebay-tooltip-base/component-browser.js
@@ -20,17 +20,21 @@ module.exports = {
         if (this.input.type !== 'dialog--mini') {
             this._setupMakeup();
         }
+        if (this.action && this._expander) {
+            if (this.action === 'expand') {
+                this.expand();
+            } else if (this.action === 'collapse') {
+                this.collapse();
+            }
+            this.action = null;
+        }
     },
 
     onInput(input) {
-        if (this._expander) {
-            if (input.open === true) {
-                this.handleExpand();
-                this.expand();
-            } else if (input.open === false) {
-                this.handleCollapse();
-                this.collapse();
-            }
+        if (input.open === true) {
+            this.action = 'expand';
+        } else if (input.open === false) {
+            this.action = 'collapse';
         }
     },
 

--- a/src/components/components/ebay-tooltip-base/component-browser.js
+++ b/src/components/components/ebay-tooltip-base/component-browser.js
@@ -23,15 +23,13 @@ module.exports = {
     },
 
     onInput(input) {
-        if (input.type !== 'tooltip') {
-            if (this._expander) {
-                if (input.open === true) {
-                    this.expand();
-                    this.handleExpand();
-                } else if (input.open === false) {
-                    this.collapse();
-                    this.handleCollapse();
-                }
+        if (this._expander) {
+            if (input.open === true) {
+                this.handleExpand();
+                this.expand();
+            } else if (input.open === false) {
+                this.handleCollapse();
+                this.collapse();
             }
         }
     },

--- a/src/components/components/ebay-tooltip-base/component-browser.js
+++ b/src/components/components/ebay-tooltip-base/component-browser.js
@@ -22,6 +22,20 @@ module.exports = {
         }
     },
 
+    onInput(input) {
+        if (input.type !== 'tooltip') {
+            if (this._expander) {
+                if (input.open === true) {
+                    this.expand();
+                    this.handleExpand();
+                } else if (input.open === false) {
+                    this.collapse();
+                    this.handleCollapse();
+                }
+            }
+        }
+    },
+
     onRender() {
         if (typeof window !== 'undefined') {
             this._cleanupMakeup();

--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -13,14 +13,17 @@ static var ignoredAttributes = [
     "host",
     "heading",
     "content",
-    "variant"
+    "variant",
+    "open"
 ];
 
 $ var isModal = input.variant === 'modal'
 $ var classPrefix = !isModal ? "infotip" : "dialog--mini";
 $ var pointer = input.pointer || "bottom";
+
 <span>
     <ebay-tooltip-base
+        open=input.open
         key="base"
         type=classPrefix
         pointer=pointer

--- a/src/components/ebay-infotip/infotip.stories.js
+++ b/src/components/ebay-infotip/infotip.stories.js
@@ -90,6 +90,10 @@ export default {
             description:
                 'A descriptive label of what the infotip button represents (e.g. "Important information")',
         },
+        open: {
+            control: { type: 'boolean' },
+            description: 'allows dev to specify whether infotip is open or closed',
+        },
     },
 };
 

--- a/src/components/ebay-tooltip/component.js
+++ b/src/components/ebay-tooltip/component.js
@@ -7,11 +7,8 @@ module.exports = {
         };
     },
     onInput(input) {
-        if (input.open === true) {
-            this.getComponent('base').expand();
-        }
-        if (input.open === false) {
-            this.getComponent('base').collapse();
+        if (input.open === true || input.open === false) {
+            this.state.open = input.open;
         }
     },
     handleExpand() {
@@ -24,7 +21,7 @@ module.exports = {
     },
     handleKeydown(e) {
         eventUtils.handleEscapeKeydown(e, () => {
-            this.getComponent('base').collapse();
+            this.handleCollapse();
         });
     },
 };

--- a/src/components/ebay-tooltip/component.js
+++ b/src/components/ebay-tooltip/component.js
@@ -21,7 +21,7 @@ module.exports = {
     },
     handleKeydown(e) {
         eventUtils.handleEscapeKeydown(e, () => {
-            this.handleCollapse();
+            this.state.open = false;
         });
     },
 };

--- a/src/components/ebay-tooltip/component.js
+++ b/src/components/ebay-tooltip/component.js
@@ -1,10 +1,18 @@
 const eventUtils = require('../../common/event-utils');
 
 module.exports = {
-    onInput() {
+    onCreate() {
         this.state = {
             open: false,
         };
+    },
+    onInput(input) {
+        if (input.open === true) {
+            this.getComponent('base').expand();
+        }
+        if (input.open === false) {
+            this.getComponent('base').collapse();
+        }
     },
     handleExpand() {
         this.state.open = true;

--- a/src/components/ebay-tooltip/examples/01-icon-button-host/template.marko
+++ b/src/components/ebay-tooltip/examples/01-icon-button-host/template.marko
@@ -1,4 +1,4 @@
-<ebay-tooltip>
+<ebay-tooltip open=input.open>
     <@host>
         <button
             name="icon-btn-1"

--- a/src/components/ebay-tooltip/index.marko
+++ b/src/components/ebay-tooltip/index.marko
@@ -21,6 +21,7 @@ $ var pointer = input.pointer || "bottom";
 
 <span>
     <ebay-tooltip-base
+        open=state.open
         key="base"
         type="tooltip"
         pointer=pointer

--- a/src/components/ebay-tooltip/test/test.browser.js
+++ b/src/components/ebay-tooltip/test/test.browser.js
@@ -23,7 +23,7 @@ describe('given the default tooltip', () => {
         });
 
         it('then it emits the expand event', () => {
-            expect(component.emitted('expand')).has.length(2);
+            expect(component.emitted('expand')).has.length(1);
         });
 
         describe('when the host element loses hover', () => {

--- a/src/components/ebay-tooltip/test/test.browser.js
+++ b/src/components/ebay-tooltip/test/test.browser.js
@@ -23,7 +23,7 @@ describe('given the default tooltip', () => {
         });
 
         it('then it emits the expand event', () => {
-            expect(component.emitted('expand')).has.length(1);
+            expect(component.emitted('expand')).has.length(2);
         });
 
         describe('when the host element loses hover', () => {

--- a/src/components/ebay-tooltip/tooltip.stories.js
+++ b/src/components/ebay-tooltip/tooltip.stories.js
@@ -69,6 +69,10 @@ export default {
                 category: '@attribute tags',
             },
         },
+        open: {
+            control: { type: 'boolean' },
+            description: 'allows dev to specify whether tooltip is open or closed',
+        },
     },
 };
 

--- a/src/components/ebay-tooltip/tooltip.stories.js
+++ b/src/components/ebay-tooltip/tooltip.stories.js
@@ -73,6 +73,26 @@ export default {
             control: { type: 'boolean' },
             description: 'allows dev to specify whether tooltip is open or closed',
         },
+        onCollapse: {
+            action: 'on-collapse',
+            description: 'Triggered on menu collapse',
+            table: {
+                category: 'Events',
+                defaultValue: {
+                    summary: '',
+                },
+            },
+        },
+        onExpand: {
+            action: 'on-expand',
+            description: 'Triggered on menu expand',
+            table: {
+                category: 'Events',
+                defaultValue: {
+                    summary: '',
+                },
+            },
+        },
     },
 };
 

--- a/src/components/ebay-tourtip/component-browser.js
+++ b/src/components/ebay-tourtip/component-browser.js
@@ -6,6 +6,13 @@ module.exports = {
         }
     },
 
+    handleExpand({ originalEvent }) {
+        if (this._expander) {
+            this._expander.expanded = true;
+            this.emit('expand', { originalEvent });
+        }
+    },
+
     onMount() {
         this._expander = this.getComponent('base')._expander;
         this._expander.expanded = true;

--- a/src/components/ebay-tourtip/index.marko
+++ b/src/components/ebay-tourtip/index.marko
@@ -17,6 +17,7 @@ $ var pointer = input.pointer || "bottom";
 
 <span>
     <ebay-tooltip-base
+        open=input.open
         key="base"
         type="tourtip"
         pointer=pointer
@@ -25,7 +26,8 @@ $ var pointer = input.pointer || "bottom";
         style-top=input.styleTop
         style-right=input.styleRight
         style-bottom=input.styleBottom
-        onBase-collapse("handleCollapse")>
+        onBase-collapse("handleCollapse")
+        onBase-expand("handleExpand")>
         <span
             ...processHtmlAttributes(input, ignoredAttributes)
             class:no-update="tourtip">

--- a/src/components/ebay-tourtip/tourtip.stories.js
+++ b/src/components/ebay-tourtip/tourtip.stories.js
@@ -66,6 +66,10 @@ export default {
                 category: '@attribute tags',
             },
         },
+        open: {
+            control: { type: 'boolean' },
+            description: 'allows dev to specify whether tourtip is open or closed',
+        },
     },
 };
 


### PR DESCRIPTION
## Description
Added open attribute to tooltip, infotip, and tourtip. This gives the developer greater control over how they are used. 

## References
closes #1508 

## Screenshots
## Infotip
![infotip-open](https://user-images.githubusercontent.com/25092249/132070437-5f00c01b-4bc5-4412-8adb-0e81e17fc2bd.gif)

## Tourtip
![tourtip](https://user-images.githubusercontent.com/25092249/132070453-8d5c139b-89d4-48fc-bb43-eab8e1991ee9.gif)

## Tooltip
![tooltip-open](https://user-images.githubusercontent.com/25092249/132070442-6faa9291-44cd-4155-a699-0b7ecd8d22db.gif)
