### PR TITLE
fix(infotip): fixed icon to be small by default

### DIFF
--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -48,7 +48,7 @@ $ var pointer = input.pointer || "bottom";
                     <${input.icon}/>
                 </if>
                 <else>
-                    <ebay-information-icon/>
+                    <ebay-information-small-icon/>
                 </else>
             </button>
             <if(isModal !== true)>


### PR DESCRIPTION
## Description
Fixed infotip icon to be small by default

## References
https://github.com/eBay/ebayui-core/issues/1524

## Screenshots
<img width="50" alt="Screen Shot 2021-09-23 at 1 08 17 PM" src="https://user-images.githubusercontent.com/1755269/134576580-985a8662-5184-4a72-94d5-510aa4a5fb5b.png">


