### PR TITLE
fix(notice): updated to show link on examples

### DIFF
--- a/src/components/ebay-page-notice/README.md
+++ b/src/components/ebay-page-notice/README.md
@@ -21,18 +21,16 @@ The `<ebay-page-notice>` is a tag used to create a custom-designed notice elemen
 <ebay-page-notice a11y-text="Attention" status="attention" type="page">
     <@title>An Error</@title>
     <p>Couldn't load all the items, please try again later.</p>
-    <@footer>
-        <ebay-button priority="secondary" transparent>Try again</ebay-button>
-    </@footer>
+    <@footer><ebay-fake-link>Try again</ebay-fake-link></@footer>
 </ebay-page-notice>
 ```
 
 ## ebay-page-notice Sub-tags
 
-| Tag         | Required | Description                                                             |
-| ----------- | -------- | ----------------------------------------------------------------------- |
-| `<@title>`  | No       | The title content to be displayed. Used mostly for celebration notice   |
-| `<@footer>` | No       | The footer content to be displayed. Used to show a CTA button generally |
+| Tag         | Required | Description                                                           |
+| ----------- | -------- | --------------------------------------------------------------------- |
+| `<@title>`  | No       | The title content to be displayed. Used mostly for celebration notice |
+| `<@footer>` | No       | The footer content to be displayed. Used to show a ebay-fake-link     |
 
 ## ebay-page-notice Attributes
 

--- a/src/components/ebay-page-notice/examples/button.marko
+++ b/src/components/ebay-page-notice/examples/button.marko
@@ -1,1 +1,1 @@
-<ebay-button>Footer</ebay-button>
+<ebay-fake-link>Footer</ebay-fake-link>

--- a/src/components/ebay-section-notice/README.md
+++ b/src/components/ebay-section-notice/README.md
@@ -22,15 +22,15 @@ This notice should be used at the top of various sections to display information
 ```marko
 <ebay-section-notice a11y-text="Attention" status="attention">
     <p>Couldn't load all the items, please try again later.</p>
-    <@footer><ebay-button priority="secondary" transparent>Try again</ebay-button></@footer>
+    <@footer><ebay-fake-link>Try again</ebay-fake-link></@footer>
 </ebay-section-notice>
 ```
 
 ## ebay-section-notice Sub-tags
 
-| Tag         | Required | Description                         |
-| ----------- | -------- | ----------------------------------- |
-| `<@footer>` | No       | The footer content (for cta button) |
+| Tag         | Required | Description                             |
+| ----------- | -------- | --------------------------------------- |
+| `<@footer>` | No       | The footer content (for ebay-fake-link) |
 
 ## ebay-section-notice Attributes
 

--- a/src/components/ebay-section-notice/examples/button.marko
+++ b/src/components/ebay-section-notice/examples/button.marko
@@ -1,1 +1,1 @@
-<ebay-button>Footer</ebay-button>
+<ebay-fake-link>Footer</ebay-fake-link>


### PR DESCRIPTION
## Description
Added links to section notice to storybook example

## Screenshots
<img width="514" alt="Screen Shot 2022-02-16 at 11 20 08 AM" src="https://user-images.githubusercontent.com/1755269/154340148-c848da1b-9494-49f5-a64b-a5972fb12b9f.png">
<img width="570" alt="Screen Shot 2022-02-16 at 11 22 23 AM" src="https://user-images.githubusercontent.com/1755269/154340152-c2f8dfa4-aa68-4c43-8c65-d160c4914254.png">

