### PR TITLE
fix(progress-spinner): added override for progress spinner

### DIFF
--- a/src/components/ebay-filter-menu/examples/01-basic/template.marko
+++ b/src/components/ebay-filter-menu/examples/01-basic/template.marko
@@ -1,4 +1,11 @@
-<ebay-filter-menu>
+class {
+    handleChange({el}) {
+        console.log(el.getAttribute('aria-checked'));
+    }
+
+}
+
+<ebay-filter-menu on-change('handleChange')>
     <@item value="item 1">item 1</@item>
     <@item value="item 2">item 2</@item>
     <@item value="item 3">item 3</@item>

--- a/src/components/ebay-filter-menu/filter-menu.stories.js
+++ b/src/components/ebay-filter-menu/filter-menu.stories.js
@@ -2,6 +2,7 @@ import { tagToString } from '../../../.storybook/storybook-code-source';
 import { addRenderBodies } from '../../../.storybook/utils';
 import Readme from './README.md';
 import Component from './index.marko';
+import ex from './examples/01-basic/template.marko';
 
 const Template = (args) => ({
     input: addRenderBodies(args),
@@ -133,3 +134,7 @@ Standard.parameters = {
         },
     },
 };
+
+export const Exam = () => ({
+    component: ex,
+});

--- a/src/components/ebay-progress-spinner/component.js
+++ b/src/components/ebay-progress-spinner/component.js
@@ -1,0 +1,34 @@
+const standard = 'https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-small.svg';
+const large = 'https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-large.svg';
+const standardDark = 'https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-dark-mode.svg';
+const largeDark =
+    'https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-large-dark-mode.svg';
+
+module.exports = class {
+    // This is done because there are issues in css backgorund-image which tries to parse this file
+    // This is a way to make it work without using CSS
+    onCreate() {
+        this.state = {
+            dark: false,
+        };
+    }
+    onMount() {
+        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            this.state.dark = true;
+        } else {
+            this.state.dark = false;
+        }
+    }
+    getIcon(input) {
+        let current = standard;
+        if (this.state.dark) {
+            current = standardDark;
+            if (input.size === 'large') {
+                current = largeDark;
+            }
+        } else if (input.size === 'large') {
+            current = large;
+        }
+        return current;
+    }
+};

--- a/src/components/ebay-progress-spinner/index.marko
+++ b/src/components/ebay-progress-spinner/index.marko
@@ -1,8 +1,13 @@
 import processHtmlAttributes from "../../common/html-attributes"
 
-static var ignoredAttributes = ["class", "size"];
+static var ignoredAttributes = ["class", "size", "style"];
+
+$ var current = component.getIcon(input);
 
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
     class=["progress-spinner", input.size === "large" && "progress-spinner--large", input.class]
+    style=[input.style, {
+        'background-image': `url(${current})`
+    }]
     role="img"/>


### PR DESCRIPTION
## Description
So because of all the issues with CSS progress spinner and double encoding, I added the spinner background-icon url directly in ebayui. 
This solves the issue (verified it on a sample page)
Added logic to switch between dark-mode as well (@DylanPiercey can you offer a solution if there's a better way to toggle the icon).
I had tried to go the route where we generate the icon, but the icon was having issues importing (need to be normalized I believe)

## References
https://github.com/eBay/skin/issues/1648

## Screenshots
<img width="109" alt="Screen Shot 2022-01-25 at 6 39 19 PM" src="https://user-images.githubusercontent.com/1755269/151095101-a3b9a0fb-bb89-4c28-aa80-40c3e27ebb43.png">
<img width="131" alt="Screen Shot 2022-01-25 at 6 39 25 PM" src="https://user-images.githubusercontent.com/1755269/151095102-befcbe6d-e7b4-42c7-a2c1-d9a0938f08c5.png">
