### PR TITLE
fix: removed aria-live from loading button

### DIFF
--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -28,7 +28,6 @@ static var validPriorities = [
     'delete'
 ];
 
-static var hasLoaded;
 $ {
     input.toJSON = toJSON;
     var size = input.size === "large" ? "large" : null;
@@ -47,9 +46,6 @@ $ {
     var tag = input.href ? "a" : "button";
     var split = input.split || 'none';
     var htmlAttributes = processHtmlAttributes(data, ignoredAttributes);
-    if(input.bodyState === "loading") hasLoaded = true;
-    else if (input.bodyState === "reset") hasLoaded = false;
-
 }
 <${tag}
     ...htmlAttributes
@@ -74,7 +70,6 @@ $ {
     type=(tag === "button" && (input.type || "button"))
     aria-disabled=((input.partiallyDisabled || input.loading) && "true")
     aria-label=(input.bodyState === "loading" ? (input.a11yText || "Loading...") : input.ariaLabel)
-    aria-live=((input.bodyState === "loading" || hasLoaded) && "polite")
     >
     <if(input.bodyState === "loading")>
         <span class="btn__cell">

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -68,7 +68,7 @@ $ {
     ]
     data-ebayui=true
     type=(tag === "button" && (input.type || "button"))
-    aria-disabled=((input.partiallyDisabled || input.loading) && "true")
+    aria-disabled=((input.partiallyDisabled) && "true")
     aria-label=(input.bodyState === "loading" ? (input.a11yText || "Loading...") : input.ariaLabel)
     >
     <if(input.bodyState === "loading")>

--- a/src/components/ebay-split-button/test/__snapshots__/renders-button-with-priority-delete.expected.html
+++ b/src/components/ebay-split-button/test/__snapshots__/renders-button-with-priority-delete.expected.html
@@ -3,7 +3,6 @@
     [33mclass[39m=[32m"split-button"[39m
   [36m>[39m
     [36m<button[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mclass[39m=[32m"btn btn--split-start btn--delete"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
@@ -22,7 +21,6 @@
       [36m<button[39m
         [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"true"[39m
-        [33maria-live[39m=[32m"polite"[39m
         [33mclass[39m=[32m"menu-button__button btn btn--split-end btn--delete"[39m
         [33mdata-ebayui[39m=[32m""[39m
         [33mtype[39m=[32m"button"[39m

--- a/src/components/ebay-split-button/test/__snapshots__/renders-button-with-priority-primary.expected.html
+++ b/src/components/ebay-split-button/test/__snapshots__/renders-button-with-priority-primary.expected.html
@@ -3,7 +3,6 @@
     [33mclass[39m=[32m"split-button"[39m
   [36m>[39m
     [36m<button[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mclass[39m=[32m"btn btn--split-start btn--primary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
@@ -22,7 +21,6 @@
       [36m<button[39m
         [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"true"[39m
-        [33maria-live[39m=[32m"polite"[39m
         [33mclass[39m=[32m"menu-button__button btn btn--split-end btn--primary"[39m
         [33mdata-ebayui[39m=[32m""[39m
         [33mtype[39m=[32m"button"[39m

--- a/src/components/ebay-split-button/test/__snapshots__/renders-button-with-priority-secondary.expected.html
+++ b/src/components/ebay-split-button/test/__snapshots__/renders-button-with-priority-secondary.expected.html
@@ -3,7 +3,6 @@
     [33mclass[39m=[32m"split-button"[39m
   [36m>[39m
     [36m<button[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mclass[39m=[32m"btn btn--split-start btn--secondary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
@@ -22,7 +21,6 @@
       [36m<button[39m
         [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"true"[39m
-        [33maria-live[39m=[32m"polite"[39m
         [33mclass[39m=[32m"menu-button__button btn btn--split-end btn--secondary"[39m
         [33mdata-ebayui[39m=[32m""[39m
         [33mtype[39m=[32m"button"[39m

--- a/src/components/ebay-split-button/test/__snapshots__/renders-button-with-size-large.expected.html
+++ b/src/components/ebay-split-button/test/__snapshots__/renders-button-with-size-large.expected.html
@@ -3,7 +3,6 @@
     [33mclass[39m=[32m"split-button"[39m
   [36m>[39m
     [36m<button[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mclass[39m=[32m"btn btn--large btn--split-start btn--secondary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
@@ -22,7 +21,6 @@
       [36m<button[39m
         [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"true"[39m
-        [33maria-live[39m=[32m"polite"[39m
         [33mclass[39m=[32m"menu-button__button btn btn--large btn--split-end btn--secondary"[39m
         [33mdata-ebayui[39m=[32m""[39m
         [33mtype[39m=[32m"button"[39m

--- a/src/components/ebay-split-button/test/__snapshots__/renders-defaults.expected.html
+++ b/src/components/ebay-split-button/test/__snapshots__/renders-defaults.expected.html
@@ -3,7 +3,6 @@
     [33mclass[39m=[32m"split-button"[39m
   [36m>[39m
     [36m<button[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mclass[39m=[32m"btn btn--split-start btn--secondary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
@@ -22,7 +21,6 @@
       [36m<button[39m
         [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"true"[39m
-        [33maria-live[39m=[32m"polite"[39m
         [33mclass[39m=[32m"menu-button__button btn btn--split-end btn--secondary"[39m
         [33mdata-ebayui[39m=[32m""[39m
         [33mtype[39m=[32m"button"[39m

--- a/src/components/ebay-split-button/test/__snapshots__/renders-loading-state.expected.html
+++ b/src/components/ebay-split-button/test/__snapshots__/renders-loading-state.expected.html
@@ -4,7 +4,6 @@
   [36m>[39m
     [36m<button[39m
       [33maria-label[39m=[32m"button loading"[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mclass[39m=[32m"btn btn--split-start btn--secondary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
@@ -55,7 +54,6 @@
         [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"true"[39m
         [33maria-label[39m=[32m"menu"[39m
-        [33maria-live[39m=[32m"polite"[39m
         [33mclass[39m=[32m"menu-button__button btn btn--split-end btn--secondary"[39m
         [33mdata-ebayui[39m=[32m""[39m
         [33mtype[39m=[32m"button"[39m

--- a/src/components/ebay-split-button/test/__snapshots__/renders-various-options.expected.html
+++ b/src/components/ebay-split-button/test/__snapshots__/renders-various-options.expected.html
@@ -3,7 +3,6 @@
     [33mclass[39m=[32m"split-button"[39m
   [36m>[39m
     [36m<button[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mclass[39m=[32m"btn btn--large btn--split-start btn--secondary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mdisabled[39m=[32m""[39m
@@ -26,7 +25,6 @@
         [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"true"[39m
         [33maria-label[39m=[32m"menu"[39m
-        [33maria-live[39m=[32m"polite"[39m
         [33mclass[39m=[32m"menu-button__button btn btn--large btn--split-end btn--secondary"[39m
         [33mdata-ebayui[39m=[32m""[39m
         [33mdisabled[39m=[32m""[39m

--- a/src/components/ebay-split-button/test/__snapshots__/renders-with-menu-items.expected.html
+++ b/src/components/ebay-split-button/test/__snapshots__/renders-with-menu-items.expected.html
@@ -3,7 +3,6 @@
     [33mclass[39m=[32m"split-button"[39m
   [36m>[39m
     [36m<button[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mclass[39m=[32m"btn btn--split-start btn--secondary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
@@ -25,7 +24,6 @@
         [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"true"[39m
         [33maria-label[39m=[32m"menu"[39m
-        [33maria-live[39m=[32m"polite"[39m
         [33mclass[39m=[32m"menu-button__button btn btn--split-end btn--secondary"[39m
         [33mdata-ebayui[39m=[32m""[39m
         [33mtype[39m=[32m"button"[39m


### PR DESCRIPTION
## Description
Removed aria-live from button
Also removed static variable which is not used anymore.

## Context
* Split button snapshots had aria-live in them. Made sure to update snapshots.

## References
https://github.com/eBay/ebayui-core/issues/1678
