### PR TITLE
fix(menu): fixed separator for marko 5

### DIFF
--- a/src/common/transformers/menu-separator/index.js
+++ b/src/common/transformers/menu-separator/index.js
@@ -7,25 +7,30 @@ function transformMarko4(el, context) {
         enter(node) {
             if (node.tagName === '@separator') {
                 node.setTagName('@item');
-                node.setAttributeValue('_isSeparator', context.builder.literalTrue());
+                node.setAttributeValue('separator', context.builder.literalTrue());
             }
         },
     });
     walker.walk(el);
     return el;
 }
+
+const replaceSeparatorVisitor = {
+    MarkoTag(tag, { t }) {
+        if (tag.get('name').isStringLiteral({ value: '@separator' })) {
+            tag.replaceWith(
+                t.markoTag(
+                    t.stringLiteral('@item'),
+                    [t.markoAttribute('separator', t.booleanLiteral(true))],
+                    t.markoTagBody()
+                )
+            );
+        }
+    },
+};
+
 function transformMarko5(path, t) {
-    path.traverse({
-        MarkoTag(tag) {
-            if (tag.get('name').isStringLiteral({ value: '@separator' })) {
-                tag.set('name.value', '@item');
-                tag.pushContainer(
-                    'attributes',
-                    t.markoAttribute('_isSeparator', t.booleanLiteral(true))
-                );
-            }
-        },
-    });
+    path.traverse(replaceSeparatorVisitor, { t });
 }
 
 module.exports = function transform(a, b) {

--- a/src/common/transformers/menu-separator/test/test.server.js
+++ b/src/common/transformers/menu-separator/test/test.server.js
@@ -11,6 +11,6 @@ describe('when the ebay-menu-separator tag is transformed', () => {
     });
 
     it('transforms the ebay-menu-separator', () => {
-        expect(outputTemplate).to.deep.equal('<@item _isSeparator=true/>');
+        expect(outputTemplate).to.deep.equal('<@item separator=true/>');
     });
 });

--- a/src/components/ebay-fake-menu-button/README.md
+++ b/src/components/ebay-fake-menu-button/README.md
@@ -86,7 +86,7 @@ Adds a line separator between each menu button items
 ```marko
 <ebay-menu>
     <@item>Item1</@item>
-    <ebay-fake-menu-button-separator/>
+    <@separator/>
     <@item>Item2</@item>
 </ebay-menu>
 ```

--- a/src/components/ebay-fake-menu-button/marko-tag.json
+++ b/src/components/ebay-fake-menu-button/marko-tag.json
@@ -42,7 +42,7 @@
     "@current": "boolean",
     "@badge-number": "expression",
     "@badge-aria-label": "string",
-    "@_isSeparator": "boolean"
+    "@separator": "boolean"
   },
   "@label <label>": {
     "@html-attributes": "expression",
@@ -53,6 +53,6 @@
     "@html-attributes": "expression",
     "@class": "string",
     "@style": "string",
-    "@_isSeparator": "boolean"
+    "@separator": "boolean"
   }
 }

