### PR TITLE
feat(combobox): added expanded attribute

### DIFF
--- a/src/components/ebay-combobox/combobox.stories.js
+++ b/src/components/ebay-combobox/combobox.stories.js
@@ -34,12 +34,8 @@ export default {
             description: 'sets the disabled attribute of the input',
         },
         expanded: {
-            type: 'boolean',
             control: { type: 'boolean' },
             description: 'sets whether the listbox is expanded',
-            table: {
-                disable: true,
-            },
         },
         autocomplete: {
             control: { type: 'text' },
@@ -89,6 +85,7 @@ export const FloatingLabel = Template.bind({});
 FloatingLabel.args = {
     name: 'example1text',
     autocomplete: 'list',
+    expanded: false,
     options: [
         { text: 'August Campaign' },
         { text: '4th of July Sale (paused)' },
@@ -116,6 +113,7 @@ export const Isolated = Template.bind({});
 Isolated.args = {
     name: 'example1text',
     autocomplete: 'list',
+    expanded: false,
     options: [
         { text: 'August Campaign' },
         { text: '4th of July Sale (paused)' },

--- a/src/components/ebay-combobox/component.js
+++ b/src/components/ebay-combobox/component.js
@@ -6,6 +6,10 @@ const eventUtils = require('../../common/event-utils');
 const safeRegex = require('../../common/build-safe-regex');
 
 module.exports = {
+    get expanded() {
+        return this.input.expanded === true;
+    },
+
     focus() {
         this.getEl('combobox').focus();
     },
@@ -85,12 +89,12 @@ module.exports = {
                     this._setSelectedText(this._getVisibleOptions()[selectedIndex].text);
                 }
 
-                this.expander.expanded = false;
+                this.expander.expanded = this.expanded;
             }
         });
 
         eventUtils.handleEscapeKeydown(originalEvent, () => {
-            this.expander.expanded = false;
+            this.expander.expanded = this.expanded;
         });
     },
 
@@ -119,7 +123,7 @@ module.exports = {
         }
 
         if (this.expander && this.expander.expanded && !wasClickedOption && !this.buttonClicked) {
-            this.expander.expanded = false;
+            this.expander.expanded = this.expanded;
         }
 
         this.buttonClicked = false;
@@ -154,6 +158,9 @@ module.exports = {
             currentValue: this.lastValue,
             viewAllOptions: (this.state && this.state.viewAllOptions) || true,
         };
+        if (this.expander) {
+            this.expander.expanded = input.expanded === true;
+        }
     },
 
     onMount() {
@@ -191,14 +198,15 @@ module.exports = {
             );
 
             this.expander = new Expander(this.el, {
-                autoCollapse: true,
+                autoCollapse: !this.expanded,
                 expandOnFocus: true,
-                collapseOnFocusOut: !this.input.readonly && !this.input.button,
+                collapseOnFocusOut: !this.expanded && !this.input.button,
                 contentSelector: '[role="listbox"]',
                 hostSelector: '[role="combobox"]',
                 expandedClass: 'combobox--expanded',
                 simulateSpacebarClick: true,
             });
+            this.expander.expanded = this.expanded;
         }
         // TODO: makeup-floating-label should be updated so that we can remove the event listeners.
         // It probably makes more sense to just move this functionality into Marko though.

--- a/src/components/ebay-combobox/index.marko
+++ b/src/components/ebay-combobox/index.marko
@@ -8,7 +8,8 @@ static var ignoredAttributes = [
     "options",
     "roledescription",
     "floatingLabel",
-    "listSelection"
+    "listSelection",
+    "expanded"
 ];
 
 static var ignoredButtonAttributes = [

--- a/src/components/ebay-combobox/marko-tag.json
+++ b/src/components/ebay-combobox/marko-tag.json
@@ -9,6 +9,7 @@
   "@floating-label": "string",
   "@borderless": "boolean",
   "@autocomplete": "string",
+  "@expanded": "boolean",
   "@list-selection": {
     "enum": ["automatic", "manual"]
   },


### PR DESCRIPTION
## Description
* Added expanded attribute.
* Used the expanded to always force expanded state. Only collapses when expanded is false (and then regular behavior happens.)

## References
https://github.com/eBay/ebayui-core/issues/1673