### PR TITLE
fix: button, menu-button textbox bugfixes

### DIFF
--- a/src/components/ebay-button/button.stories.js
+++ b/src/components/ebay-button/button.stories.js
@@ -63,8 +63,9 @@ export default {
             },
         },
         bodyState: {
-            description: 'when state is loading, adds progress spinner. default is none',
-            options: ['none', 'loading'],
+            description:
+                'when state is loading, adds progress spinner. when user interacts with button, reset should be called to reset aria-live state. default is none',
+            options: ['none', 'loading', 'reset'],
             control: { type: 'select' },
             table: {
                 defaultValue: {

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -43,6 +43,7 @@ $ {
     var tag = input.href ? "a" : "button";
     var htmlAttributes = processHtmlAttributes(data, ignoredAttributes);
     if(input.bodyState === "loading") hasLoaded = true;
+    else if (input.bodyState === "reset") hasLoaded = false;
 }
 <${tag}
     ...htmlAttributes

--- a/src/components/ebay-fake-menu-button/fake-menu-button.stories.js
+++ b/src/components/ebay-fake-menu-button/fake-menu-button.stories.js
@@ -188,12 +188,15 @@ Standard.args = {
     items: [
         {
             renderBody: `item 1 that has very long text`,
+            href: 'https://www.ebay.com',
         },
         {
             renderBody: `item 2`,
+            href: 'https://www.ebay.com',
         },
         {
             renderBody: `item 3`,
+            href: 'https://www.ebay.com',
         },
     ],
     text: `eBay Menu`,

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -42,7 +42,6 @@ $ var labelId = input.prefixId && component.getElId("label");
             `menu-button__button`,
             input.borderless && !isOverflowVariant && "expand-btn--borderless"
         ]
-        variant=(isOverflowVariant ? "icon" : "expand")
         size=input.size
         priority=(input.priority || "none")
         aria-expanded="false"

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -72,6 +72,7 @@ $ var defaultTag = input.fluid ? "div" : "span";
             <${input.buttonAriaLabel && "button"}
                 class="icon-btn"
                 aria-label=input.buttonAriaLabel
+                type=(input.buttonAriaLabel && "button")
                 on-click("handleButtonClick")>
                 <${input.postfixIcon}/>
             </>


### PR DESCRIPTION
## Description
* Added href to fake menu button storybook
* Removed variant attribute from menu-button (not used anymore)
* Added bodyState reset to button
* Added type="button" to postfix button so it won't submit form.

## References
https://github.com/eBay/ebayui-core/issues/1563
https://github.com/eBay/ebayui-core/issues/1551
https://github.com/eBay/ebayui-core/issues/1559
https://github.com/eBay/ebayui-core/issues/1558

## Screenshots
Screenshot for button
![loading](https://user-images.githubusercontent.com/1755269/144151748-be56670e-349e-4f7c-a031-8c484f8a87ef.gif)

