### PR TITLE
feat(select): added floating label support

### DIFF
--- a/src/components/ebay-select/component.js
+++ b/src/components/ebay-select/component.js
@@ -1,3 +1,5 @@
+const FloatingLabel = require('makeup-floating-label');
+
 module.exports = {
     handleChange(event) {
         const { selectedIndex } = event.target;
@@ -14,6 +16,10 @@ module.exports = {
         });
     },
 
+    handleFloatingLabelInit() {
+        this.emit('floating-label-init');
+    },
+
     onCreate() {
         this.state = { selectedIndex: 0 };
     },
@@ -25,5 +31,31 @@ module.exports = {
             0,
             input.options.findIndex((option) => option.selected)
         );
+    },
+
+    onMount() {
+        this._setupMakeup();
+    },
+
+    onUpdate() {
+        this._setupMakeup();
+    },
+
+    _setupMakeup() {
+        // TODO: makeup-floating-label should be updated so that we can remove the event listeners.
+        // It probably makes more sense to just move this functionality into Marko though.
+        if (this.input.floatingLabel) {
+            if (this._floatingLabel) {
+                this._floatingLabel.refresh();
+                this.handleFloatingLabelInit();
+            } else if (document.readyState === 'complete') {
+                if (this.el) {
+                    this._floatingLabel = new FloatingLabel(this.el);
+                    this.handleFloatingLabelInit();
+                }
+            } else {
+                this.subscribeTo(window).once('load', this._setupMakeup.bind(this));
+            }
+        }
     },
 };

--- a/src/components/ebay-select/index.marko
+++ b/src/components/ebay-select/index.marko
@@ -1,68 +1,91 @@
-import processHtmlAttributes from "../../common/html-attributes";
+import processHtmlAttributes from "../../common/html-attributes"
 
 static var ignoredAttributes = [
     "class",
     "style",
     "borderless",
-    "options"
+    "options",
+    "floatingLabel",
+    "isLarge"
 ];
-static var itemIgnoredAttributes = [
-    "selected",
-    "optgroup"
-];
+
+static var itemIgnoredAttributes = ["selected", "optgroup"];
 
 $ var selectedOption = input.options[state.selectedIndex];
 $ var list = [];
+$ var isLarge = input.isLarge;
 $ var optgroups = {};
