### PR TITLE
fix(listbox): changed default selected value to be blank

### DIFF
--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -22,7 +22,7 @@ module.exports = {
 
     onCreate() {
         this.state = {
-            selectedIndex: 0,
+            selectedIndex: -1,
         };
     },
 
@@ -30,7 +30,7 @@ module.exports = {
         const { state } = this;
         input.options = input.options || [];
         state.selectedIndex = Math.max(
-            0,
+            -1,
             input.options.findIndex((option) => option.selected)
         );
     },

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -11,12 +11,15 @@ static var ignoredAttributes = [
     "options",
     "truncate",
     "prefixLabel",
-    "prefixId"
+    "prefixId",
+    "unselectedText"
 ];
 
 $ var selectedOption = input.options[state.selectedIndex];
 $ var selectedText = selectedOption && selectedOption.text;
 $ var labelId = input.prefixId && component.getElId("label");
+$ var unselectedText = input.unselectedText || '-';
+$ var displayText = selectedText || unselectedText;
 
 <${input.truncate && !input.fluid ? "div" : "span"}
     ...processHtmlAttributes(input, ignoredAttributes)
@@ -48,13 +51,13 @@ $ var labelId = input.prefixId && component.getElId("label");
                     "expand-btn__floating-label--animate",
                     !selectedText && "expand-btn__floating-label--inline",
                     ]>${input.floatingLabel}</span>
-                <span class="expand-btn__text">${selectedText}</span>
+                <span class="expand-btn__text">${displayText}</span>
             </if>
             <else-if (input.prefixLabel)>
-                <span class="expand-btn__text">${input.prefixLabel} ${selectedText}</span>
+                <span class="expand-btn__text">${input.prefixLabel} ${displayText}</span>
             </else-if>
             <else>
-                <span id=labelId class="expand-btn__text">${selectedText}</span>
+                <span id=labelId class="expand-btn__text">${displayText}</span>
             </else>
             <ebay-dropdown-icon/>
         </span>

--- a/src/components/ebay-listbox-button/listbox-button.stories.js
+++ b/src/components/ebay-listbox-button/listbox-button.stories.js
@@ -63,7 +63,10 @@ export default {
             description:
                 'The label to add that floats to the top when item is selected. Cannot be used with `prefix-label`',
         },
