### PR TITLE
fix(video): added reportText, dropped a11yReportText

### DIFF
--- a/src/components/ebay-video/component.js
+++ b/src/components/ebay-video/component.js
@@ -224,7 +224,7 @@ module.exports = {
         );
 
         // eslint-disable-next-line no-undef,new-cap
-        shaka.ui.Controls.registerElement('report', new Report.Factory());
+        shaka.ui.Controls.registerElement('report', new Report.Factory(this.input.reportText));
 
         // eslint-disable-next-line no-undef,new-cap
         shaka.ui.Controls.registerElement('captions', new TextSelection.Factory());

--- a/src/components/ebay-video/elements.js
+++ b/src/components/ebay-video/elements.js
@@ -26,8 +26,12 @@ function getElements(self) {
         }
     };
     Report.Factory = class {
-        create(rootElement, controls, text) {
-            return new Report(rootElement, controls, text);
+        constructor(reportText) {
+            this.reportText = reportText;
+        }
+
+        create(rootElement, controls) {
+            return new Report(rootElement, controls, this.reportText);
         }
     };
 

--- a/src/components/ebay-video/examples/08-mp4/template.marko
+++ b/src/components/ebay-video/examples/08-mp4/template.marko
@@ -4,6 +4,7 @@ class {}
     width=460
     height=300
     a11y-load-text="This video is loading now"
-    a11y-play-text="Click to start this video">
+    a11y-play-text="Click to start this video"
+    report-text="Custom Text">
     <@source src="https://ir.ebaystatic.com/cr/v/c1/ebayui/video/v1/video.mp4"/>
 </ebay-video>

--- a/src/components/ebay-video/index.marko
+++ b/src/components/ebay-video/index.marko
@@ -11,7 +11,7 @@ static var ignoredAttributes = [
     "playView",
     "a11yPlayText",
     "a11yLoadText",
-    "a11yReportText",
+    "reportText",
     "errorText",
     "volume",
     "muted",

--- a/src/components/ebay-video/marko-tag.json
+++ b/src/components/ebay-video/marko-tag.json
@@ -12,7 +12,6 @@
   "@cdn-version": "string",
   "@a11y-play-text": "string",
   "@a11y-load-text": "string",
-  "@a11y-report-text": "string",
   "@report-text": "string",
   "@error-text": "string",
   "@volume": "number",

--- a/src/components/ebay-video/video.stories.js
+++ b/src/components/ebay-video/video.stories.js
@@ -75,11 +75,6 @@ export default {
             description:
                 'The content for error when an either the library or video cannot load. Default is "An error has occurred"',
         },
-        a11yReportText: {
-            control: { type: 'text' },
-            description:
-                'The text for screen readers for the report menu popup. Default is "Report"',
-        },
         reportText: {
             control: { type: 'text' },
             description: 'The text for report button. Default is "Report"',


### PR DESCRIPTION
## Description
Fixed Report Text for video and dropped a11yReportText

## References
closes #1533 

## Screenshots
<img width="601" alt="Screen Shot 2021-10-05 at 10 33 39 PM" src="https://user-images.githubusercontent.com/25092249/136145972-e794b007-f782-4ec5-98a4-35ece4b1bf91.png">