-$ input.options.forEach(function (option) {
+$ var id = input.id || component.getElId("select");
+$ input.options.forEach(function(option) {
     var optgroup = option.optgroup;
 
     if (optgroup) {
         if (optgroups[optgroup]) {
             optgroups[optgroup].options.push(option);
         } else {
-            list.push(optgroups[optgroup] = {
-                optgroup: optgroup,
-                options: [option]
-            });
+            list.push(
+                (optgroups[optgroup] = {
+                    optgroup: optgroup,
+                    options: [option]
+                })
+            );
         }
     } else {
         list.push(option);
     }
 });
-
-<span
-    class=[
-        "select",
-        input.borderless && "select--borderless",
-        input.class
-    ]
-    style=input.style>
-    <select
-        ...processHtmlAttributes(input, ignoredAttributes)
-        onChange("handleChange")>
-        <for|optionOrGroup| of=list>
-            <if(optionOrGroup.optgroup)>
-                <optgroup label=optionOrGroup.optgroup>
-                    <for|option| of=optionOrGroup.options>
-                        <option
-                            ...processHtmlAttributes(option, itemIgnoredAttributes)
-                            key="option[]"
-                            selected=(option === selectedOption)>
-                            ${option.text}
-                        </option>
-                    </for>
-                </optgroup>
-            </if>
-            <else>
-                <option
-                    ...processHtmlAttributes(optionOrGroup, itemIgnoredAttributes)
-                    key="option[]"
-                    selected=(optionOrGroup === selectedOption)>
-                    ${optionOrGroup.text}
-                </option>
-            </else>
-        </for>
-    </select>
-    <ebay-dropdown-icon/>
-</span>
+<${input.floatingLabel && "span"} class=["floating-label", isLarge && "floating-label--large"]>
+    <if(input.floatingLabel)>
+        <label
+            for=id
+            class=[
+                "floating-label__label",
+                input.disabled && "floating-label__label--disabled"
+            ]>
+            ${input.floatingLabel}
+        </label>
+    </if>
+    <span
+        class=[
+            "select",
+            isLarge && "select--large",
+            input.borderless && "select--borderless",
+            input.class
+        ]
+        style=input.style>
+        <select
+            ...processHtmlAttributes(input, ignoredAttributes)
+            id=id
+            onChange("handleChange")>
+            <for|optionOrGroup| of=list>
+                <if(optionOrGroup.optgroup)>
+                    <optgroup label=optionOrGroup.optgroup>
+                        <for|option| of=optionOrGroup.options>
+                            <option
+                                ...processHtmlAttributes(
+                                    option,
+                                    itemIgnoredAttributes
+                                )
+                                key="option[]"
+                                selected=(option === selectedOption)>
+                                ${option.text}
+                            </option>
+                        </for>
+                    </optgroup>
+                </if>
+                <else>
+                    <option
+                        ...processHtmlAttributes(
+                            optionOrGroup,
+                            itemIgnoredAttributes
+                        )
+                        key="option[]"
+                        selected=(optionOrGroup === selectedOption)>
+                        ${optionOrGroup.text}
+                    </option>
+                </else>
+            </for>
+        </select>
+        <ebay-dropdown-icon/>
+    </span>
+</>

--- a/src/components/ebay-select/select.stories.js
+++ b/src/components/ebay-select/select.stories.js
@@ -29,11 +29,23 @@ export default {
             control: { type: 'number' },
             description: 'allows you to set the selected index option to `selected`',
         },
+        floatingLabel: {
+            type: 'string',
+            control: { type: 'string' },
+            description:
+                'if set, then label will move up and down. Need to have first option to have a nullable value.',
+        },
         borderless: {
             type: 'boolean',
             control: { type: 'boolean' },
             description: 'whether button has borders',
         },
+        isLarge: {
+            type: 'boolean',
+            control: { type: 'boolean' },
+            description: 'to show large version',
+        },
+
         text: {
             control: { type: 'text' },
             description: 'text to use in the option',
@@ -88,6 +100,37 @@ Standard.parameters = {
     docs: {
         source: {
             code: tagToString('ebay-select', Standard.args, { options: 'option' }),
+        },
+    },
+};
+
+export const Floating = Template.bind({});
+Floating.args = {
+    floatingLabel: 'Option',
+    options: [
+        {
+            text: 'Select an option',
+            value: '',
+        },
+
+        {
+            text: 'option 1',
+            value: 'option 1',
+        },
+        {
+            text: 'option 2',
+            value: 'option 2',
+        },
+        {
+            text: 'option 3',
+            value: 'option 3',
+        },
+    ],
+};
+Floating.parameters = {
+    docs: {
+        source: {
+            code: tagToString('ebay-select', Floating.args, { options: 'option' }),
         },
     },
 };

--- a/src/components/ebay-select/test/mock/index.js
+++ b/src/components/ebay-select/test/mock/index.js
@@ -11,6 +11,13 @@ exports.Basic_3Options = {
     })),
 };
 
+exports.Basic_3OptionsWithBlank = {
+    options: getNItems(4, (i) => ({
+        value: i === 0 ? '' : String(i),
+        text: `option ${i}`,
+    })),
+};
+
 exports.Borderless_3Options = Object.assign({}, exports.Basic_3Options, {
     borderless: true,
 });
@@ -22,3 +29,23 @@ exports.Basic_3Options_1Selected = {
         selected: i === 1,
     })),
 };
+
+exports.Floating_Label_Always = Object.assign({}, exports.Basic_3Options, {
+    floatingLabel: 'Email address',
+});
+
+exports.Floating_Label = Object.assign({}, exports.Basic_3OptionsWithBlank, {
+    floatingLabel: 'Email address',
+});
+
+exports.Floating_Label_No_Value = Object.assign({}, exports.Floating_Label, {
+    value: undefined,
+});
+
+exports.Floating_Label_With_ID = Object.assign({}, exports.Floating_Label, {
+    id: 'select-id',
+});
+
+exports.Floating_Label_Disabled = Object.assign({}, exports.Floating_Label, {
+    disabled: true,
+});

