### PR TITLE
fix: dialog title and menu-button label/prefix label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "browser-refresh": "^1.7.2",
         "chai": "^4.2.0",
         "chai-dom": "^1.10.0",
-        "chromedriver": "^94.0.0",
+        "chromedriver": "^95.0.0",
         "coveralls": "^3.1.1",
         "css-loader": "^5.2.7",
         "dotenv-webpack": "^7.0.2",
@@ -17018,9 +17018,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "94.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-94.0.0.tgz",
-      "integrity": "sha512-x4hK7R7iOyAhdLHJEcOyGBW/oa2kno6AqpHVLd+n3G7c2Vk9XcAXMz84XhNItqykJvTc6E3z/JRIT1eHYH//Eg==",
+      "version": "95.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
+      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -58695,9 +58695,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "94.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-94.0.0.tgz",
-      "integrity": "sha512-x4hK7R7iOyAhdLHJEcOyGBW/oa2kno6AqpHVLd+n3G7c2Vk9XcAXMz84XhNItqykJvTc6E3z/JRIT1eHYH//Eg==",
+      "version": "95.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
+      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "browser-refresh": "^1.7.2",
     "chai": "^4.2.0",
     "chai-dom": "^1.10.0",
-    "chromedriver": "^94.0.0",
+    "chromedriver": "^95.0.0",
     "coveralls": "^3.1.1",
     "css-loader": "^5.2.7",
     "dotenv-webpack": "^7.0.2",

--- a/src/components/components/ebay-dialog-base/index.marko
+++ b/src/components/components/ebay-dialog-base/index.marko
@@ -29,13 +29,14 @@ static var ignoredAttributes = [
     "top"
 ];
 
-static var ignoredHeaderAttributes = ["id", "as"];
+static var ignoredHeaderAttributes = ["id", "as", "class"];
 
 $ var buttonPosition = input.buttonPosition || "left";
 $ var baseEl = input.baseEl || "div";
 $ var header = input.header;
 <macro name="header-content">
     <${header.as || "h2"}
+        class=[header.class, `${input.classPrefix}__title`]
         ...processHtmlAttributes(header, ignoredHeaderAttributes)
         id=(header.id || component.getElId("dialog-title"))>
         <${header.renderBody}/>

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -45,7 +45,6 @@ $ var labelId = input.prefixId && component.getElId("label");
         variant=(isOverflowVariant ? "icon" : "expand")
         size=input.size
         priority=(input.priority || "none")
-        icon-only=(!input.text && !input.icon && !isOverflowVariant)
         aria-expanded="false"
         aria-haspopup="true"
         aria-label=input.a11yText

--- a/src/components/ebay-menu-button/test/test.server.js
+++ b/src/components/ebay-menu-button/test/test.server.js
@@ -61,12 +61,6 @@ describe('menu-button', () => {
         expect(getByRole('button')).has.class('expand-btn--small');
     });
 
-    it('renders without text', async () => {
-        const input = Object.assign({}, mock.Basic_2Items, { text: '' });
-        const { getByRole } = await render(template, input);
-        expect(getByRole('button')).has.class('expand-btn--icon-only');
-    });
-
     it('renders with icon', async () => {
         const input = mock.Settings_Icon;
         const { getByRole, getByText } = await render(template, input);


### PR DESCRIPTION
## Description
* Fixed dialog to have `__title` on `h2` element
* Fixed menu button by removing `icon-only` attribute. It is no longer needed. 

## References
https://github.com/eBay/ebayui-core/issues/1555
https://github.com/eBay/ebayui-core/issues/1554

## Screenshots
<img width="255" alt="Screen Shot 2021-11-11 at 10 17 11 AM" src="https://user-images.githubusercontent.com/1755269/141353469-36eff39b-43c3-4179-939e-c25fb3126aff.png">

<img width="732" alt="Screen Shot 2021-11-11 at 10 58 53 AM" src="https://user-images.githubusercontent.com/1755269/141353616-079c948d-0a2e-4266-8c05-d18f940aeea7.png">

