### PR TITLE
fix(progress-stepper): updated a11y for step and title

### DIFF
--- a/src/components/ebay-progress-stepper/README.md
+++ b/src/components/ebay-progress-stepper/README.md
@@ -29,31 +29,3 @@
     </@step>
 </ebay-progress-stepper>
 ```
-
-## ebay-progress-stepper Sub-tags
-
-| Tag       | Required | Description                                                                       |
-| --------- | -------- | --------------------------------------------------------------------------------- |
-| `<@step>` | Yes      | Each step to represented. The body will display as text next to the current state |
-
-## ebay-progress-stepper Attributes
-
-| Name             | Type    | Stateful | Required | Description                                                                                                                                                                                                                                    |
-| ---------------- | ------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `direction`      | Enum    | No       | No       | Either 'column' or 'row'. Will display stepper as a vertical column or horizontal row. Default is 'row'                                                                                                                                        |
-| `default-state`  | Enum    | Yes      | No       | Either 'complete', 'upcoming' or 'active'. If complete, then all items will be in complete state by default. If upcoming, all items will be in upcoming state. Otherwise, the default (active), will change items based on the `current` item. |
-| `auto-paragraph` | Boolean | No       | No       | Specify whether to auto wrap @step body text with a paragraph tag (default: true)                                                                                                                                                              |
-
-## ebay-progress-stepper @step Sub-tags
-
-| Tag        | Required | Description                                                                                                                                                                                                            |
-| ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<@title>` | No       | The bolded title for each step. Will be rendered in an `h4` by default. In order to override, pass the `as` attribute. `<@title as="h3">Title</@title>`. All other attributes will be passed through to the header tag |
-
-## ebay-progress-stepper @step Attributes
-
-| Name      | Type    | Stateful | Required | Description                                                                                                                                                                                                                                                 |
-| --------- | ------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `current` | Boolean | No       | No       | The current step. Only first step that has this attribute will be considered current. All steps before will be rendered as complete, and all after will render as upcoming. If not present on any item, then will render based on `default-state` attribute |
-| `type`    | Enumm   | No       | No       | Either `attention`, `information`, or `complete`. This takes prescedence over current. Will render the current step with the given icon and color                                                                                                           |
-| `number`  | Number  | No       | No       | Renders the current step with the given number. Overrides the default number counting for this step                                                                                                                                                         |

--- a/src/components/ebay-progress-stepper/index.marko
+++ b/src/components/ebay-progress-stepper/index.marko
@@ -7,10 +7,12 @@ static var ignoredStepAttributes = [
     "current",
     "information",
     "attention",
-    "class"
+    "class",
+    "a11yHeadingText",
+    "a11yHeadingTag",
 ];
 
-static var ignoredStepTitleAttributes = ["as"];
+static var ignoredStepTitleAttributes = ["as", "a11yText", "current", "type", "title"];
 
 $ var direction = input.direction || "row";
 $ var current = (input.step || []).findIndex(item => item.current);
@@ -20,7 +22,12 @@ $ var current = (input.step || []).findIndex(item => item.current);
         direction === "column" && "progress-stepper--vertical",
         input.class
     ]
+    aria-labelledby:scoped="stepper-heading"
     ...processHtmlAttributes(input, ignoredAttributes)>
