### PR TITLE
feat(dialog): changed useHiddenProperty logic and set default for fullscreen

### DIFF
--- a/src/components/components/ebay-dialog-base/component.js
+++ b/src/components/components/ebay-dialog-base/component.js
@@ -5,6 +5,10 @@ const eventUtils = require('../../../common/event-utils');
 const transition = require('../../../common/transition');
 
 module.exports = {
+    get useHiddenProperty() {
+        return this.input.useHiddenProperty || false;
+    },
+
     trackLastClick(e) {
         if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) {
             return;
@@ -133,13 +137,15 @@ module.exports = {
     },
 
     _getTrapCallback(restoreTrap, isTrapped, wasTrapped) {
-        const useHiddenProperty = this.input.useHiddenProperty || false;
         const willTrap = this.input.isModal && (restoreTrap || (isTrapped && !wasTrapped));
+        const useHiddenProperty = this.useHiddenProperty;
 
         return () => {
             if (willTrap) {
                 screenReaderTrap.trap(this.el, { useHiddenProperty });
-                keyboardTrap.trap(this.windowEl);
+                if (!useHiddenProperty) {
+                    keyboardTrap.trap(this.windowEl);
+                }
             }
         };
     },
@@ -242,7 +248,9 @@ module.exports = {
         if (this.isTrapped && this.input.isModal) {
             this.restoreTrap = this.state.open;
             screenReaderTrap.untrap(this.el);
-            keyboardTrap.untrap(this.windowEl);
+            if (!this.useHiddenProperty) {
+                keyboardTrap.untrap(this.windowEl);
+            }
         } else {
             this.restoreTrap = false;
         }

--- a/src/components/components/ebay-dialog-base/test/test.browser.js
+++ b/src/components/components/ebay-dialog-base/test/test.browser.js
@@ -365,10 +365,10 @@ describe('given a closed dialog with useHiddenProperty', () => {
             await component.rerender(Object.assign({}, input, { open: true }));
         });
 
-        thenItIsOpen(true);
+        useHiddenPropertyIsOpened(true);
     });
 
-    function thenItIsOpen(wasToggled) {
+    function useHiddenPropertyIsOpened(wasToggled) {
         it('then it is visible in the DOM', async () => {
             await waitFor(() => expect(component.getByRole('dialog')).does.not.have.attr('hidden'));
         });
@@ -382,15 +382,10 @@ describe('given a closed dialog with useHiddenProperty', () => {
         });
 
         if (wasToggled) {
-            it('then it traps focus', async () => {
-                await waitFor(() => {
-                    expect(component.getByRole('dialog').children[1]).has.class(
-                        'keyboard-trap--active'
-                    );
-                    component
-                        .getByLabelText(input.a11yCloseText)
-                        .classList.forEach((cls) => expect(document.activeElement).has.class(cls));
-                });
+            it('then it still does not trap focus', () => {
+                expect(
+                    component.getByRole('dialog', { hidden: true }).children[0]
+                ).does.not.have.class('keyboard-trap--active');
             });
 
             it('then it emits the show event', async () => {
@@ -399,7 +394,7 @@ describe('given a closed dialog with useHiddenProperty', () => {
 
             describe('when it is rerendered with the same input', () => {
                 beforeEach(async () => await component.rerender());
-                thenItIsOpen();
+                useHiddenPropertyIsOpened();
             });
         }
     }

--- a/src/components/ebay-fullscreen-dialog/index.marko
+++ b/src/components/ebay-fullscreen-dialog/index.marko
@@ -6,6 +6,7 @@
     on-open("emit", "open")
     on-close("emit", "close")
     class=input.class
+    useHiddenProperty=true
     window-class="fullscreen-dialog__window--slide">
     <${input.renderBody}/>
 </ebay-dialog-base>


### PR DESCRIPTION

## Description
* Set fullscreen dialog to `useHiddenProperty` by default
* Changed dialog-base to not run `keyboard-traps` if `useHiddenProperty` is true.
