### PR TITLE
feat(progress-stepper): updatd stepper to match EVO

### DIFF
--- a/src/components/ebay-progress-stepper/index.marko
+++ b/src/components/ebay-progress-stepper/index.marko
@@ -59,7 +59,7 @@ $ var current = (input.step || []).findIndex(item => item.current);
                         <ebay-stepper-confirmation-icon width="24" height="24"/>
                     </else-if>
                     <else>
-                        <span role="img">${item.number || index + 1}</span>
+                        <span></span>
                     </else>
                 </span>
                 <span class="progress-stepper__text">

--- a/src/components/ebay-progress-stepper/progress-stepper.stories.js
+++ b/src/components/ebay-progress-stepper/progress-stepper.stories.js
@@ -1,16 +1,10 @@
 import { tagToString } from '../../../.storybook/storybook-code-source';
+import { addRenderBodies } from '../../../.storybook/utils';
 import Readme from './README.md';
-import Component from './examples/01-direction/01-default/template.marko';
+import Component from './';
 
 const Template = (args) => ({
-    input: {
-        ...args,
-        renderBody: args.renderBody
-            ? (out) => {
-                  out.html(args.renderBody);
-              }
-            : null,
-    },
+    input: addRenderBodies(args),
 });
 
 export default {
@@ -58,6 +52,7 @@ export default {
                 'The bolded title for each step. Will be rendered in an `h4` by default. In order to override, pass the `as` attribute. `<@title as="h3">Title</@title>`. All other attributes will be passed through to the header tag',
             table: {
                 category: '@step subtags',
+                control: false,
             },
         },
         current: {
@@ -65,6 +60,7 @@ export default {
             control: { type: 'boolean' },
             table: {
                 category: '@step attributes',
+                control: false,
             },
             description:
                 'The current step. Only first step that has this attribute will be considered current. All steps before will be rendered as complete, and all after will render as upcoming. If not present on any item, then will render based on `default-state` attribute',
@@ -72,6 +68,7 @@ export default {
         type: {
             table: {
                 category: '@step attributes',
+                control: false,
             },
             type: 'enum',
             control: { type: 'select' },
@@ -79,23 +76,100 @@ export default {
             description:
                 'Either `attention`, `information`, or `complete`. This takes prescedence over current. Will render the current step with the given icon and color',
         },
-        number: {
-            table: {
-                category: '@step attributes',
-            },
-            type: 'number',
-            description:
-                'Renders the current step with the given number. Overrides the default number counting for this step',
+    },
+};
+
+export const InProgress = Template.bind({});
+InProgress.args = {
+    step: [
+        {
+            title: { renderBody: 'Started' },
+            renderBody: 'July 3rd',
+        },
+
+        {
+            title: { renderBody: 'Shipped' },
+            renderBody: 'July 4th',
+        },
+        {
+            current: true,
+            title: { renderBody: 'Transit' },
+            renderBody: 'July 5th',
+        },
+        {
+            title: { renderBody: 'Delivered' },
+            renderBody: 'July 6th',
+        },
+    ],
+};
+InProgress.parameters = {
+    docs: {
+        source: {
+            code: tagToString('ebay-progress-stepper', InProgress.args, { step: 'step' }),
         },
     },
 };
 
-export const Standard = Template.bind({});
-Standard.args = {};
-Standard.parameters = {
+export const Blocked = Template.bind({});
+Blocked.args = {
+    step: [
+        {
+            title: { renderBody: 'Started' },
+            renderBody: 'July 3rd',
+        },
+
+        {
+            title: { renderBody: 'Shipped' },
+            renderBody: 'July 4th',
+        },
+        {
+            current: true,
+            type: 'attention',
+            title: { renderBody: 'Blocked' },
+            renderBody: 'July 5th',
+        },
+        {
+            title: { renderBody: 'Delivered' },
+            renderBody: 'July 6th',
+        },
+    ],
+};
+Blocked.parameters = {
     docs: {
         source: {
-            code: tagToString('ebay-progress-stepper', Standard.args),
+            code: tagToString('ebay-progress-stepper', Blocked.args, { step: 'step' }),
+        },
+    },
+};
+
+export const Information = Template.bind({});
+Information.args = {
+    step: [
+        {
+            title: { renderBody: 'Started' },
+            renderBody: 'July 3rd',
+        },
+
+        {
+            title: { renderBody: 'Shipped' },
+            renderBody: 'July 4th',
+        },
+        {
+            current: true,
+            type: 'information',
+            title: { renderBody: 'Information' },
+            renderBody: 'July 5th',
+        },
+        {
+            title: { renderBody: 'Delivered' },
+            renderBody: 'July 6th',
+        },
+    ],
+};
+Information.parameters = {
+    docs: {
+        source: {
+            code: tagToString('ebay-progress-stepper', Information.args, { step: 'step' }),
         },
     },
 };

--- a/src/components/ebay-progress-stepper/test/test.server.js
+++ b/src/components/ebay-progress-stepper/test/test.server.js
@@ -16,12 +16,12 @@ describe('stepper', () => {
         const list = getAllByRole('listitem');
         expect(list).has.length(4);
 
-        expect(getByText('3').parentElement.parentElement).has.attr('aria-current');
+        expect(getByText('status 2').parentElement.parentElement).has.attr('aria-current');
 
         checkItem(list[0], 'confirmation');
         checkItem(list[1], 'confirmation');
-        checkItem(list[2], 3);
-        checkItem(list[3], 4);
+        checkItem(list[2], 'status 2', true);
+        checkItem(list[3], 'status 3', true);
     });
 
     it('renders vertical stepper', async () => {
@@ -32,12 +32,12 @@ describe('stepper', () => {
 
         const list = getAllByRole('listitem');
         expect(list).has.length(4);
-        expect(getByText('3').parentElement.parentElement).has.attr('aria-current');
+        expect(getByText('status 2').parentElement.parentElement).has.attr('aria-current');
 
         checkItem(list[0], 'confirmation');
         checkItem(list[1], 'confirmation');
-        checkItem(list[2], 3);
-        checkItem(list[3], 4);
+        checkItem(list[2], 'status 2', true);
+        checkItem(list[3], 'status 3', true);
     });
 
     it('renders stepper with states', async () => {
@@ -49,16 +49,16 @@ describe('stepper', () => {
         expect(list).has.length(5);
 
         checkItem(list[0], 'confirmation');
-        checkItem(list[1], 2);
-        checkItem(list[2], 3);
+        checkItem(list[1], 'status 1', true);
+        checkItem(list[2], 'status 2', true);
         checkItem(list[3], 'attention');
         checkItem(list[4], 'information');
     });
 
-    function checkItem(list, icon) {
+    function checkItem(list, icon, text) {
         const firstChild = list.children[0].children[0];
-        if (typeof icon === 'number') {
-            expect(within(firstChild).getAllByText(icon)).has.length(1);
+        if (text) {
+            expect(within(list).getAllByText(icon)).has.length(1);
         } else {
             expect(firstChild).has.class(`icon--stepper-${icon}`);
         }


### PR DESCRIPTION
## Description
Changed progress stepper to no longer have numbers.
Also fixed up stories to add better examples

## References
#1570 

## Screenshots
<img width="560" alt="Screen Shot 2021-12-06 at 12 48 49 PM" src="https://user-images.githubusercontent.com/1755269/144920327-a91e31da-bc3d-48ff-94e4-d2b4eaa4acfd.png">
<img width="553" alt="Screen Shot 2021-12-06 at 12 48 53 PM" src="https://user-images.githubusercontent.com/1755269/144920337-93c55eee-99c0-4b43-8c66-e56b233c8e52.png">
n
<img width="656" alt="Screen Shot 2021-12-06 at 12 48 56 PM" src="https://user-images.githubusercontent.com/1755269/144920340-53a4807a-7c81-4976-8846-ec03efc1d2bb.png">


