### PR TITLE
fix(menu): don't trigger events when item is disabled

### DIFF
--- a/src/components/ebay-fake-menu/index.marko
+++ b/src/components/ebay-fake-menu/index.marko
@@ -58,8 +58,8 @@ $ var baseClass = input.classPrefix || "fake-menu";
                         aria-disabled=(item.type !== "button" && item.disabled && 'true')
                         aria-current=(item.current ? defaultAriaCurrent : false)
                         href=(item.disabled ? null : item.href)
-                        onKeydown("handleItemKeydown", index)
-                        onClick("handleItemClick", index)
+                        onKeydown(!item.disabled && "handleItemKeydown", index)
+                        onClick(!item.disabled && "handleItemClick", index)
                         key="item[]">
                         <span>
                             <${item.renderBody}/>

--- a/src/components/ebay-menu/index.marko
+++ b/src/components/ebay-menu/index.marko
@@ -61,9 +61,9 @@ $ var baseClass = input.classPrefix || "menu";
                 aria-disabled=(item.disabled && "true")
                 href=(item.disabled ? null : item.href)
                 role=itemRole
-                onClick("handleItemClick", index)
-                onKeydown("handleItemKeydown", index)
-                onKeypress("handleItemKeypress")
+                onClick(!item.disabled && "handleItemClick", index)
+                onKeydown(!item.disabled && "handleItemKeydown", index)
+                onKeypress(!item.disabled && "handleItemKeypress")
                 key="item[]">
                 <span>
                     <${item.renderBody}/>


### PR DESCRIPTION
## Description
Added a check to remove events if the item is disabled (added the same in fake-menu too)

## References
https://github.com/eBay/ebayui-core/issues/1586
