### PR TITLE
fix(progress-stepper): added a11y-text to icons instead of aria-label

### DIFF
--- a/src/components/ebay-progress-stepper/index.marko
+++ b/src/components/ebay-progress-stepper/index.marko
@@ -53,17 +53,17 @@ $ var current = (input.step || []).findIndex(item => item.current);
                 ...processHtmlAttributes(item, ignoredStepAttributes)>
                 <span class="progress-stepper__icon">
                     <if(item.type === "attention")>
-                        <ebay-stepper-attention-icon width="24" height="24" aria-label=(item.a11yText || 'blocked')/>
+                        <ebay-stepper-attention-icon width="24" height="24" a11y-text=(item.a11yText || 'blocked')/>
                     </if>
                     <else-if(item.type === "information")>
-                        <ebay-stepper-information-icon width="24" height="24" aria-label=(item.a11yText || 'issue')/>
+                        <ebay-stepper-information-icon width="24" height="24" a11y-text=(item.a11yText || 'issue')/>
                     </else-if>
                     <else-if(
                         index < current ||
                         item.type === "complete" ||
                         input.defaultState === "complete"
                     )>
-                        <ebay-stepper-confirmation-icon width="24" height="24" aria-label=(item.a11yText || 'complete')/>
+                        <ebay-stepper-confirmation-icon width="24" height="24" a11y-text=(item.a11yText || 'complete')/>
                     </else-if>
                     <else>
                         <span role="img" aria-label=(item.a11yText || (current === index ? 'current' : 'upcoming'))></span>


### PR DESCRIPTION
## Description
Because ebay-icon only adds role=icon when `a11y-text` is passed, needed to change the `aria-label` to be `a11y-text`.
This fixed the loading of correct icon color

## References
https://github.com/eBay/ebayui-core/issues/1682

## Screenshots
<img width="722" alt="Screen Shot 2022-04-04 at 3 24 39 PM" src="https://user-images.githubusercontent.com/1755269/161641845-9ceb201e-6148-4233-9bb6-a0c84aea5ebf.png">

