### PR TITLE
fix(fake-menu): anchor tags display aria-disabled when item is disabled

### DIFF
--- a/src/components/ebay-fake-menu/README.md
+++ b/src/components/ebay-fake-menu/README.md
@@ -1,25 +1,25 @@
 <h1 style='display: flex; justify-content: space-between; align-items: center;'>
     <span>
-        ebay-menu
+        ebay-fake-menu
     </span>
     <span style='font-weight: normal; font-size: medium; margin-bottom: -15px;'>
         DS v1.1.0
     </span>
 </h1>
 
-## ebay-menu Tag
+## ebay-fake-menu Tag
 
-### ebay-menu Usage
+### ebay-fake-menu Usage
 
 ```marko
-<ebay-menu text="text">
+<ebay-fake-menu text="text">
     <@item>item 1</@item>
     <@item>item 2</@item>
     <@item>item 3</@item>
-</ebay-menu>
+</ebay-fake-menu>
 ```
 
-### ebay-menu Attributes
+### ebay-fake-menu Attributes
 
 | Name       | Type   | Stateful | Required | Description                                                 |
 | ---------- | ------ | -------- | -------- | ----------------------------------------------------------- |
@@ -48,6 +48,7 @@
 | Name                          | Type    | Stateful | Required                               | Description                                                                                                                                                                |
 | ----------------------------- | ------- | -------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `href`                        | String  | No       | No                                     | for link that looks like a menu-item. If set to null then will disable item                                                                                                |
+| `disabled`                    | String  | No       | No                                     | HTML disabled on button, but will add `aria-disabled` to <a> tags.                                                                                                         |
 | `type`                        | String  | No       | No                                     | Set to "button" for fake menu-item `<button>`                                                                                                                              |
 | `value` (radio or checkbox)   | String  | No       | No                                     | the value to use with event responses for for the `checked` array                                                                                                          |
 | `checked` (radio or checkbox) | Boolean | No       | No                                     | whether or not the item is checked                                                                                                                                         |

--- a/src/components/ebay-fake-menu/index.marko
+++ b/src/components/ebay-fake-menu/index.marko
@@ -18,7 +18,8 @@ static {
         "checked",
         "current",
         "badgeNumber",
-        "badgeAriaLabel"
+        "badgeAriaLabel",
+        "disabled"
     ];
 }
 
@@ -53,6 +54,8 @@ $ var baseClass = input.classPrefix || "fake-menu";
                         ...processHtmlAttributes(item, itemIgnoredAttributes)
                         class=[`${baseClass}__item`, item.class]
                         style=item.style
+                        disabled=(item.type === "button" && item.disabled)
+                        aria-disabled=(item.type !== "button" && item.disabled && 'true')
                         aria-current=(item.current ? defaultAriaCurrent : false)
                         href=(item.disabled ? null : item.href)
                         onKeydown("handleItemKeydown", index)


### PR DESCRIPTION
## Description
The fake menu now shows aria-disabled=true on anchor tags when the corresponding item is disabled. 

## Context
This is part two of the fake-menu fixes; part one was [here](https://github.com/eBay/ebayui-core/pull/1511)

## References
closes #1480 

## Screenshots
![fake-menu-aria-disabled](https://user-images.githubusercontent.com/25092249/132876735-7ddc6ed9-a554-4b6a-9b82-516839785f62.gif)