--- a/src/components/ebay-select/test/test.browser.js
+++ b/src/components/ebay-select/test/test.browser.js
@@ -38,3 +38,71 @@ describe('given the select with 3 options', () => {
         });
     });
 });
+
+describe('given an input select with floating label and no value', () => {
+    const input = mock.Floating_Label_No_Value;
+
+    beforeEach(async () => {
+        component = await render(template, input);
+    });
+
+    it('then component is wrapped into floating label element', () => {
+        expect(component.container.firstElementChild).has.class('floating-label');
+    });
+
+    it('then is showing the label inline', () => {
+        expect(component.getByText(input.floatingLabel)).has.class('floating-label__label--inline');
+    });
+
+    describe('when the input is focused', () => {
+        beforeEach(async () => {
+            await fireEvent.focus(component.getByRole('combobox'));
+        });
+
+        it('then it is not showing the label inline', () => {
+            expect(component.getByText(input.floatingLabel)).does.not.have.class(
+                'floating-label__label--inline'
+            );
+        });
+
+        describe('when the input is blurred', () => {
+            beforeEach(async () => {
+                await fireEvent.blur(component.getByRole('combobox'));
+            });
+
+            it('then is showing the label inline', () => {
+                expect(component.getByText(input.floatingLabel)).has.class(
+                    'floating-label__label--inline'
+                );
+            });
+        });
+    });
+
+    describe('when the component is updated/re-rendered', () => {
+        beforeEach(async () => {
+            await component.rerender();
+        });
+
+        it('it should send a select floating label init event', () => {
+            expect(component.emitted('floating-label-init')).has.length(1);
+        });
+    });
+});
+
+describe('given an input select with floating label and no value with all options filled', () => {
+    const input = mock.Floating_Label_Always;
+
+    beforeEach(async () => {
+        component = await render(template, input);
+    });
+
+    it('then component is wrapped into floating label element', () => {
+        expect(component.container.firstElementChild).has.class('floating-label');
+    });
+
+    it('then is showing the label not inline', () => {
+        expect(component.getByText(input.floatingLabel)).does.not.have.class(
+            'floating-label__label--inline'
+        );
+    });
+});

--- a/src/components/ebay-select/test/test.server.js
+++ b/src/components/ebay-select/test/test.server.js
@@ -51,6 +51,25 @@ describe('select', () => {
             .with.class('select--borderless');
     });
 
+    it('renders an input select with inline floating label', async () => {
+        const input = mock.Floating_Label;
+        const { getByRole, getByLabelText, getByText } = await render(template, input);
+        expect(getByRole('combobox')).to.equal(getByLabelText(input.floatingLabel));
+        expect(getByText(input.floatingLabel)).has.class('floating-label__label');
+    });
+
+    it('renders an input select with inline floating label and an id', async () => {
+        const input = mock.Floating_Label_With_ID;
+        const { getByLabelText } = await render(template, input);
+        expect(getByLabelText(input.floatingLabel)).has.id(input.id);
+    });
+
+    it('renders a disabled input select with disabled floating label', async () => {
+        const input = mock.Floating_Label_Disabled;
+        const { getByText } = await render(template, input);
+        expect(getByText(input.floatingLabel)).has.class('floating-label__label--disabled');
+    });
+
     testPassThroughAttributes(template, {
         getClassAndStyleEl(component) {
             return component.getByRole('combobox').parentElement;


### PR DESCRIPTION
## Description
* Added support for floating label for select
* makeup-floating-label has been updated on `8.0.0`

## Screenshot
(__NOTE__: This is without skin changes which align it better)
<img width="232" alt="Screen Shot 2021-10-01 at 1 24 03 PM" src="https://user-images.githubusercontent.com/1755269/135682035-a69c6b28-4560-47f6-a553-26cc1ff3c0e8.png">

