### PR TITLE
fix(filter-menu-button): added type to filter menu button storybook

### DIFF
--- a/src/components/ebay-filter-menu-button/filter-menu-button.stories.js
+++ b/src/components/ebay-filter-menu-button/filter-menu-button.stories.js
@@ -23,6 +23,11 @@ export default {
             control: { type: 'text' },
             description: 'button text',
         },
+        type: {
+            options: ['radio', 'checkbox'],
+            control: { type: 'select' },
+            description: 'Can be "radio" / "checkbox"',
+        },
         a11yText: {
             control: { type: 'text' },
             description: 'a11y text for the button',

--- a/src/components/ebay-filter-menu/filter-menu.stories.js
+++ b/src/components/ebay-filter-menu/filter-menu.stories.js
@@ -20,7 +20,8 @@ export default {
 
     argTypes: {
         type: {
-            control: { type: 'text' },
+            options: ['radio', 'checkbox'],
+            control: { type: 'select' },
             description: 'Can be "radio" / "checkbox"',
         },
         variant: {


### PR DESCRIPTION
## Description
Added `type` to filter-menu-button storybook. Fixed type to be dropdown options (and fixed it in filter-menu)

## References
https://github.com/eBay/ebayui-core/issues/1591

## Screenshots
<img width="813" alt="Screen Shot 2022-01-21 at 12 13 06 PM" src="https://user-images.githubusercontent.com/1755269/150593906-c5041fd1-4dcd-4001-82ea-ffa9fcc9bfa0.png">

