### PR TITLE
feat(destructive-buttons): implementing destructive button variant

### DIFF
--- a/src/components/ebay-button/button.stories.js
+++ b/src/components/ebay-button/button.stories.js
@@ -91,6 +91,17 @@ export default {
                 },
             },
         },
+        variant: {
+            options: ['destructive'],
+            description:
+                'transforms to a specific variant that styles in conjunction with priority',
+            table: {
+                defaultValue: {
+                    summary: 'none',
+                },
+            },
+            type: { category: 'Options' },
+        },
         'partially-disabled': {
             description: 'programmatically disabled, but remains keyboard focusable',
             table: {
@@ -192,6 +203,7 @@ Standard.args = {
     transparent: false,
     'fixed-height': false,
     truncate: false,
+    destructive: false,
 };
 
 Standard.parameters = {

--- a/src/components/ebay-button/button.stories.js
+++ b/src/components/ebay-button/button.stories.js
@@ -92,12 +92,12 @@ export default {
             },
         },
         variant: {
-            options: ['destructive'],
+            options: ['standard', 'destructive'],
             description:
                 'transforms to a specific variant that styles in conjunction with priority',
             table: {
                 defaultValue: {
-                    summary: 'none',
+                    summary: 'standard',
                 },
             },
             type: { category: 'Options' },
@@ -203,7 +203,6 @@ Standard.args = {
     transparent: false,
     'fixed-height': false,
     truncate: false,
-    destructive: false,
 };
 
 Standard.parameters = {

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -40,6 +40,7 @@ $ {
     var fixedHeightClass =
         input.fixedHeight &&
         (sizeClass ? sizeClass + "-fixed-height" : baseClass + "--fixed-height");
+    var variantClass = input.variant ? baseClass + "--" + input.variant : "";
     var tag = input.href ? "a" : "button";
     var htmlAttributes = processHtmlAttributes(data, ignoredAttributes);
     if(input.bodyState === "loading") hasLoaded = true;
@@ -58,6 +59,7 @@ $ {
         truncateClass,
         fixedHeightClass,
         transparentClass,
+        variantClass,
         !truncateClass && !fixedHeightClass && sizeClass,
         (validPriorities.includes(priority) &&
         `${baseClass}--${priority}`)

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -16,7 +16,8 @@ static var ignoredAttributes = [
     "truncate",
     "transparent",
     "bodyState",
-    "toJSON"
+    "toJSON",
+    "variant"
 ];
 
 static var validPriorities = [

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -42,7 +42,7 @@ $ {
         input.fixedHeight &&
         (sizeClass ? sizeClass + "-fixed-height" : baseClass + "--fixed-height");
     var variant = input.variant || 'standard';
-    var variantClass = variant !== 'standard' ? `${baseClass}--${input.variant}` : "";
+    var variantClass = variant !== 'standard' && `${baseClass}--${input.variant}`;
     var tag = input.href ? "a" : "button";
     var htmlAttributes = processHtmlAttributes(data, ignoredAttributes);
     if(input.bodyState === "loading") hasLoaded = true;

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -40,7 +40,8 @@ $ {
     var fixedHeightClass =
         input.fixedHeight &&
         (sizeClass ? sizeClass + "-fixed-height" : baseClass + "--fixed-height");
-    var variantClass = input.variant ? baseClass + "--" + input.variant : "";
+    var variant = input.variant || 'standard';
+    var variantClass = variant !== 'standard' ? `${baseClass}--${input.variant}` : "";
     var tag = input.href ? "a" : "button";
     var htmlAttributes = processHtmlAttributes(data, ignoredAttributes);
     if(input.bodyState === "loading") hasLoaded = true;


### PR DESCRIPTION
## Description
Added support for destructive button variant.

## Context
Added destructive option for creating that variant for button.

## References
#1593 

## Screenshots
<img width="194" alt="sbook-destructive-p" src="https://user-images.githubusercontent.com/1675667/154739587-92e52908-059e-4088-8370-a6a01665eea3.png">
<img width="197" alt="sbook-destructive-s" src="https://user-images.githubusercontent.com/1675667/154739585-89e46487-d0db-458d-9a7c-2d926b56899d.png">
<img width="154" alt="sbook-destructive-t" src="https://user-images.githubusercontent.com/1675667/154739583-02bb021e-8623-4ee9-b978-1d9992fb3d8b.png">

<img width="163" alt="sbook-destructive-p-loading" src="https://user-images.githubusercontent.com/1675667/154739581-7e5cd633-3bc7-4a7e-9cd0-d05f00ebd59d.png">
<img width="162" alt="sbook-destructive-s-loading" src="https://user-images.githubusercontent.com/1675667/154739580-5ae52e1f-91ff-4268-a0e6-ab4ceb9d5126.png">
<img width="160" alt="sbook-destructive-t-loading" src="https://user-images.githubusercontent.com/1675667/154739576-d923a2f9-57bb-4d8b-88ef-1dea22539e80.png">