### PR TITLE
fix(infotip,textbox): fixed gray background bug with icon-btn

### DIFF
--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -39,7 +39,7 @@ $ var pointer = input.pointer || "bottom";
             ]>
             <button
                 key="host"
-                class=[`${classPrefix}__host`, "icon-btn"]
+                class=[`${classPrefix}__host`, "icon-btn", "icon-btn--transparent"]
                 type="button"
                 on-click(isModal && "handleExpand")
                 disabled=input.disabled

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -70,7 +70,7 @@ $ var defaultTag = input.fluid ? "div" : "span";
         </>
         <if(displayIcon && input.postfixIcon)>
             <${input.buttonAriaLabel && "button"}
-                class="icon-btn"
+                class="icon-btn icon-btn--transparent"
                 aria-label=input.buttonAriaLabel
                 type=(input.buttonAriaLabel && "button")
                 on-click("handleButtonClick")>


### PR DESCRIPTION
## Description
See title. Screenshot from textbox shows button in hover state.

## References
closes #1580 

## Screenshots
<img width="103" alt="Screen Shot 2021-12-15 at 12 03 09 PM" src="https://user-images.githubusercontent.com/25092249/146267812-60f0fa82-9032-4491-8e0a-3d91cef40498.png">
<img width="73" alt="Screen Shot 2021-12-15 at 12 17 57 PM" src="https://user-images.githubusercontent.com/25092249/146267815-3d84aec7-4ca4-48ec-8914-3a5ee9884551.png">

