### PR TITLE
updated package that have an unment dependency i.e nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,14 +151,14 @@
   },
   "dependencies": {
     "@marko-tags/subscribe": "^0.4.2",
-    "makeup-active-descendant": "0.4.0",
-    "makeup-expander": "~0.9.0",
+    "makeup-active-descendant": "0.5.0",
+    "makeup-expander": "~0.10.0",
     "makeup-floating-label": "~0.2.1",
     "makeup-focusables": "~0.2.0",
     "makeup-key-emitter": "~0.2.0",
     "makeup-keyboard-trap": "~0.3.0",
     "makeup-prevent-scroll-keys": "~0.1.0",
-    "makeup-roving-tabindex": "~0.4.0",
+    "makeup-roving-tabindex": "~0.5.0",
     "makeup-screenreader-trap": "~0.3.0",
     "makeup-typeahead": "^0.1.0"
   },


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
ebayui-core has an unmet dependency on nanoid.
nanoid has been removed as dependency from the makeup-next-id NPM package.
Updating these three packages fixes the issue.
## Context
<!--- Why did you make these changes, and why in this particular way? -->

## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->

## Screenshots
<!-- Upload screenshots if appropriate. -->
<img width="486" alt="Screen Shot 2022-02-02 at 6 08 35 PM" src="https://user-images.githubusercontent.com/16830503/152258946-cd638b98-c997-4787-bb85-0f16b4e26c8b.png">

