### PR TITLE
fix(toast-dialog and tourtip): proper style for close button

### DIFF
--- a/src/components/components/ebay-dialog-base/index.marko
+++ b/src/components/components/ebay-dialog-base/index.marko
@@ -45,7 +45,7 @@ $ var header = input.header;
     <if(buttonPosition !== "hidden")>
         <button
             key="close"
-            class=["icon-btn", `${input.classPrefix}__close`]
+            class=["icon-btn", input.classPrefix == "toast-dialog" && "icon-btn--transparent", `${input.classPrefix}__close` ]
             type="button"
             aria-label=input.a11yCloseText
             onClick("handleCloseButtonClick")>

--- a/src/components/components/ebay-tooltip-overlay/index.marko
+++ b/src/components/components/ebay-tooltip-overlay/index.marko
@@ -52,7 +52,7 @@ $ var overlayStyles = hasUserStyles ? {
             <if(input.type !== "tooltip")>
                 <button
                     aria-label=input.a11yCloseText
-                    class=['icon-btn', `${input.type}__close`]
+                    class=['icon-btn', 'icon-btn--transparent', `${input.type}__close`]
                     type="button"
                     onClick("handleCloseButton")>
                     <ebay-close-icon/>


### PR DESCRIPTION
## Description
Added `icon-btn--transparent` styles to close icon button on tourtip and toast dialog to fix styling bug. 

## References
closes #1536 

## Screenshots
![toast-dialog-working](https://user-images.githubusercontent.com/25092249/137038835-f86eaa86-80a8-4efc-8e9b-202f1dbc6fdf.gif)
![tourtip-working](https://user-images.githubusercontent.com/25092249/137038836-d4951a74-d99e-4b89-aefa-7ba81b67f1ea.gif)


