### PR TITLE
fix(progress-stepper): added role=img to empty span

### DIFF
--- a/src/components/ebay-progress-stepper/index.marko
+++ b/src/components/ebay-progress-stepper/index.marko
@@ -59,7 +59,7 @@ $ var current = (input.step || []).findIndex(item => item.current);
                         <ebay-stepper-confirmation-icon width="24" height="24"/>
                     </else-if>
                     <else>
-                        <span></span>
+                        <span role="img"></span>
                     </else>
                 </span>
                 <span class="progress-stepper__text">


### PR DESCRIPTION
## Description
Added role=img to apply the right styles

## References
https://github.com/eBay/ebayui-core/issues/1581

## Screenshots
<img width="1644" alt="Screen Shot 2021-12-14 at 11 23 46 AM" src="https://user-images.githubusercontent.com/1755269/146066493-c540d674-e473-4b82-866f-95ed2872d108.png">

