### PR TITLE
feat(dialog): added close focus attribute (and other cleanup)

### DIFF
--- a/src/components/components/ebay-dialog-base/component.js
+++ b/src/components/components/ebay-dialog-base/component.js
@@ -23,10 +23,14 @@ module.exports = {
         this.clickTarget = el;
     },
 
-    getActiveElement() {
+    getActiveElement(input) {
+        let closeFocusEl;
+        if (input && input.closeFocus) {
+            closeFocusEl = document.getElementById(input.closeFocus);
+        }
         const el =
             document.activeElement === document.body ? this.clickTarget : document.activeElement;
-        return el;
+        return closeFocusEl || el;
     },
 
     handleStartClick({ target }) {
@@ -165,7 +169,7 @@ module.exports = {
 
         // Ensure focus is set and body scroll prevented on initial render.
         if (isFirstRender && this.input.isModal && isTrapped) {
-            this._prevFocusEl = this.getActiveElement();
+            this._prevFocusEl = this.getActiveElement(this.input);
             this._triggerFocus(focusEl);
             this._triggerBodyScroll(true);
         }
@@ -205,7 +209,7 @@ module.exports = {
 
             if (isTrapped) {
                 if (!isFirstRender) {
-                    this._prevFocusEl = this.getActiveElement();
+                    this._prevFocusEl = this.getActiveElement(this.input);
                     this._triggerBodyScroll(true);
                     this.cancelTransition = transition(
                         {

--- a/src/components/components/ebay-dialog-base/index.marko
+++ b/src/components/components/ebay-dialog-base/index.marko
@@ -7,6 +7,7 @@ static var ignoredAttributes = [
     "type",
     "classPrefix",
     "focus",
+    "closeFocus",
     "a11yCloseText",
     "windowClass",
     "baseEl",
@@ -15,6 +16,7 @@ static var ignoredAttributes = [
     "transitionEl",
     "isModal",
     "closeButton",
+    "closeButtonClass",
     "ignoreEscape",
     "windowType",
     "mainId",
@@ -46,7 +48,7 @@ $ var header = input.header;
     <if(buttonPosition !== "hidden")>
         <button
             key="close"
-            class=["icon-btn", input.classPrefix == "toast-dialog" && "icon-btn--transparent", `${input.classPrefix}__close` ]
+            class=["icon-btn", input.closeButtonClass, `${input.classPrefix}__close` ]
             type="button"
             aria-label=input.a11yCloseText
             onClick("handleCloseButtonClick")>

--- a/src/components/ebay-alert-dialog/alertDialog.stories.js
+++ b/src/components/ebay-alert-dialog/alertDialog.stories.js
@@ -27,6 +27,11 @@ export default {
                 disable: true,
             },
         },
+        closeFocus: {
+            control: { type: 'text' },
+            description:
+                'An id for an element which will receive focus when the dialog closes. Defaults to the last clicked element before the dialog is opened',
+        },
         'confirm-text': {
             control: { type: 'text' },
             description: 'Text for confirm button',

--- a/src/components/ebay-alert-dialog/marko-tag.json
+++ b/src/components/ebay-alert-dialog/marko-tag.json
@@ -7,6 +7,7 @@
   "@html-attributes": "expression",
   "@open": "boolean",
   "@confirm-text": "string",
+  "@close-focus": "string",
   "@role": "never",
   "@hidden": "never",
   "@footer": "never",

--- a/src/components/ebay-confirm-dialog/confirm-dialog.stories.js
+++ b/src/components/ebay-confirm-dialog/confirm-dialog.stories.js
@@ -27,6 +27,11 @@ export default {
                 disable: true,
             },
         },
+        closeFocus: {
+            control: { type: 'text' },
+            description:
+                'An id for an element which will receive focus when the dialog closes. Defaults to the last clicked element before the dialog is opened',
+        },
         'confirm-text': {
             control: { type: 'text' },
             description: 'Text for confirm button',

--- a/src/components/ebay-confirm-dialog/index.marko
+++ b/src/components/ebay-confirm-dialog/index.marko
@@ -2,7 +2,6 @@ $ var confirmId = component.getElId("confirm-dialog-confirm");
 $ var mainId = component.getElId("confirm-dialog-main");
 <ebay-dialog-base
     ...input
-    variant="_confirm"
     open=input.open
     on-open("emit", "open")
     on-close("emit", "reject")

--- a/src/components/ebay-confirm-dialog/marko-tag.json
+++ b/src/components/ebay-confirm-dialog/marko-tag.json
@@ -6,6 +6,7 @@
   },
   "@html-attributes": "expression",
   "@open": "boolean",
+  "@close-focus": "string",
   "@confirm-text": "string",
   "@reject-text": "string",
   "@role": "never",

--- a/src/components/ebay-drawer-dialog/drawer-dialog.stories.js
+++ b/src/components/ebay-drawer-dialog/drawer-dialog.stories.js
@@ -37,6 +37,11 @@ export default {
             description:
                 'An id for an element which will receive focus when the drawer opens (defaults to close button).',
         },
+        closeFocus: {
+            control: { type: 'text' },
+            description:
+                'An id for an element which will receive focus when the dialog closes. Defaults to the last clicked element before the dialog is opened',
+        },
         a11yCloseText: {
             control: { type: 'text' },
             description: 'A11y text for close button and mask.',

--- a/src/components/ebay-drawer-dialog/marko-tag.json
+++ b/src/components/ebay-drawer-dialog/marko-tag.json
@@ -8,6 +8,7 @@
   "@open": "boolean",
   "@expanded": "boolean",
   "@focus": "string",
+  "@close-focus": "string",
   "@a11y-close-text": "string",
   "@a11y-minimize-text": "string",
   "@a11y-maximize-text": "string",

--- a/src/components/ebay-fullscreen-dialog/fullsceen-dialog.stories.js
+++ b/src/components/ebay-fullscreen-dialog/fullsceen-dialog.stories.js
@@ -32,6 +32,11 @@ export default {
             description:
                 'An id for an element which will receive focus when the dialog opens (defaults to close button).',
         },
+        closeFocus: {
+            control: { type: 'text' },
+            description:
+                'An id for an element which will receive focus when the dialog closes. Defaults to the last clicked element before the dialog is opened',
+        },
         a11yCloseText: {
             control: { type: 'text' },
             description: 'A11y text for close button and mask.',

--- a/src/components/ebay-fullscreen-dialog/marko-tag.json
+++ b/src/components/ebay-fullscreen-dialog/marko-tag.json
@@ -8,6 +8,7 @@
   "@html-attributes": "expression",
   "@open": "boolean",
   "@focus": "string",
+  "@close-focus": "string",
   "@a11y-close-text": "string",
   "@role": "never",
   "@hidden": "never",

--- a/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
+++ b/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
@@ -29,6 +29,11 @@ export default {
             description:
                 'An id for an element which will receive focus when the dialog opens (defaults to close button).',
         },
+        closeFocus: {
+            control: { type: 'text' },
+            description:
+                'An id for an element which will receive focus when the dialog closes. Defaults to the last clicked element before the dialog is opened',
+        },
         a11yCloseText: {
             control: { type: 'text' },
             description: 'A11y text for close button and mask.',

--- a/src/components/ebay-lightbox-dialog/marko-tag.json
+++ b/src/components/ebay-lightbox-dialog/marko-tag.json
@@ -7,6 +7,7 @@
   "@html-attributes": "expression",
   "@open": "boolean",
   "@focus": "string",
+  "@close-focus": "string",
   "@a11y-close-text": "string",
   "@role": "never",
   "@hidden": "never",

--- a/src/components/ebay-panel-dialog/marko-tag.json
+++ b/src/components/ebay-panel-dialog/marko-tag.json
@@ -8,6 +8,7 @@
   "@html-attributes": "expression",
   "@open": "boolean",
   "@focus": "string",
+  "@close-focus": "string",
   "@a11y-close-text": "string",
   "@role": "never",
   "@hidden": "never",

--- a/src/components/ebay-panel-dialog/panel-dialog.stories.js
+++ b/src/components/ebay-panel-dialog/panel-dialog.stories.js
@@ -43,6 +43,11 @@ export default {
             description:
                 'An id for an element which will receive focus when the dialog opens (defaults to close button)',
         },
+        closeFocus: {
+            control: { type: 'text' },
+            description:
+                'An id for an element which will receive focus when the dialog closes. Defaults to the last clicked element before the dialog is opened',
+        },
         a11yCloseText: {
             control: { type: 'text' },
             description: 'A11y text for close button and mask.',

--- a/src/components/ebay-toast-dialog/index.marko
+++ b/src/components/ebay-toast-dialog/index.marko
@@ -11,6 +11,7 @@ $ var header = input.header || {};
     buttonPosition="right"
     on-open("emit", "open")
     on-close("emit", "close")
+    closeButtonClass = ["icon-btn--transparent"]
     class=[input.class, "toast-dialog--transition"]>
     <@header ...header class=[header.class, "toast-dialog__title"] />
     <${input.renderBody}/>


### PR DESCRIPTION

## Description
* Added close-focus attribute to focus an element on close. This will normally default to the button clicked to open the dialog. 
* Removed unused variable
* Cleaned up a bit of code smell (added `close-button-class` attribute to control the close buttons class)

## References
[#1597](https://github.com/eBay/ebayui-core/issues/1597)
[#1540](https://github.com/eBay/ebayui-core/issues/1540)
[#1612](https://github.com/eBay/ebayui-core/issues/1612)

## Screenshots
Tested this by changing `src/components/ebay-lightbox-dialog/examples/01-basic/template.marko` to add `closeFocus="testid"` to dialog and added `<ebay-textbox id="testid"/>` to the template
![dialog](https://user-images.githubusercontent.com/1755269/152842045-0f774cec-3897-441f-b5d3-8d122364c9b7.gif)