+    <${input.a11yHeadingTag || "h2"} id:scoped="stepper-heading" class="clipped">
+        ${input.a11yHeadingText}
+    </>
+
     <div
         class=[
             "progress-stepper__items",
@@ -46,20 +53,20 @@ $ var current = (input.step || []).findIndex(item => item.current);
                 ...processHtmlAttributes(item, ignoredStepAttributes)>
                 <span class="progress-stepper__icon">
                     <if(item.type === "attention")>
-                        <ebay-stepper-attention-icon width="24" height="24"/>
+                        <ebay-stepper-attention-icon width="24" height="24" aria-label=(item.a11yText || 'blocked')/>
                     </if>
                     <else-if(item.type === "information")>
-                        <ebay-stepper-information-icon width="24" height="24"/>
+                        <ebay-stepper-information-icon width="24" height="24" aria-label=(item.a11yText || 'issue')/>
                     </else-if>
                     <else-if(
                         index < current ||
                         item.type === "complete" ||
                         input.defaultState === "complete"
                     )>
-                        <ebay-stepper-confirmation-icon width="24" height="24"/>
+                        <ebay-stepper-confirmation-icon width="24" height="24" aria-label=(item.a11yText || 'complete')/>
                     </else-if>
                     <else>
-                        <span role="img"></span>
+                        <span role="img" aria-label=(item.a11yText || (current === index ? 'current' : 'upcoming'))></span>
                     </else>
                 </span>
                 <span class="progress-stepper__text">

--- a/src/components/ebay-progress-stepper/marko-tag.json
+++ b/src/components/ebay-progress-stepper/marko-tag.json
@@ -8,6 +8,8 @@
   "@default-state": {
     "enum": ["upcoming", "complete", "active"]
   },
+  "@a11y-heading-text": "string",
+  "@a11y-heading-tag": "string",
   "@auto-paragraph": "boolean",
   "@direction": {
     "enum": ["row", "column"]
@@ -20,6 +22,7 @@
     },
     "@html-attributes": "expression",
     "@current": "boolean",
+    "@a11y-text": "string",
     "@type": {
       "enum": ["attention", "default", "complete"]
     },

--- a/src/components/ebay-progress-stepper/progress-stepper.stories.js
+++ b/src/components/ebay-progress-stepper/progress-stepper.stories.js
@@ -39,6 +39,19 @@ export default {
             description:
                 'Specify whether to auto wrap @step body text with a paragraph tag (default: true)',
         },
+        a11yHeadingTag: {
+            type: 'string',
+            defaultValue: {
+                summary: 'h2',
+            },
+            control: { type: 'string' },
+            description: 'heading tag for progress stepper',
+        },
+        a11yHeadingText: {
+            type: 'string',
+            control: { type: 'string' },
+            description: 'heading text for progress stepper which will be clipped',
+        },
         step: {
             name: '@step',
             description: '',
@@ -64,6 +77,15 @@ export default {
             },
             description:
                 'The current step. Only first step that has this attribute will be considered current. All steps before will be rendered as complete, and all after will render as upcoming. If not present on any item, then will render based on `default-state` attribute',
+        },
+        a11yText: {
+            table: {
+                category: '@step attributes',
+                control: false,
+            },
+            type: 'string',
+            description:
+                'The accessibility text for the icon. Defaults to either complete, upcoming, current, issue, or blocked depending on type or current',
         },
         type: {
             table: {
@@ -101,6 +123,7 @@ InProgress.args = {
             renderBody: 'July 6th',
         },
     ],
+    a11yHeadingText: 'Shipment progress',
 };
 InProgress.parameters = {
     docs: {
@@ -133,6 +156,7 @@ Blocked.args = {
             renderBody: 'July 6th',
         },
     ],
+    a11yHeadingText: 'Shipment progress, shipment is blocked',
 };
 Blocked.parameters = {
     docs: {
@@ -165,6 +189,7 @@ Information.args = {
             renderBody: 'July 6th',
         },
     ],
+    a11yHeadingText: 'Shipment progress, waiting for more info.',
 };
 Information.parameters = {
     docs: {

--- a/src/components/ebay-progress-stepper/test/mock/index.js
+++ b/src/components/ebay-progress-stepper/test/mock/index.js
@@ -12,8 +12,10 @@ function getType(i) {
 }
 
 exports.ProgressStepper = {
+    a11yHeadingText: 'shipment',
     step: getNItems(4, (i) => ({
         current: i === 2,
+        a11yText: i === 3 && 'a11yIconLabel',
         renderBody: createRenderBody(`status ${i}`),
     })),
 };

--- a/src/components/ebay-progress-stepper/test/test.server.js
+++ b/src/components/ebay-progress-stepper/test/test.server.js
@@ -9,7 +9,13 @@ use(require('chai-dom'));
 describe('stepper', () => {
     it('renders basic stepper', async () => {
         const input = mock.ProgressStepper;
-        const { getByRole, getAllByRole, getByText } = await render(template, input);
+        const { getByLabelText, getByRole, getAllByRole, getByText } = await render(
+            template,
+            input
+        );
+
+        expect(getByLabelText(input.a11yHeadingText)).has.class('progress-stepper');
+
         expect(getAllByRole('presentation')).has.length(3);
         expect(getByRole('list').parentElement).does.not.have.class('progress-stepper--vertical');
 
@@ -22,6 +28,8 @@ describe('stepper', () => {
         checkItem(list[1], 'confirmation');
         checkItem(list[2], 'status 2', true);
         checkItem(list[3], 'status 3', true);
+
+        expect(getByLabelText('a11yIconLabel')).has.attr('role', 'img');
     });
 
     it('renders vertical stepper', async () => {


### PR DESCRIPTION
## Description
* Added `a11yText` for each step
* Added `a11yHeadingText` for header text to use as `aria-labelledby`

## Context
Added both tests and storybook examples
I removed the readme part since we should be using storybook for now.

## References
https://github.com/eBay/ebayui-core/issues/1582