-
+        unselectedText: {
+            control: { type: 'text' },
+            description: 'The text to be shown when no options are selected. Default is "-"',
+        },
         prefixLabel: {
             control: { type: 'text' },
             description:
@@ -123,6 +126,7 @@ export default {
 
 export const Standard = Template.bind({});
 Standard.args = {
+    prefixLabel: 'Selected:',
     options: [
         {
             value: '1',

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -14,6 +14,7 @@
   "@prefix-id": "string",
   "@prefix-label": "string",
   "@floating-label": "string",
+  "@unselected-text": "string",
   "@list-selection": {
     "enum": ["manual", "auto"]
   },

--- a/src/components/ebay-listbox-button/test/mock/index.js
+++ b/src/components/ebay-listbox-button/test/mock/index.js
@@ -33,6 +33,16 @@ exports.Basic_3Options = {
     })),
 };
 
+exports.Basic_3Options_FirstSelected = {
+    name: 'listbox-name',
+    buttonName: 'listbox-button-name',
+    options: getNItems(3, (i) => ({
+        selected: i === 0,
+        value: String(i),
+        text: `option ${i}`,
+    })),
+};
+
 exports.Basic_3Options_1Selected = {
     name: 'listbox-name',
     options: getNItems(3, (i) => ({

--- a/src/components/ebay-listbox-button/test/test.browser.js
+++ b/src/components/ebay-listbox-button/test/test.browser.js
@@ -95,7 +95,7 @@ describe('given the listbox with 3 items', () => {
 });
 
 describe('given the listbox is in an expanded state', () => {
-    const input = mock.Basic_3Options;
+    const input = mock.Basic_3Options_FirstSelected;
 
     beforeEach(async () => {
         component = await render(template, Object.assign({}, input, { listSelection: 'auto' }), {
@@ -143,7 +143,7 @@ describe('given the listbox is in an expanded state', () => {
 });
 
 describe('given the listbox is in an expanded state with manual list-selection', () => {
-    const input = mock.Basic_3Options;
+    const input = mock.Basic_3Options_FirstSelected;
 
     beforeEach(async () => {
         component = await render(template, input, { container: form });

--- a/src/components/ebay-listbox-button/test/test.server.js
+++ b/src/components/ebay-listbox-button/test/test.server.js
@@ -20,18 +20,14 @@ describe('listbox', () => {
 
         expect(btnEl).has.attr('aria-haspopup', 'listbox');
         expect(btnEl).has.attr('name', input.buttonName);
-        expect(btnEl).has.text(input.options[0].text);
+        expect(btnEl).has.text('-');
         expect(btnEl).has.class('listbox-button__control');
 
         expect(listboxEl).has.class('listbox-button__listbox');
 
         expect(visibleOptionEls).has.length(3);
-        visibleOptionEls.forEach((optionEl, i) => {
-            if (i === 0) {
-                expect(optionEl).has.attr('aria-selected', 'true');
-            } else {
-                expect(optionEl).does.not.have.attr('aria-selected');
-            }
+        visibleOptionEls.forEach((optionEl) => {
+            expect(optionEl).does.not.have.attr('aria-selected');
         });
     });
 

--- a/src/components/ebay-listbox/component.js
+++ b/src/components/ebay-listbox/component.js
@@ -56,7 +56,7 @@ module.exports = {
 
     onCreate() {
         this.state = {
-            selectedIndex: 0,
+            selectedIndex: -1,
         };
     },
 
@@ -64,7 +64,7 @@ module.exports = {
         const { state } = this;
         input.options = input.options || [];
         state.selectedIndex = Math.max(
-            0,
+            -1,
             input.options.findIndex((option) => option.selected)
         );
     },

--- a/src/components/ebay-listbox/test/mock/index.js
+++ b/src/components/ebay-listbox/test/mock/index.js
@@ -12,6 +12,15 @@ exports.Basic_3Options = {
     })),
 };
 
+exports.Basic_3Options_FirstSelected = {
+    name: 'listbox-name',
+    options: getNItems(3, (i) => ({
+        selected: i === 0,
+        value: String(i),
+        text: `option ${i}`,
+    })),
+};
+
 exports.Basic_3Options_1Selected = {
     name: 'listbox-name',
     options: getNItems(3, (i) => ({

--- a/src/components/ebay-listbox/test/test.browser.js
+++ b/src/components/ebay-listbox/test/test.browser.js
@@ -16,7 +16,7 @@ before(() => document.body.appendChild(form));
 after(() => document.body.removeChild(form));
 
 describe('given the listbox with 3 items', () => {
-    const input = mock.Basic_3Options;
+    const input = mock.Basic_3Options_FirstSelected;
 
     beforeEach(async () => {
         component = await render(template, Object.assign({}, input, { listSelection: 'auto' }), {
@@ -73,7 +73,7 @@ describe('given the listbox with 3 items', () => {
 });
 
 describe('given the listbox is in an expanded state', () => {
-    const input = mock.Basic_3Options;
+    const input = mock.Basic_3Options_FirstSelected;
 
     beforeEach(async () => {
         component = await render(template, Object.assign({}, input, { listSelection: 'auto' }), {
@@ -141,7 +141,7 @@ describe('given the listbox is in an expanded state', () => {
 });
 
 describe('given the listbox is in an expanded state with manual selection', () => {
-    const input = mock.Basic_3Options;
+    const input = mock.Basic_3Options_FirstSelected;
 
     beforeEach(async () => {
         component = await render(template, input, { container: form });

--- a/src/components/ebay-listbox/test/test.server.js
+++ b/src/components/ebay-listbox/test/test.server.js
@@ -20,12 +20,8 @@ describe('listbox', () => {
         expect(listboxEl).has.class('listbox__options');
 
         expect(visibleOptionEls).has.length(3);
-        visibleOptionEls.forEach((optionEl, i) => {
-            if (i === 0) {
-                expect(optionEl).has.attr('aria-selected', 'true');
-            } else {
-                expect(optionEl).does.not.have.attr('aria-selected');
-            }
+        visibleOptionEls.forEach((optionEl) => {
+            expect(optionEl).does.not.have.attr('aria-selected');
         });
     });
 


### PR DESCRIPTION
## Description
Fixed listbox to not selected a default option. 
Added an `unselectedText` attribute to default the initial text when no option is selected. (Should default to - like in skin).
Fixed tests and made sure they work with the new missing attribute. Added a new mock to check for first item selected (As most tests are)

## References
https://github.com/eBay/ebayui-core/issues/1599

## Screenshots
<img width="242" alt="Screen Shot 2022-01-21 at 11 53 54 AM" src="https://user-images.githubusercontent.com/1755269/150591781-47fa001b-e824-4d03-942c-b6cbdd39c8d3.png">
<img width="207" alt="Screen Shot 2022-01-21 at 11 53 56 AM" src="https://user-images.githubusercontent.com/1755269/150591786-8704c741-9b9d-493d-b267-297b6116a0fa.png">
<img width="228" alt="Screen Shot 2022-01-21 at 11 54 00 AM" src="https://user-images.githubusercontent.com/1755269/150591789-bd7dea07-ed9f-4466-87f7-65cd93aa88b1.png">

