### PR TITLE
fix(notice): dropped extra padding when icon===none

### DIFF
--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -24,10 +24,9 @@ $ var prefixClass = input.prefixClass;
     aria-roledescription=input.a11yRoleDescription
     class=[prefixClass, input.class]
     ...processHtmlAttributes(input, ignoredAttributes)>
-    <${input.headerRoot || "div"} class=`${prefixClass}__header` id:scoped="status"
-    >
-
-        <if(input.icon !== "none")>
+    <if(input.icon !== "none")>
+        <${input.headerRoot || "div"} class=`${prefixClass}__header` id:scoped="status"
+        >
             <if(status === "confirmation" || status === "celebration")>
                 <ebay-confirmation-filled-icon
                     a11y-text=input.a11yText
@@ -46,8 +45,8 @@ $ var prefixClass = input.prefixClass;
                     a11y-text=input.a11yText
                     class=input.iconClass/>
             </else-if>
-        </if>
-    </>
+        </>
+    </if>
     <${input.mainRoot || "div"} class=`${prefixClass}__main`>
         <if(input.title)>
             <${input.title.as || "h2"}


### PR DESCRIPTION
## Description
The `__header` classes on the notices were still being displayed when icon was set to `'none'`, which added unnecessary padding. This PR fixes that. 

## References
closes #1488 

## Screenshots
<img width="442" alt="Screen Shot 2021-09-10 at 3 22 15 PM" src="https://user-images.githubusercontent.com/25092249/132923931-eb6621ec-d97f-4b8f-8f17-9677eabfdc13.png">
<img width="440" alt="Screen Shot 2021-09-10 at 3 22 26 PM" src="https://user-images.githubusercontent.com/25092249/132923934-43f6166f-f0da-4b36-b9ef-b2df2cf451b5.png">
<img width="384" alt="Screen Shot 2021-09-10 at 3 22 37 PM" src="https://user-images.githubusercontent.com/25092249/132923935-c6dd5de4-55a9-47fe-a0cf-189c3acfcc9f.png">

