### PR TITLE
fix(carousel): added a check to not disable buttons on state change

### DIFF
--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -18,7 +18,10 @@ function getTemplateData(state) {
     const prevControlDisabled = isSingleSlide || (!autoplayInterval && offset === 0);
     const nextControlDisabled =
         isSingleSlide || (!autoplayInterval && offset === getMaxOffset(state));
-    const bothControlsDisabled = prevControlDisabled && nextControlDisabled;
+    // If left/right is undefined, the carousel is moving at that moment. We should keep the old disabled state
+    const bothControlsDisabled = isAnimating
+        ? state.bothControlsDisabled
+        : prevControlDisabled && nextControlDisabled;
     let slide, itemWidth, totalSlides, a11yStatusText;
 
     if (itemsPerSlide) {
@@ -428,6 +431,21 @@ function forEls(parent, fn) {
         fn(child, i++);
         child = child.nextElementSibling;
     }
+}
+
+/**
+ * Checks if the left/right offset is undefined
+ *
+ * @param {*} state  The widget state
+ * @returns
+ */
+function isAnimating(state) {
+    const { items, index } = state;
+    if (!items.length) {
+        return false;
+    }
+    const currentItem = items[index];
+    return currentItem.left === undefined || currentItem.right === undefined;
 }
 
 /**

--- a/src/components/ebay-carousel/examples/04-dynamic-loading/template.marko
+++ b/src/components/ebay-carousel/examples/04-dynamic-loading/template.marko
@@ -1,0 +1,35 @@
+class {
+    move({ visibleIndexes }) {
+        console.log(arguments);
+        if (visibleIndexes[visibleIndexes.length - 1] > this.state.count - 10) {
+            this.state.count += 10;
+        }
+
+        this.state.index = visibleIndexes[0];
+    }
+
+    onCreate() {
+        this.state = {
+            count: 20,
+            index: 0,
+        };
+    }
+}
+<style>
+    .demo-card {
+        color: #0a1c6b;
+        background: #c2f5ff;
+        font-size: 24px;
+        font-weight: bold;
+        width: 200px;
+        height: 120px;
+        line-height: 120px;
+        text-align: center;
+    }
+</style>
+
+<ebay-carousel index=state.index items-per-slide=1 on-move('move')>
+    <for|i| from=0 to=state.count>
+        <@item key=`item-${i}` class=`demo-card`>Card ${i + 1}</@item>
+    </for>
+</ebay-carousel>


### PR DESCRIPTION
## Description
Changed logic in `bothControlsDisabled` to check if the left/right position is undefined. If it's undefined, it means the carousel is rerendering before animationFrame is triggered. 
This was causing a flicker in paddles since this logic was turning to true between animation frame was changed.

Also added an example (for our reference) which reproduces this issue, but it's not exposed.

## References
#1566 

## Screenshots
After change:
![working](https://user-images.githubusercontent.com/1755269/144146004-1edb9885-0f54-4290-abcd-598374056aa3.gif)

Before:
![flicker](https://user-images.githubusercontent.com/1755269/144145856-028a0522-63ea-41b5-9af1-8d781865d5ba.gif)