--- a/src/components/ebay-fake-menu-button/test/mock/index.js
+++ b/src/components/ebay-fake-menu-button/test/mock/index.js
@@ -19,7 +19,7 @@ exports.Basic_3Items = Object.assign({}, exports.Basic_2Items, {
 exports.Separator_4Items = Object.assign({}, exports.Basic_2Items, {
     items: getNItems(4, (i) => ({
         href: `#${i}`,
-        _isSeparator: i === 2,
+        separator: i === 2,
         renderBody: createRenderBody(`Item text ${i}`),
     })),
 });

--- a/src/components/ebay-fake-menu-button/test/test.server.js
+++ b/src/components/ebay-fake-menu-button/test/test.server.js
@@ -97,7 +97,7 @@ describe('fake-menu-button', () => {
         const { queryByText, getAllByRole } = await render(template, input);
         const separators = getAllByRole('separator');
         input.items.forEach((item) => {
-            if (item._isSeparator) {
+            if (item.separator) {
                 const menuItemEl = separators.shift();
                 const textEl = queryByText(item.renderBody.text);
                 expect(textEl).to.equal(null);

--- a/src/components/ebay-fake-menu/index.marko
+++ b/src/components/ebay-fake-menu/index.marko
@@ -43,7 +43,7 @@ $ var baseClass = input.classPrefix || "fake-menu";
         <for|item, index| of=input.items>
             $ var isDisabled = !item.href || item.disabled;
             $ var defaultAriaCurrent = item.itemMatchesUrl === false ? 'true' : 'page';
-            <if (item._isSeparator)>
+            <if (item.separator)>
                 <li>
                     <hr class=`${baseClass}__separator` role="separator" />
                 </li>

--- a/src/components/ebay-fake-menu/marko-tag.json
+++ b/src/components/ebay-fake-menu/marko-tag.json
@@ -25,12 +25,12 @@
     "@current": "boolean",
     "@badge-number": "expression",
     "@badge-aria-label": "string",
-    "@_isSeparator": "boolean"
+    "@separator": "boolean"
   },
   "@separator <separator>[]": {
     "@html-attributes": "expression",
     "@class": "string",
     "@style": "string",
-    "@_isSeparator": "boolean"
+    "@separator": "boolean"
   }
 }

--- a/src/components/ebay-fake-menu/test/mock/index.js
+++ b/src/components/ebay-fake-menu/test/mock/index.js
@@ -34,7 +34,7 @@ exports.A11y_Current_True = Object.assign({}, exports.Basic_2Items, {
 exports.Separator_4Items = Object.assign({}, exports.Basic_2Items, {
     items: getNItems(4, (i) => ({
         value: `item ${i}`,
-        _isSeparator: i === 2,
+        separator: i === 2,
         renderBody: createRenderBody(`Item text ${i}`),
     })),
 });

--- a/src/components/ebay-fake-menu/test/test.server.js
+++ b/src/components/ebay-fake-menu/test/test.server.js
@@ -40,7 +40,7 @@ describe('fake-menu', () => {
         const { queryByText, getAllByRole } = await render(template, input);
         const separators = getAllByRole('separator');
         input.items.forEach((item) => {
-            if (item._isSeparator) {
+            if (item.separator) {
                 const menuItemEl = separators.shift();
                 const textEl = queryByText(item.renderBody.text);
                 expect(textEl).to.equal(null);

--- a/src/components/ebay-menu-button/marko-tag.json
+++ b/src/components/ebay-menu-button/marko-tag.json
@@ -45,7 +45,7 @@
     "@checked": "boolean",
     "@badge-number": "expression",
     "@badge-aria-label": "string",
-    "@_isSeparator": "boolean"
+    "@separator": "boolean"
   },
   "@label <label>": {
     "@html-attributes": "expression",
@@ -56,6 +56,6 @@
     "@html-attributes": "expression",
     "@class": "string",
     "@style": "string",
-    "@_isSeparator": "boolean"
+    "@separator": "boolean"
   }
 }

--- a/src/components/ebay-menu-button/menu-button.stories.js
+++ b/src/components/ebay-menu-button/menu-button.stories.js
@@ -4,6 +4,7 @@ import Readme from './README.md';
 import badgedExample from './examples/22-badged-items/template.marko';
 import iconExample from './examples/09-icon-with-text/template.marko';
 import typeaheadExample from './examples/18-typeahead/template.marko';
+import separatorExample from './examples/02-separator/template.marko';
 import Component from './index.marko';
 
 const Template = (args) => ({
@@ -199,4 +200,8 @@ export const BadgedItems = () => ({
 });
 export const Typeahead = () => ({
     component: typeaheadExample,
+});
+
+export const Separator = () => ({
+    component: separatorExample,
 });

--- a/src/components/ebay-menu-button/test/mock/index.js
+++ b/src/components/ebay-menu-button/test/mock/index.js
@@ -19,7 +19,7 @@ exports.Basic_3Items = Object.assign({}, exports.Basic_2Items, {
 exports.Separator_4Items = Object.assign({}, exports.Basic_2Items, {
     items: getNItems(4, (i) => ({
         value: `item ${i}`,
-        _isSeparator: i === 2,
+        separator: i === 2,
         renderBody: createRenderBody(`Item text ${i}`),
     })),
 });

--- a/src/components/ebay-menu-button/test/test.server.js
+++ b/src/components/ebay-menu-button/test/test.server.js
@@ -122,7 +122,7 @@ describe('menu-button', () => {
         const menuItemEls = getAllByRole('menuitem');
         const separators = getAllByRole('separator');
         input.items.forEach((item) => {
-            if (item._isSeparator) {
+            if (item.separator) {
                 const menuItemEl = separators.shift();
                 const textEl = queryByText(item.renderBody.text);
                 expect(textEl).to.equal(null);

--- a/src/components/ebay-menu/index.marko
+++ b/src/components/ebay-menu/index.marko
@@ -49,7 +49,7 @@ $ var baseClass = input.classPrefix || "menu";
                                 : "menuitem";
                 var checked = component.isChecked(index);
             }
-            <if (item._isSeparator)>
+            <if (item.separator)>
                 <hr class=`${baseClass}__separator` role="separator" />
             </if>
             <else>

--- a/src/components/ebay-menu/marko-tag.json
+++ b/src/components/ebay-menu/marko-tag.json
@@ -24,12 +24,12 @@
     "@checked": "boolean",
     "@badge-number": "expression",
     "@badge-aria-label": "string",
-    "@_isSeparator": "boolean"
+    "@separator": "boolean"
   },
   "@separator <separator>[]": {
     "@html-attributes": "expression",
     "@class": "string",
     "@style": "string",
-    "@_isSeparator": "boolean"
+    "@separator": "boolean"
   }
 }

--- a/src/components/ebay-menu/test/mock/index.js
+++ b/src/components/ebay-menu/test/mock/index.js
@@ -17,7 +17,7 @@ exports.Basic_3Items = Object.assign({}, exports.Basic_2Items, {
 exports.Separator_4Items = Object.assign({}, exports.Basic_2Items, {
     items: getNItems(4, (i) => ({
         value: `item ${i}`,
-        _isSeparator: i === 2,
+        separator: i === 2,
         renderBody: createRenderBody(`Item text ${i}`),
     })),
 });

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -39,7 +39,7 @@ describe('menu', () => {
         const menuItemEls = getAllByRole('menuitem');
         const separators = getAllByRole('separator');
         input.items.forEach((item) => {
-            if (item._isSeparator) {
+            if (item.separator) {
                 const menuItemEl = separators.shift();
                 const textEl = queryByText(item.renderBody.text);
                 expect(textEl).to.equal(null);


### PR DESCRIPTION

## Description
* There's an issue with the transformer for marko 5
* Basically we are adding support for `<@item separator>` which we can use in the future if needed.
* Added a story for separator (which uses marko 5)

## References
https://github.com/eBay/ebayui-core/issues/1632

## Screenshots
<img width="390" alt="Screen Shot 2022-03-02 at 10 24 41 AM" src="https://user-images.githubusercontent.com/1755269/156424513-8909f79e-787d-4749-93f8-e61bbb8ce74f.png">

