### PR TITLE
fix(carousel): fixed to call isAnimating as a function

### DIFF
--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -19,7 +19,7 @@ function getTemplateData(state) {
     const nextControlDisabled =
         isSingleSlide || (!autoplayInterval && offset === getMaxOffset(state));
     // If left/right is undefined, the carousel is moving at that moment. We should keep the old disabled state
-    const bothControlsDisabled = isAnimating
+    const bothControlsDisabled = isAnimating(state)
         ? state.bothControlsDisabled
         : prevControlDisabled && nextControlDisabled;
     let slide, itemWidth, totalSlides, a11yStatusText;


### PR DESCRIPTION
## Description
* `isAnimating` is actually a function, but this was being called as a reference. Simply changed it to be called as a function. 

## References
https://github.com/eBay/ebayui-core/issues/1616

## Screenshots
<img width="443" alt="Screen Shot 2022-02-07 at 4 03 56 PM" src="https://user-images.githubusercontent.com/1755269/152892643-b9c4b331-62b9-4704-9e9c-ae9f064048b8.png">
<img width="1443" alt="Screen Shot 2022-02-07 at 4 04 07 PM" src="https://user-images.githubusercontent.com/1755269/152892645-a8fb7bd7-ea49-4397-809d-dca063957e8a.png">

