### PR TITLE
fix(tooltip-base): added checking for open on onMount

### DIFF
--- a/src/components/components/ebay-tooltip-base/component-browser.js
+++ b/src/components/components/ebay-tooltip-base/component-browser.js
@@ -11,23 +11,11 @@ module.exports = {
     },
 
     onMount() {
-        if (this.input.type !== 'dialog--mini') {
-            this._setupMakeup();
-        }
+        this._setupBaseTooltip();
     },
 
     onUpdate() {
-        if (this.input.type !== 'dialog--mini') {
-            this._setupMakeup();
-        }
-        if (this.action && this._expander) {
-            if (this.action === 'expand') {
-                this.expand();
-            } else if (this.action === 'collapse') {
-                this.collapse();
-            }
-            this.action = null;
-        }
+        this._setupBaseTooltip();
     },
 
     onInput(input) {
@@ -83,6 +71,20 @@ module.exports = {
             if (isTooltip && !host.hasAttribute('aria-describedby')) {
                 host.setAttribute('aria-describedby', input.overlayId);
             }
+        }
+    },
+
+    _setupBaseTooltip() {
+        if (this.input.type !== 'dialog--mini') {
+            this._setupMakeup();
+        }
+        if (this.action && this._expander) {
+            if (this.action === 'expand') {
+                this.expand();
+            } else if (this.action === 'collapse') {
+                this.collapse();
+            }
+            this.action = null;
         }
     },
 

--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -23,7 +23,7 @@ $ var pointer = input.pointer || "bottom";
 
 <span>
     <ebay-tooltip-base
-        open=input.open
+        open=state.open
         key="base"
         type=classPrefix
         pointer=pointer

--- a/src/components/ebay-infotip/infotip.stories.js
+++ b/src/components/ebay-infotip/infotip.stories.js
@@ -133,3 +133,21 @@ Standard.parameters = {
         },
     },
 };
+
+export const OpenOnRender = Template.bind({});
+OpenOnRender.args = {
+    heading: {
+        renderBody: `Important`,
+    },
+    content: {
+        renderBody: `<p>This is some important info</p>`,
+    },
+    open: true,
+};
+OpenOnRender.parameters = {
+    docs: {
+        source: {
+            code: tagToString('ebay-infotip', OpenOnRender.args),
+        },
+    },
+};


### PR DESCRIPTION
## Description
Added check for opening tooltips in `onMount`

Basically changed both checks to be in a similar function and just changed the way they are called

## Context
Added a storybook example for it (we can remove it if needed, but it's the only way to simulate a first render open)

## References
https://github.com/eBay/ebayui-core/issues/1561
