### PR TITLE
fix(filter-menu): added index and currentChecked arguments

### DIFF
--- a/src/components/ebay-filter-menu-button/component.js
+++ b/src/components/ebay-filter-menu-button/component.js
@@ -11,7 +11,7 @@ module.exports = Object.assign({}, menuUtils, {
         // TODO: the event data from the filter-menu should probably
         // change to include which items are checked not just the values.
         this.toggleChecked(checkedIndex);
-        this._emitComponentEvent('change', el, originalEvent, index, currentChecked);
+        this._emitComponentEvent('change', originalEvent, { el, index, currentChecked });
     },
 
     handleFooterButtonClick() {
@@ -24,11 +24,11 @@ module.exports = Object.assign({}, menuUtils, {
     },
 
     handleExpand({ originalEvent }) {
-        this._emitComponentEvent('expand', null, originalEvent);
+        this._emitComponentEvent('expand', originalEvent);
     },
 
     handleCollapse({ originalEvent }) {
-        this._emitComponentEvent('collapse', null, originalEvent);
+        this._emitComponentEvent('collapse', originalEvent);
     },
 
     onInput(input) {
@@ -54,7 +54,8 @@ module.exports = Object.assign({}, menuUtils, {
         this._cleanupMakeup();
     },
 
-    _emitComponentEvent(eventType, el, originalEvent, index, currentChecked) {
+    _emitComponentEvent(eventType, originalEvent, args) {
+        const { el, index, currentChecked } = args || {};
         switch (eventType) {
             case 'expand':
                 this.emit(eventType);

--- a/src/components/ebay-filter-menu-button/component.js
+++ b/src/components/ebay-filter-menu-button/component.js
@@ -7,11 +7,11 @@ module.exports = Object.assign({}, menuUtils, {
         eventUtils.handleEscapeKeydown(originalEvent, () => (this._expander.expanded = false));
     },
 
-    handleMenuChange({ checkedIndex, el, originalEvent }) {
+    handleMenuChange({ checkedIndex, el, originalEvent, index, currentChecked }) {
         // TODO: the event data from the filter-menu should probably
         // change to include which items are checked not just the values.
         this.toggleChecked(checkedIndex);
-        this._emitComponentEvent('change', el, originalEvent);
+        this._emitComponentEvent('change', el, originalEvent, index, currentChecked);
     },
 
     handleFooterButtonClick() {
@@ -54,7 +54,7 @@ module.exports = Object.assign({}, menuUtils, {
         this._cleanupMakeup();
     },
 
-    _emitComponentEvent(eventType, el, originalEvent) {
+    _emitComponentEvent(eventType, el, originalEvent, index, currentChecked) {
         switch (eventType) {
             case 'expand':
                 this.emit(eventType);
@@ -68,6 +68,8 @@ module.exports = Object.assign({}, menuUtils, {
                     el,
                     checked,
                     originalEvent,
+                    index,
+                    currentChecked,
                 });
                 break;
             }

--- a/src/components/ebay-filter-menu-button/filter-menu-button.stories.js
+++ b/src/components/ebay-filter-menu-button/filter-menu-button.stories.js
@@ -125,7 +125,7 @@ export default {
             table: {
                 category: 'Events',
                 defaultValue: {
-                    summary: '{ el, selected }',
+                    summary: '{ el, selected, index, currentChecked, checked }',
                 },
             },
         },

--- a/src/components/ebay-filter-menu-button/test/test.browser.js
+++ b/src/components/ebay-filter-menu-button/test/test.browser.js
@@ -134,6 +134,8 @@ describe('given the menu is in the expanded state', () => {
             const [[eventArg]] = selectEvents;
             expect(eventArg).has.property('el').with.text(firstItemText);
             expect(eventArg).has.property('checked').to.deep.equal(['item 0']);
+            expect(eventArg).has.property('currentChecked').to.equal(true);
+            expect(eventArg).has.property('index').to.equal(0);
         });
     });
 
@@ -150,6 +152,10 @@ describe('given the menu is in the expanded state', () => {
             const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el', firstItem);
             expect(secondEventData).has.property('el', secondItem);
+            expect(firstEventData).has.property('currentChecked').to.equal(true);
+            expect(secondEventData).has.property('currentChecked').to.equal(true);
+            expect(firstEventData).has.property('index').to.equal(0);
+            expect(secondEventData).has.property('index').to.equal(1);
         });
 
         it('then both items are selected', () => {
@@ -171,6 +177,10 @@ describe('given the menu is in the expanded state', () => {
             const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
             expect(secondEventData).has.property('checked').to.deep.equal([]);
+            expect(firstEventData).has.property('currentChecked').to.equal(true);
+            expect(secondEventData).has.property('currentChecked').to.equal(false);
+            expect(firstEventData).has.property('index').to.equal(0);
+            expect(secondEventData).has.property('index').to.equal(0);
         });
 
         it('then the item is unchecked', () => {
@@ -193,6 +203,8 @@ describe('given the menu is in the expanded state', () => {
             const [firstEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el').with.text(firstItemText);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
+            expect(firstEventData).has.property('currentChecked').to.equal(true);
+            expect(firstEventData).has.property('index').to.equal(0);
         });
     });
 
@@ -224,6 +236,8 @@ describe('given the menu is in the expanded state', () => {
 
             const [[eventArg]] = selectEvents;
             expect(eventArg).has.property('el').with.text(thirdItemText);
+            expect(eventArg).has.property('currentChecked').to.equal(true);
+            expect(eventArg).has.property('index').to.equal(2);
         });
     });
 });

--- a/src/components/ebay-filter-menu/component.js
+++ b/src/components/ebay-filter-menu/component.js
@@ -5,13 +5,13 @@ const menuUtils = require('../../common/menu-utils');
 
 module.exports = Object.assign({}, menuUtils, {
     handleRadioClick(index, ev, itemEl) {
-        this._toggleItemChecked(index, itemEl);
+        this._toggleItemChecked(index, ev, itemEl);
     },
 
     handleItemClick(index, ev, itemEl) {
         const targetEv = ev.originalEvent || ev;
         if (this.input.variant !== 'form' || targetEv.target.tagName !== 'INPUT') {
-            this._toggleItemChecked(index, itemEl);
+            this._toggleItemChecked(index, ev, itemEl);
         }
     },
 
@@ -19,22 +19,22 @@ module.exports = Object.assign({}, menuUtils, {
         eventUtils.handleEscapeKeydown(ev, () => {
             // TODO: this event is not documented.
             // Do we need it? (it is only used by the filter-menu-button)
-            this._emitComponentEvent('keydown', null, ev, index);
+            this._emitComponentEvent('keydown', ev, { index });
         });
 
         if (this.input.variant !== 'form') {
             eventUtils.handleActionKeydown(ev, () => {
-                this._toggleItemChecked(index, itemEl);
+                this._toggleItemChecked(index, ev, itemEl);
             });
         }
     },
 
     handleFooterButtonClick(originalEvent) {
-        this._emitComponentEvent('footer-click', null, originalEvent);
+        this._emitComponentEvent('footer-click', originalEvent);
     },
 
     handleFormSubmit(originalEvent) {
-        this._emitComponentEvent('form-submit', null, originalEvent);
+        this._emitComponentEvent('form-submit', originalEvent);
     },
 
     onInput(input) {
@@ -59,12 +59,13 @@ module.exports = Object.assign({}, menuUtils, {
         this._cleanupMakeup();
     },
 
-    _toggleItemChecked(index, itemEl) {
+    _toggleItemChecked(index, originalEvent, el) {
         this.toggleChecked(index);
-        this._emitComponentEvent('change', itemEl, null, index);
+        this._emitComponentEvent('change', originalEvent, { el, index });
     },
 
-    _emitComponentEvent(eventType, el, originalEvent, index) {
+    _emitComponentEvent(eventType, originalEvent, args) {
+        const { el, index } = args || {};
         const checked = this.getCheckedValues();
         const checkedIndex = this.getCheckedIndexes();
         const currentChecked = this.isChecked(index);

--- a/src/components/ebay-filter-menu/component.js
+++ b/src/components/ebay-filter-menu/component.js
@@ -19,7 +19,7 @@ module.exports = Object.assign({}, menuUtils, {
         eventUtils.handleEscapeKeydown(ev, () => {
             // TODO: this event is not documented.
             // Do we need it? (it is only used by the filter-menu-button)
-            this._emitComponentEvent('keydown', null, ev);
+            this._emitComponentEvent('keydown', null, ev, index);
         });
 
         if (this.input.variant !== 'form') {
@@ -61,18 +61,21 @@ module.exports = Object.assign({}, menuUtils, {
 
     _toggleItemChecked(index, itemEl) {
         this.toggleChecked(index);
-        this._emitComponentEvent('change', itemEl);
+        this._emitComponentEvent('change', itemEl, null, index);
     },
 
-    _emitComponentEvent(eventType, el, originalEvent) {
+    _emitComponentEvent(eventType, el, originalEvent, index) {
         const checked = this.getCheckedValues();
         const checkedIndex = this.getCheckedIndexes();
+        const currentChecked = this.isChecked(index);
 
         this.emit(`${eventType}`, {
             el,
             checked,
             checkedIndex,
             originalEvent,
+            index,
+            currentChecked,
         });
     },
 

--- a/src/components/ebay-filter-menu/filter-menu.stories.js
+++ b/src/components/ebay-filter-menu/filter-menu.stories.js
@@ -81,7 +81,7 @@ export default {
             table: {
                 category: 'Events',
                 defaultValue: {
-                    summary: '{ el, checked, originalEvent }',
+                    summary: '{ el, checked, itemChecked, index, originalEvent }',
                 },
             },
         },

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -71,6 +71,10 @@ describe('given the menu is in the default state', () => {
             const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
             expect(secondEventData).has.property('checked').to.deep.equal([]);
+            expect(firstEventData).has.property('currentChecked').to.equal(true);
+            expect(secondEventData).has.property('currentChecked').to.equal(false);
+            expect(firstEventData).has.property('index').to.equal(0);
+            expect(secondEventData).has.property('index').to.equal(0);
         });
 
         it('then the item is unchecked', () => {
@@ -93,6 +97,8 @@ describe('given the menu is in the default state', () => {
             const [firstEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el').with.text(firstItemText);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
+            expect(firstEventData).has.property('currentChecked').to.equal(true);
+            expect(firstEventData).has.property('index').to.equal(0);
         });
     });
 
@@ -121,6 +127,8 @@ describe('given the menu is in the default state', () => {
 
             const [[eventArg]] = selectEvents;
             expect(eventArg).has.property('checked').to.deep.equal(['item 2']);
+            expect(eventArg).has.property('currentChecked').to.equal(true);
+            expect(eventArg).has.property('index').to.equal(2);
         });
     });
 });
@@ -149,6 +157,8 @@ describe('given the menu is in the radio state', () => {
             const [[eventArg]] = selectEvents;
             expect(eventArg).has.property('el').with.text(firstItemText);
             expect(eventArg).has.property('checked').to.deep.equal(['item 0']);
+            expect(eventArg).has.property('currentChecked').to.equal(true);
+            expect(eventArg).has.property('index').to.equal(0);
         });
     });
 
@@ -165,6 +175,10 @@ describe('given the menu is in the radio state', () => {
             const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el', firstItem);
             expect(secondEventData).has.property('el', secondItem);
+            expect(firstEventData).has.property('currentChecked').to.equal(true);
+            expect(secondEventData).has.property('currentChecked').to.equal(true);
+            expect(firstEventData).has.property('index').to.equal(0);
+            expect(secondEventData).has.property('index').to.equal(1);
         });
 
         it('then only last item is selected', () => {
@@ -186,6 +200,10 @@ describe('given the menu is in the radio state', () => {
             const [firstEventData, secondEventData] = changeEvents.flat();
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
             expect(secondEventData).has.property('checked').to.deep.equal(['item 0']);
+            expect(firstEventData).has.property('currentChecked').to.equal(true);
+            expect(secondEventData).has.property('currentChecked').to.equal(true);
+            expect(firstEventData).has.property('index').to.equal(0);
+            expect(secondEventData).has.property('index').to.equal(0);
         });
 
         it('then the item is still checked', () => {
@@ -208,6 +226,8 @@ describe('given the menu is in the radio state', () => {
             const [firstEventData] = changeEvents.flat();
             expect(firstEventData).has.property('el').with.text(firstItemText);
             expect(firstEventData).has.property('checked').to.deep.equal(['item 0']);
+            expect(firstEventData).has.property('currentChecked').to.equal(true);
+            expect(firstEventData).has.property('index').to.equal(0);
         });
     });
 
@@ -236,6 +256,8 @@ describe('given the menu is in the radio state', () => {
 
             const [[eventArg]] = selectEvents;
             expect(eventArg).has.property('checked').to.deep.equal(['item 2']);
+            expect(eventArg).has.property('currentChecked').to.equal(true);
+            expect(eventArg).has.property('index').to.equal(2);
         });
     });
 });


### PR DESCRIPTION
## Description
* Added extra arguments to change event for filter-menu and filter-menu-button. Added `index` which is the index of the clicked item and `checkedValue` which will be true/false depending if that item is checked (on radio it will always be checked. I kept it for radio to be consistent) 

## References
https://github.com/eBay/ebayui-core/issues/1607

## Screenshots
<img width="895" alt="Screen Shot 2022-02-14 at 10 47 15 AM" src="https://user-images.githubusercontent.com/1755269/153926947-29967a57-18ca-4e4d-8c70-eecea718817e.png">
<img width="956" alt="Screen Shot 2022-02-14 at 10 47 31 AM" src="https://user-images.githubusercontent.com/1755269/153926951-53c51a79-10f4-4480-b806-1ad7bd0c4c8e.png">

