### PR TITLE
feat(menu-button): added support for normal button

### DIFF
--- a/src/components/ebay-fake-menu-button/fake-menu-button.stories.js
+++ b/src/components/ebay-fake-menu-button/fake-menu-button.stories.js
@@ -58,11 +58,10 @@ export default {
             description: 'button size, "large" (default: "none")',
         },
         priority: {
-            control: { type: 'text' },
-            description:
-                'button priority, "primary" (deprecated) / "secondary" (deprecated) / "none" (default)',
+            control: { type: 'select' },
+            options: ['primary', 'secondary', 'delete', 'tertiary', 'none'],
+            description: 'button priority, only used when variant="button"',
         },
-
         disabled: {
             type: 'boolean',
             control: { type: 'boolean' },
@@ -70,8 +69,10 @@ export default {
                 'Will disable the entire dropdown (disables the ebay-button label) if set to true',
         },
         variant: {
-            control: { type: 'text' },
-            description: 'will change the button style, "overflow" / "default"',
+            control: { type: 'select' },
+            options: ['overflow', 'form', 'button'],
+            description:
+                'will change the button style, "overflow", "form" or "button. Default is form"',
         },
         item: {
             name: '@item',

--- a/src/components/ebay-fake-menu-button/index.marko
+++ b/src/components/ebay-fake-menu-button/index.marko
@@ -1,6 +1,7 @@
 import processHtmlAttributes from "../../common/html-attributes"
 import ExpandButton from '<ebay-expand-button>'
 import IconButton from '<ebay-icon-button>'
+import Button from '<ebay-button>'
 
 static var ignoredAttributes = [
     "class",
@@ -24,7 +25,22 @@ static var ignoredAttributes = [
     "textAlign"
 ];
 
-$ var isOverflowVariant = input.variant === "overflow";
+$ {
+    var labelId = input.prefixId && component.getElId("label");
+    var isOverflowVariant = input.variant === "overflow";
+    var isButtonVariant = input.variant === "button";
+    var priority = null;
+    var prefix = 'expand-btn'
+
+    var tagName = ExpandButton;
+    if (isOverflowVariant) {
+        tagName = IconButton;
+    } else if (isButtonVariant) {
+        tagName = Button;
+        priority = input.priority
+        prefix = 'btn';
+    }
+}
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
     class=["fake-menu-button", input.class]
@@ -32,13 +48,13 @@ $ var isOverflowVariant = input.variant === "overflow";
     onExpander-expand("handleExpand")
     onExpander-collapse("handleCollapse")
     onMousedown("handleMousedown")>
-    <${isOverflowVariant ? IconButton : ExpandButton}
+    <${tagName}
         class=[
             `fake-menu-button__button`,
             input.borderless && !isOverflowVariant && "expand-btn--borderless"
         ]
         size=input.size
-        priority=(input.priority || "none")
+        priority=priority
         icon-only=(!input.text && !input.icon && !isOverflowVariant)
         aria-expanded="false"
         aria-label=input.a11yText
@@ -51,7 +67,7 @@ $ var isOverflowVariant = input.variant === "overflow";
         </if>
         <else>
             <span class=[
-                "expand-btn__cell",
+                `${prefix}__cell`,
                 input.label && "menu-button__control--custom-label",
                 input.textAlign === "center" && "expand-btn__cell--center"
             ]>
@@ -66,6 +82,9 @@ $ var isOverflowVariant = input.variant === "overflow";
                         <span>${input.text}</span>
                     </if>
                 </else>
+                <if(isButtonVariant && !input.noToggleIcon)>
+                    <ebay-dropdown-icon/>
+                </if>
             </span>
         </else>
     </>

--- a/src/components/ebay-menu-button/index.marko
+++ b/src/components/ebay-menu-button/index.marko
@@ -1,6 +1,7 @@
 import processHtmlAttributes from "../../common/html-attributes"
 import ExpandButton from '<ebay-expand-button>'
 import IconButton from '<ebay-icon-button>'
+import Button from '<ebay-button>'
 
 static var ignoredAttributes = [
     "class",
@@ -27,8 +28,22 @@ static var ignoredAttributes = [
     "collapseOnSelect"
 ];
 
-$ var isOverflowVariant = input.variant === "overflow";
-$ var labelId = input.prefixId && component.getElId("label");
+$ {
+    var labelId = input.prefixId && component.getElId("label");
+    var isOverflowVariant = input.variant === "overflow";
+    var isButtonVariant = input.variant === "button";
+    var priority = null;
+    var prefix = 'expand-btn'
+
+    var tagName = ExpandButton;
+    if (isOverflowVariant) {
+        tagName = IconButton;
+    } else if (isButtonVariant) {
+        tagName = Button;
+        priority = input.priority
+        prefix = 'btn';
+    }
+}
 
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
@@ -37,13 +52,13 @@ $ var labelId = input.prefixId && component.getElId("label");
     onExpander-expand("handleExpand")
     onExpander-collapse("handleCollapse")
     onMousedown("handleMousedown")>
-    <${isOverflowVariant ? IconButton : ExpandButton}
+    <${tagName}
         class=[
             `menu-button__button`,
             input.borderless && !isOverflowVariant && "expand-btn--borderless"
         ]
         size=input.size
-        priority=(input.priority || "none")
+        priority=priority
         aria-expanded="false"
         aria-haspopup="true"
         aria-label=input.a11yText
@@ -57,7 +72,7 @@ $ var labelId = input.prefixId && component.getElId("label");
         </if>
         <else>
             <span class=[
-                "expand-btn__cell",
+                `${prefix}__cell`,
                 input.label && "menu-button__control--custom-label",
                 input.textAlign === 'center' && "expand-btn__cell--center"
             ]>
@@ -80,6 +95,9 @@ $ var labelId = input.prefixId && component.getElId("label");
                         <span id=labelId>${input.text}</span>
                     </if>
                 </else>
+                <if(isButtonVariant && !input.noToggleIcon)>
+                    <ebay-dropdown-icon/>
+                </if>
             </span>
         </else>
     </>

--- a/src/components/ebay-menu-button/menu-button.stories.js
+++ b/src/components/ebay-menu-button/menu-button.stories.js
@@ -64,9 +64,9 @@ export default {
             description: 'button size, "large" (default: "none")',
         },
         priority: {
-            control: { type: 'text' },
-            description:
-                'button priority, "primary" (deprecated) / "secondary" (deprecated) / "none" (default)',
+            control: { type: 'select' },
+            options: ['primary', 'secondary', 'delete', 'tertiary', 'none'],
+            description: 'button priority, only used when variant="button"',
         },
         checked: {
             description:
@@ -79,8 +79,10 @@ export default {
                 'Will disable the entire dropdown (disables the ebay-button label) if set to true',
         },
         variant: {
-            control: { type: 'text' },
-            description: 'will change the button style, "overflow" / "default"',
+            control: { type: 'select' },
+            options: ['overflow', 'form', 'button'],
+            description:
+                'will change the button style, "overflow", "form" or "button. Default is form"',
         },
         collapseOnSelect: {
             type: 'boolean',

--- a/src/components/ebay-menu-button/test/mock/index.js
+++ b/src/components/ebay-menu-button/test/mock/index.js
@@ -52,3 +52,8 @@ exports.Overflow_Variant = Object.assign({}, exports.Basic_2Items, {
     text: '',
     variant: 'overflow',
 });
+
+exports.Button_Variant = Object.assign({}, exports.Basic_2Items, {
+    text: 'Button',
+    variant: 'button',
+});

--- a/src/components/ebay-menu-button/test/test.server.js
+++ b/src/components/ebay-menu-button/test/test.server.js
@@ -104,6 +104,18 @@ describe('menu-button', () => {
         expect(menuEl).has.property('parentElement').with.class('menu-button__menu--reverse');
     });
 
+    it('renders with button variant', async () => {
+        const input = mock.Button_Variant;
+        const { getByRole, getByLabelText } = await render(template, input);
+        const btnEl = getByRole('button');
+        expect(btnEl).is.equal(getByLabelText(input.a11yText));
+        expect(btnEl).has.class('btn');
+        expect(btnEl).has.attr('aria-haspopup', 'true');
+        expect(btnEl).has.attr('aria-expanded', 'false');
+        expect(btnEl).has.property('parentElement').with.class('menu-button');
+        expect(btnEl.querySelector('.icon')).has.property('tagName', 'svg');
+    });
+
     it('renders with separators', async () => {
         const input = mock.Separator_4Items;
         const { queryByText, getAllByRole, getByText } = await render(template, input);


### PR DESCRIPTION
## Description
Added support for normal button (using variant). 
Should also fix priority being passed through (will only be passed to button now, should be null for other cases)

## References
#1598
#1592

## Screenshots
<img width="279" alt="Screen Shot 2022-01-21 at 8 53 29 AM" src="https://user-images.githubusercontent.com/1755269/150577041-9a2dde33-c4b6-41f2-b09d-b1e1823b58bf.png">
<img width="225" alt="Screen Shot 2022-01-21 at 8 53 32 AM" src="https://user-images.githubusercontent.com/1755269/150577045-a7340a7a-f671-4c27-b03e-0b503f4a4dd5.png">

