### PR TITLE
fix: removed process from ds utils

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,57 +1,54 @@
 const path = require('path');
 const { BrowserJSONPlugin } = require('webpack-plugin-browser-json');
-const markoCompiler = require("marko/compiler")
+const markoCompiler = require('marko/compiler');
 const { getDSFlags } = require('../src/common/ds-util');
-const SourcePlugin = require('./sourceCodeUtils/webpackPlugin')
+const SourcePlugin = require('./sourceCodeUtils/webpackPlugin');
 
-markoCompiler.taglibFinder.excludePackage("@lasso/marko-taglib");
+markoCompiler.taglibFinder.excludePackage('@lasso/marko-taglib');
 
 function getRawSoruces() {
-  const data = {
-    files: {
-      ...previousFiles,
-      ...cache.getSources(),
-    },
-    id: sourceId++,
-  }
-  previousFiles = data.files
-  const sources = JSON.stringify(data);
-  cache.cleanCache()
-  return {
-    source: () => sources,
-      size: () => sources.length,
-  };
+    const data = {
+        files: {
+            ...previousFiles,
+            ...cache.getSources(),
+        },
+        id: sourceId++,
+    };
+    previousFiles = data.files;
+    const sources = JSON.stringify(data);
+    cache.cleanCache();
+    return {
+        source: () => sources,
+        size: () => sources.length,
+    };
 }
 
-
 module.exports = async ({ config }) => {
-  config.devtool = "none";
-  config.resolve.extensions.push('.less');
+    config.devtool = 'none';
+    config.resolve.extensions.push('.less');
 
-  config.module.rules.push({
-    test: /\.less$/,
-    use: [
-      'style-loader',
-      'css-loader',
-      'less-loader'
-    ]
-  });
+    config.module.rules.push({
+        test: /\.less$/,
+        use: ['style-loader', 'css-loader', 'less-loader'],
+    });
 
-  config.module.rules.push({
-    test: /\.marko?$/,
-    use: [
-      {
-        loader: path.resolve(__dirname, 'sourceCodeUtils/webpackLoader.js'),
-        options: { root: path.resolve(__dirname, "../src") }
-      }
-    ]
-  });
+    config.module.rules.push({
+        test: /\.marko?$/,
+        use: [
+            {
+                loader: path.resolve(__dirname, 'sourceCodeUtils/webpackLoader.js'),
+                options: { root: path.resolve(__dirname, '../src') },
+            },
+        ],
+    });
 
-  config.plugins.push(new BrowserJSONPlugin({
-    flags: getDSFlags()
-  }));
+    config.plugins.push(
+        new BrowserJSONPlugin({
+            flags: getDSFlags(process.env.DS),
+        })
+    );
 
-  config.plugins.push(new SourcePlugin())
+    config.plugins.push(new SourcePlugin());
 
-  return config;
+    return config;
 };

--- a/demo/index.js
+++ b/demo/index.js
@@ -83,7 +83,7 @@ app.get('/:designSystem/:component?', (req, res) => {
         components: demoUtils.getComponentsWithExamples('src'),
     };
 
-    const dsFlag = dsUtils.getDSFlags(req.params.designSystem);
+    const dsFlag = dsUtils.getDSFlags(req.params.designSystem || process.env.DS);
     const lassoFlags = ['ebayui-no-bg-icons'];
 
     // allow .only in example folder name

--- a/src/common/ds-util/index.js
+++ b/src/common/ds-util/index.js
@@ -47,7 +47,7 @@ const requireRemap = dsList
 requireRemap.reverse();
 
 function getDSVersion(dsV) {
-    const dsVFull = dsV || process.env.DS || defaultDS;
+    const dsVFull = dsV || defaultDS;
     const dsVCheck = dsVFull.startsWith('ds') ? dsVFull.substring(2) : dsVFull;
     return dsVCheck;
 }


### PR DESCRIPTION
## Description
Removed `process` from ds-utils and moved it to different server configs.
This way if it's loaded on lasso it won't try to do `require('process');`

The only change to the webpack file is
```
config.plugins.push(
        new BrowserJSONPlugin({
            flags: getDSFlags(process.env.DS),
        })
    );
``` 
The other changes are prettier formatting

Will need to port to `8.x` too

## References
https://github.com/eBay/ebayui-core/issues/1548