### PR TITLE
feat(star-rating-select): new component

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Each layer does its bit to enforce and enhance accessibility. We consider this l
 -   [`ebay-signal`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-signal)
 -   [`ebay-snackbar-dialog`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-snackbar-dialog)
 -   [`ebay-split-button`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-split-button)
+-   [`ebay-star-rating-select`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-star-rating-select)
 -   [`ebay-switch`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-switch)
 -   [`ebay-tabs`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-tabs)
 -   [`ebay-textbox`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-textbox)

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@commitlint/cli": "^16",
         "@commitlint/config-conventional": "^16",
         "@ebay/browserslist-config": "^2.0.2",
-        "@ebay/skin": "~13.6.0",
+        "@ebay/skin": "~13.7.0-0",
         "@lasso/marko-taglib": "^2.0.1",
         "@marko/build": "^4.2.3",
         "@marko/compile": "^4.1.2",
@@ -56,7 +56,7 @@
         "browser-refresh": "^1.7.2",
         "chai": "4.3.6",
         "chai-dom": "^1.10.0",
-        "chromedriver": "^99",
+        "chromedriver": "^100",
         "coveralls": "^3.1.1",
         "css-loader": "^6",
         "dotenv-webpack": "^7.0.2",
@@ -107,7 +107,7 @@
         "wdio-chromedriver-service": "^7.2.2"
       },
       "peerDependencies": {
-        "@ebay/skin": "~13.6.0",
+        "@ebay/skin": "~13.7.0-0",
         "marko": "^4 || ^5"
       }
     },
@@ -2585,9 +2585,9 @@
       "dev": true
     },
     "node_modules/@ebay/skin": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/@ebay/skin/-/skin-13.6.0.tgz",
-      "integrity": "sha512-zwXxHigXok9wzGNgEyJc1jVkmiqM+skxhDsAPQMeh3krJG9oXZpq9op+lRBV3ty/2vnCO4lrDdrJVRtmQlp5Yw==",
+      "version": "13.7.0-0",
+      "resolved": "https://registry.npmjs.org/@ebay/skin/-/skin-13.7.0-0.tgz",
+      "integrity": "sha512-efYxFjlgekqBJeaQ1c9Umw5C8+AT08mB0zgWUO0J+06Vs8cNmaBijOl8T3dxoljTPccD/Y+HMoB9g/cvkbmgIA==",
       "dev": true
     },
     "node_modules/@emotion/cache": {
@@ -16694,9 +16694,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "99.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-99.0.0.tgz",
-      "integrity": "sha512-pyB+5LuyZdb7EBPL3i5D5yucZUD+SlkdiUtmpjaEnLd9zAXp+SvD/hP5xF4l/ZmWvUo/1ZLxAI1YBdhazGTpgA==",
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-100.0.0.tgz",
+      "integrity": "sha512-oLfB0IgFEGY9qYpFQO/BNSXbPw7bgfJUN5VX8Okps9W2qNT4IqKh5hDwKWtpUIQNI6K3ToWe2/J5NdpurTY02g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -46143,9 +46143,9 @@
       "dev": true
     },
     "@ebay/skin": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/@ebay/skin/-/skin-13.6.0.tgz",
-      "integrity": "sha512-zwXxHigXok9wzGNgEyJc1jVkmiqM+skxhDsAPQMeh3krJG9oXZpq9op+lRBV3ty/2vnCO4lrDdrJVRtmQlp5Yw==",
+      "version": "13.7.0-0",
+      "resolved": "https://registry.npmjs.org/@ebay/skin/-/skin-13.7.0-0.tgz",
+      "integrity": "sha512-efYxFjlgekqBJeaQ1c9Umw5C8+AT08mB0zgWUO0J+06Vs8cNmaBijOl8T3dxoljTPccD/Y+HMoB9g/cvkbmgIA==",
       "dev": true
     },
     "@emotion/cache": {
@@ -57323,9 +57323,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "99.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-99.0.0.tgz",
-      "integrity": "sha512-pyB+5LuyZdb7EBPL3i5D5yucZUD+SlkdiUtmpjaEnLd9zAXp+SvD/hP5xF4l/ZmWvUo/1ZLxAI1YBdhazGTpgA==",
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-100.0.0.tgz",
+      "integrity": "sha512-oLfB0IgFEGY9qYpFQO/BNSXbPw7bgfJUN5VX8Okps9W2qNT4IqKh5hDwKWtpUIQNI6K3ToWe2/J5NdpurTY02g==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@commitlint/cli": "^16",
     "@commitlint/config-conventional": "^16",
     "@ebay/browserslist-config": "^2.0.2",
-    "@ebay/skin": "~13.6.0",
+    "@ebay/skin": "~13.7.0-0",
     "@lasso/marko-taglib": "^2.0.1",
     "@marko/build": "^4.2.3",
     "@marko/compile": "^4.1.2",
@@ -96,7 +96,7 @@
     "browser-refresh": "^1.7.2",
     "chai": "4.3.6",
     "chai-dom": "^1.10.0",
-    "chromedriver": "^99",
+    "chromedriver": "^100",
     "coveralls": "^3.1.1",
     "css-loader": "^6",
     "dotenv-webpack": "^7.0.2",
@@ -147,7 +147,7 @@
     "wdio-chromedriver-service": "^7.2.2"
   },
   "peerDependencies": {
-    "@ebay/skin": "~13.6.0",
+    "@ebay/skin": "~13.7.0-0",
     "marko": "^4 || ^5"
   },
   "dependencies": {

--- a/src/components/ebay-star-rating-select/README.md
+++ b/src/components/ebay-star-rating-select/README.md
@@ -1,6 +1,6 @@
 <h1 style='display: flex; justify-content: space-between; align-items: center;'>
     <span>
-        ebay-star-ratingselect-
+        ebay-star-rating-select
     </span>
     <span style='font-weight: normal; font-size: medium; margin-bottom: -15px;'>
         DS v1.2.0

--- a/src/components/ebay-star-rating-select/README.md
+++ b/src/components/ebay-star-rating-select/README.md
@@ -1,0 +1,20 @@
+<h1 style='display: flex; justify-content: space-between; align-items: center;'>
+    <span>
+        ebay-star-ratingselect-
+    </span>
+    <span style='font-weight: normal; font-size: medium; margin-bottom: -15px;'>
+        DS v1.2.0
+    </span>
+</h1>
+
+## ebay-star-rating-select Usage
+
+```marko
+<ebay-star-rating-select/>
+```
+
+## Links
+
+-   (Storybook)[https://ebay.github.io/ebayui-core/?path=/story/ebay-star-rating-select]
+-   (Storybook Docs)[https://ebay.github.io/ebayui-core/?path=/docs/ebay-star-rating-select]
+-   (Code Examples)[https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-star-rating-select/examples]

--- a/src/components/ebay-star-rating-select/browser.json
+++ b/src/components/ebay-star-rating-select/browser.json
@@ -1,0 +1,9 @@
+{
+  "requireRemap": [
+    {
+      "from": "./style.js",
+      "to": "../../common/empty.js",
+      "if-flag": "ebayui-no-skin"
+    }
+  ]
+}

--- a/src/components/ebay-star-rating-select/component.js
+++ b/src/components/ebay-star-rating-select/component.js
@@ -1,0 +1,29 @@
+module.exports = {
+    onCreate() {
+        this.state = {
+            value: 0,
+        };
+    },
+    onInput(input) {
+        let value = parseInt(input.value, 0) || 0;
+        if (value > 5) {
+            value = 0;
+        }
+        this.state.value = input.value;
+    },
+    handleClick: forwardEvent('change'),
+    handleFocus: forwardEvent('focus'),
+    handleKeydown: forwardEvent('keydown'),
+};
+
+function forwardEvent(eventName) {
+    return function (value, originalEvent, el) {
+        if (!el.disabled) {
+            this.state.value = value;
+            this.emit(eventName, {
+                originalEvent,
+                value: value,
+            });
+        }
+    };
+}

--- a/src/components/ebay-star-rating-select/examples/01-default/template.marko
+++ b/src/components/ebay-star-rating-select/examples/01-default/template.marko
@@ -1,0 +1,13 @@
+class {
+    onCreate() {
+        this.state = {
+            value: 0
+        };
+    }
+    handleStarChange({value}) {
+        this.state.value = value;
+
+    }
+}
+
+<ebay-star-rating-select value=state.value on-change('handleStarChange')/>

--- a/src/components/ebay-star-rating-select/examples/02-fieldset/template.marko
+++ b/src/components/ebay-star-rating-select/examples/02-fieldset/template.marko
@@ -1,0 +1,12 @@
+class {}
+
+<fieldset>
+    <legend>Select rating</legend>
+    <ebay-star-rating-select
+        value=input.value
+        a11y-star-text=input.a11yStarText
+        onChange("emit", 'change')
+        onKeyup("emit", 'keyup')
+        onFocus("emit", 'focus')
+    />
+</fieldset>

--- a/src/components/ebay-star-rating-select/examples/02-fieldset/template.marko
+++ b/src/components/ebay-star-rating-select/examples/02-fieldset/template.marko
@@ -1,7 +1,7 @@
 class {}
 
 <fieldset>
-    <legend>Select rating</legend>
+    <legend>Rate Product</legend>
     <ebay-star-rating-select
         value=input.value
         a11y-star-text=input.a11yStarText

--- a/src/components/ebay-star-rating-select/index.marko
+++ b/src/components/ebay-star-rating-select/index.marko
@@ -10,7 +10,8 @@ $ var starText = input.a11yStarText || [];
             <input
                 aria-label=starText[i - 1]
                 class=[
-                    i <= state.value && "star-rating-select_filled",
+                    "star-rating-select__control",
+                    i <= state.value && "star-rating-select__control--filled"
                 ]
                 type="radio"
                 name:scoped="star-rating"
@@ -20,7 +21,7 @@ $ var starText = input.a11yStarText || [];
                 onClick("handleClick", i)
                 onFocus("handleFocus", i)
                 onKeydown("handleKeydown", i)/>
-            <span class="star-rating-select__icon">
+            <span class="star-rating-select__radio-icon">
                 <ebay-star-dynamic-icon/>
             </span>
         </span>

--- a/src/components/ebay-star-rating-select/index.marko
+++ b/src/components/ebay-star-rating-select/index.marko
@@ -1,0 +1,28 @@
+import processHtmlAttributes from "../../common/html-attributes"
+
+static var ignoredAttributes = ["class", "value", "a11yText", "a11yStarText", "disbaled"];
+$ var starText = input.a11yStarText || [];
+
+<div role=(input.a11yText && "radiogroup") aria-label=input.a11yText class=["star-rating-select", input.class] ...processHtmlAttributes(input, ignoredAttributes)>
+    <for|i| from=1 to=5>
+       <span
+       class="star-rating-select__radio">
+            <input
+                aria-label=starText[i - 1]
+                class=[
+                    i <= state.value && "star-rating-select_filled",
+                ]
+                type="radio"
+                name:scoped="star-rating"
+                value=i
+                disabled=input.disabled
+                checked=(state.value === i)
+                onClick("handleClick", i)
+                onFocus("handleFocus", i)
+                onKeydown("handleKeydown", i)/>
+            <span class="star-rating-select__icon">
+                <ebay-star-dynamic-icon/>
+            </span>
+        </span>
+    </for>
+</div>

--- a/src/components/ebay-star-rating-select/marko-tag.json
+++ b/src/components/ebay-star-rating-select/marko-tag.json
@@ -1,0 +1,13 @@
+{
+  "attribute-groups": ["html-attributes"],
+  "@*": {
+    "targetProperty": null,
+    "type": "expression"
+  },
+  "@html-attributes": "expression",
+  "@value": "#html-value",
+  "@disabled": "#html-disabled",
+  "@form": "#html-form",
+  "@a11y-text": "string",
+  "@a11y-star-text": "array"
+}

--- a/src/components/ebay-star-rating-select/star-rating-select.stories.js
+++ b/src/components/ebay-star-rating-select/star-rating-select.stories.js
@@ -1,0 +1,113 @@
+import { tagToString } from '../../../.storybook/storybook-code-source';
+import Readme from './README.md';
+import Component from './index.marko';
+import FieldsetTemplate from './examples/02-fieldset/template.marko';
+import FieldsetCode from './examples/02-fieldset/template.marko?raw';
+
+const Template = (args) => ({
+    input: {
+        ...args,
+        renderBody: args.renderBody
+            ? (out) => {
+                  out.html(args.renderBody);
+              }
+            : null,
+    },
+});
+
+export default {
+    title: 'ebay-star-rating-select',
+    component: Component,
+    parameters: {
+        docs: {
+            description: {
+                component: Readme,
+            },
+        },
+    },
+
+    argTypes: {
+        disabled: {
+            control: { type: 'boolean' },
+        },
+        value: {
+            control: { type: 'number' },
+            description:
+                '1 - 5, depending on how many starts are selected. If 0 or null defaults to no stars selected',
+        },
+        a11yStarText: {
+            control: 'object',
+            description: 'Array object which sets the aria label for each star',
+        },
+        a11yText: {
+            control: { type: 'text' },
+            description: 'The aria label for the outer container. Only used on isolated case.',
+        },
+
+        onChange: {
+            action: 'on-change',
+            description: 'Triggered on change',
+            table: {
+                category: 'Events',
+                defaultValue: {
+                    summary: '{ originalEvent, value }',
+                },
+            },
+        },
+        onFocus: {
+            action: 'on-focus',
+            description: 'Triggered on focus',
+            table: {
+                category: 'Events',
+                defaultValue: {
+                    summary: '{ originalEvent, value }',
+                },
+            },
+        },
+        onKeydown: {
+            action: 'on-keydown',
+            description: 'Triggered on keydown',
+            table: {
+                category: 'Events',
+                defaultValue: {
+                    summary: '{ originalEvent, value }',
+                },
+            },
+        },
+    },
+};
+
+export const Isolated = Template.bind({});
+Isolated.args = {
+    disabled: false,
+    a11yStarText: ['1 star', '2 stars', '3 stars', '4 stars', '5 stars'],
+    a11yText: 'Leave a rating',
+    value: 0,
+};
+
+Isolated.parameters = {
+    docs: {
+        source: {
+            code: tagToString('ebay-radio', Isolated.args),
+        },
+    },
+};
+
+export const Fieldset = (args) => ({
+    input: args,
+    component: FieldsetTemplate,
+});
+
+Fieldset.args = {
+    disabled: false,
+    a11yStarText: ['1 star', '2 stars', '3 stars', '4 stars', '5 stars'],
+    value: 0,
+};
+
+Fieldset.parameters = {
+    docs: {
+        source: {
+            code: FieldsetCode,
+        },
+    },
+};

--- a/src/components/ebay-star-rating-select/star-rating-select.stories.js
+++ b/src/components/ebay-star-rating-select/star-rating-select.stories.js
@@ -88,7 +88,7 @@ Isolated.args = {
 Isolated.parameters = {
     docs: {
         source: {
-            code: tagToString('ebay-radio', Isolated.args),
+            code: tagToString('ebay-star-rating-select', Isolated.args),
         },
     },
 };

--- a/src/components/ebay-star-rating-select/star-rating-select.stories.js
+++ b/src/components/ebay-star-rating-select/star-rating-select.stories.js
@@ -33,7 +33,7 @@ export default {
         value: {
             control: { type: 'number' },
             description:
-                '1 - 5, depending on how many starts are selected. If 0 or null defaults to no stars selected',
+                '1 - 5, depending on how many stars are selected. If 0 or null defaults to no stars selected',
         },
         a11yStarText: {
             control: 'object',
@@ -81,7 +81,7 @@ export const Isolated = Template.bind({});
 Isolated.args = {
     disabled: false,
     a11yStarText: ['1 star', '2 stars', '3 stars', '4 stars', '5 stars'],
-    a11yText: 'Leave a rating',
+    a11yText: 'Rate product',
     value: 0,
 };
 

--- a/src/components/ebay-star-rating-select/style.js
+++ b/src/components/ebay-star-rating-select/style.js
@@ -1,0 +1,1 @@
+require('@ebay/skin/star-rating-select');

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-basic.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-basic.expected.html
@@ -1,0 +1,139 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-label[39m=[32m"star"[39m
+    [33mclass[39m=[32m"star-rating-select"[39m
+    [33mrole[39m=[32m"radiogroup"[39m
+  [36m>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 1"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-star-dynamic"[39m
+              [33mviewBox[39m=[32m"0 0 22 22"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-full, #ccc)"[39m
+              [36m/>[39m
+              [36m<path[39m
+                [33mclip-path[39m=[32m"polygon(0 0, 50% 0, 50% 100%, 0 100%)"[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-half, transparent)"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 2"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 3"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 4"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"4"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 5"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"5"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-basic.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-basic.expected.html
@@ -9,12 +9,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 1"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"1"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -48,12 +49,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 2"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"2"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -71,12 +73,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 3"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"3"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -94,12 +97,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 4"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"4"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -117,12 +121,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 5"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"5"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-defaults.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-defaults.expected.html
@@ -1,0 +1,132 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"star-rating-select"[39m
+  [36m>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-star-dynamic"[39m
+              [33mviewBox[39m=[32m"0 0 22 22"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-full, #ccc)"[39m
+              [36m/>[39m
+              [36m<path[39m
+                [33mclip-path[39m=[32m"polygon(0 0, 50% 0, 50% 100%, 0 100%)"[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-half, transparent)"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"4"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"5"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-defaults.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-defaults.expected.html
@@ -6,12 +6,13 @@
       [33mclass[39m=[32m"star-rating-select__radio"[39m
     [36m>[39m
       [36m<input[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"1"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -44,12 +45,13 @@
       [33mclass[39m=[32m"star-rating-select__radio"[39m
     [36m>[39m
       [36m<input[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"2"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -66,12 +68,13 @@
       [33mclass[39m=[32m"star-rating-select__radio"[39m
     [36m>[39m
       [36m<input[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"3"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -88,12 +91,13 @@
       [33mclass[39m=[32m"star-rating-select__radio"[39m
     [36m>[39m
       [36m<input[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"4"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -110,12 +114,13 @@
       [33mclass[39m=[32m"star-rating-select__radio"[39m
     [36m>[39m
       [36m<input[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"5"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-0-selected.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-0-selected.expected.html
@@ -1,0 +1,139 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-label[39m=[32m"star"[39m
+    [33mclass[39m=[32m"star-rating-select"[39m
+    [33mrole[39m=[32m"radiogroup"[39m
+  [36m>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 1"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-star-dynamic"[39m
+              [33mviewBox[39m=[32m"0 0 22 22"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-full, #ccc)"[39m
+              [36m/>[39m
+              [36m<path[39m
+                [33mclip-path[39m=[32m"polygon(0 0, 50% 0, 50% 100%, 0 100%)"[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-half, transparent)"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 2"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 3"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 4"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"4"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 5"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"5"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-0-selected.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-0-selected.expected.html
@@ -9,12 +9,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 1"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"1"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -48,12 +49,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 2"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"2"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -71,12 +73,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 3"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"3"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -94,12 +97,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 4"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"4"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -117,12 +121,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 5"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"5"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-2-selected.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-2-selected.expected.html
@@ -9,13 +9,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 1"[39m
-        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mclass[39m=[32m"star-rating-select__control star-rating-select__control--filled"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"1"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -50,13 +50,13 @@
       [36m<input[39m
         [33maria-label[39m=[32m"star 2"[39m
         [33mchecked[39m=[32m""[39m
-        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mclass[39m=[32m"star-rating-select__control star-rating-select__control--filled"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"2"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -74,12 +74,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 3"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"3"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -97,12 +98,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 4"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"4"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -120,12 +122,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 5"[39m
+        [33mclass[39m=[32m"star-rating-select__control"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"5"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-2-selected.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-2-selected.expected.html
@@ -1,0 +1,142 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-label[39m=[32m"star"[39m
+    [33mclass[39m=[32m"star-rating-select"[39m
+    [33mrole[39m=[32m"radiogroup"[39m
+  [36m>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 1"[39m
+        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-star-dynamic"[39m
+              [33mviewBox[39m=[32m"0 0 22 22"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-full, #ccc)"[39m
+              [36m/>[39m
+              [36m<path[39m
+                [33mclip-path[39m=[32m"polygon(0 0, 50% 0, 50% 100%, 0 100%)"[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-half, transparent)"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 2"[39m
+        [33mchecked[39m=[32m""[39m
+        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 3"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 4"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"4"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 5"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"5"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-5-selected.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-5-selected.expected.html
@@ -9,13 +9,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 1"[39m
-        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mclass[39m=[32m"star-rating-select__control star-rating-select__control--filled"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"1"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -49,13 +49,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 2"[39m
-        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mclass[39m=[32m"star-rating-select__control star-rating-select__control--filled"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"2"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -73,13 +73,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 3"[39m
-        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mclass[39m=[32m"star-rating-select__control star-rating-select__control--filled"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"3"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -97,13 +97,13 @@
     [36m>[39m
       [36m<input[39m
         [33maria-label[39m=[32m"star 4"[39m
-        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mclass[39m=[32m"star-rating-select__control star-rating-select__control--filled"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"4"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
@@ -122,13 +122,13 @@
       [36m<input[39m
         [33maria-label[39m=[32m"star 5"[39m
         [33mchecked[39m=[32m""[39m
-        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mclass[39m=[32m"star-rating-select__control star-rating-select__control--filled"[39m
         [33mname[39m=[32m"s0-star-rating"[39m
         [33mtype[39m=[32m"radio"[39m
         [33mvalue[39m=[32m"5"[39m
       [36m/>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"star-rating-select__icon"[39m
+        [33mclass[39m=[32m"star-rating-select__radio-icon"[39m
       [36m>[39m
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m

--- a/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-5-selected.expected.html
+++ b/src/components/ebay-star-rating-select/test/__snapshots__/renders-with-5-selected.expected.html
@@ -1,0 +1,145 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-label[39m=[32m"star"[39m
+    [33mclass[39m=[32m"star-rating-select"[39m
+    [33mrole[39m=[32m"radiogroup"[39m
+  [36m>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 1"[39m
+        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-star-dynamic"[39m
+              [33mviewBox[39m=[32m"0 0 22 22"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-full, #ccc)"[39m
+              [36m/>[39m
+              [36m<path[39m
+                [33mclip-path[39m=[32m"polygon(0 0, 50% 0, 50% 100%, 0 100%)"[39m
+                [33md[39m=[32m"M11.0418 2.19068C11.3405 1.26977 12.6556 1.26977 12.9544 2.19068L15.0869 9H21.998C22.9684 9 23.3684 9.97367 22.5863 10.5428L16.9857 14.6188L19.1191 21.1958C19.4171 22.1146 18.3532 22.8737 17.5682 22.3024L11.9981 18.2486L6.42795 22.3024C5.64292 22.8737 4.57902 22.1146 4.87705 21.1958L7.01047 14.6188L1.40983 10.5428C0.627778 9.97367 1.04044 9 2.0108 9H8.92191L11.0418 2.19068Z"[39m
+                [33mfill[39m=[32m"var(--color-star-rating-half, transparent)"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 2"[39m
+        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 3"[39m
+        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 4"[39m
+        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"4"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"star-rating-select__radio"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33maria-label[39m=[32m"star 5"[39m
+        [33mchecked[39m=[32m""[39m
+        [33mclass[39m=[32m"star-rating-select_filled"[39m
+        [33mname[39m=[32m"s0-star-rating"[39m
+        [33mtype[39m=[32m"radio"[39m
+        [33mvalue[39m=[32m"5"[39m
+      [36m/>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"star-rating-select__icon"[39m
+      [36m>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--star-dynamic"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-star-dynamic"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</span>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-star-rating-select/test/mock/index.js
+++ b/src/components/ebay-star-rating-select/test/mock/index.js
@@ -1,0 +1,21 @@
+exports.Basic = {
+    a11yText: 'star',
+    a11yStarText: ['star 1', 'star 2', 'star 3', 'star 4', 'star 5'],
+};
+
+exports.Basic_0Selected = Object.assign({}, exports.Basic, {
+    value: 0,
+});
+
+exports.Basic_2Selected = Object.assign({}, exports.Basic, {
+    value: 2,
+});
+
+exports.Basic_5Selected = Object.assign({}, exports.Basic, {
+    value: 5,
+});
+
+exports.Basic_Disbaled = Object.assign({}, exports.Basic, {
+    value: 2,
+    disabled: true,
+});

--- a/src/components/ebay-star-rating-select/test/test.browser.js
+++ b/src/components/ebay-star-rating-select/test/test.browser.js
@@ -1,0 +1,92 @@
+const { expect, use } = require('chai');
+const { render, fireEvent, cleanup } = require('@marko/testing-library');
+const template = require('..');
+const mock = require('./mock');
+
+use(require('chai-dom'));
+afterEach(cleanup);
+
+/** @type import("@marko/testing-library").RenderResult */
+let component;
+
+describe('given star rating', () => {
+    beforeEach(async () => {
+        component = await render(template, mock.Basic);
+        await fireEvent.click(component.getByLabelText('star 2'));
+    });
+
+    it('then it emits the event', () => {
+        const changeEvents = component.emitted('change');
+        expect(changeEvents).has.length(1);
+
+        const eventArgs = changeEvents[0];
+        expect(eventArgs).has.length(1);
+        expect(eventArgs[0].originalEvent).to.be.an.instanceof(Event);
+        expect(eventArgs[0].value).to.equal(2);
+    });
+
+    describe('when star is clicked', () => {
+        beforeEach(async () => {
+            await fireEvent.click(component.getByLabelText('star 4'));
+        });
+
+        it('then it emits the event', () => {
+            const changeEvents = component.emitted('change');
+            expect(changeEvents).has.length(2);
+
+            const eventArgs = changeEvents[1];
+            expect(eventArgs).has.length(1);
+            expect(eventArgs[0].originalEvent).to.be.an.instanceof(Event);
+            expect(eventArgs[0].value).to.equal(4);
+        });
+    });
+});
+
+describe('given star is disabled', () => {
+    beforeEach(async () => {
+        component = await render(template, mock.Basic_Disbaled);
+    });
+
+    describe('when star is clicked', () => {
+        beforeEach(async () => {
+            await fireEvent.click(component.getByLabelText('star 2'));
+        });
+
+        it("then it doesn't emit the event", () => {
+            const changeEvents = component.emitted('change');
+            expect(changeEvents).has.length(0);
+        });
+    });
+});
+
+describe('when native focus event is fired on star', () => {
+    beforeEach(async () => {
+        component = await render(template, mock.Basic);
+        await fireEvent.focus(component.getByLabelText('star 2'));
+    });
+
+    it('then it emits the event', () => {
+        const events = component.emitted('focus');
+        expect(events).has.length(1);
+
+        const [[eventArg]] = events;
+        expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+        expect(eventArg.value).to.equal(2);
+    });
+});
+
+describe('when native keyboard event is fired on star', () => {
+    beforeEach(async () => {
+        component = await render(template, mock.Basic);
+        await fireEvent.keyDown(component.getByLabelText('star 5'));
+    });
+
+    it('then it emits the event', () => {
+        const events = component.emitted('keydown');
+        expect(events).has.length(1);
+
+        const [[eventArg]] = events;
+        expect(eventArg).has.property('originalEvent').is.an.instanceOf(Event);
+        expect(eventArg.value).to.equal(5);
+    });
+});

--- a/src/components/ebay-star-rating-select/test/test.server.js
+++ b/src/components/ebay-star-rating-select/test/test.server.js
@@ -1,0 +1,36 @@
+const { use } = require('chai');
+const { render, prettyDOM } = require('@marko/testing-library');
+const snap = require('mocha-snap').default;
+const template = require('..');
+const mock = require('./mock');
+
+const snapDOM = (node) => snap(prettyDOM(node), '.html', __dirname);
+
+use(require('chai-dom'));
+
+describe('star-rating-select', () => {
+    it('renders defaults', async () => {
+        const { container } = await render(template);
+        await snapDOM(container);
+    });
+
+    it('renders basic', async () => {
+        const { container } = await render(template, mock.Basic);
+        await snapDOM(container);
+    });
+
+    it('renders with 0 selected', async () => {
+        const { container } = await render(template, mock.Basic_0Selected);
+        await snapDOM(container);
+    });
+
+    it('renders with 2 selected', async () => {
+        const { container } = await render(template, mock.Basic_2Selected);
+        await snapDOM(container);
+    });
+
+    it('renders with 5 selected', async () => {
+        const { container } = await render(template, mock.Basic_5Selected);
+        await snapDOM(container);
+    });
+});

--- a/src/components/ebay-star-rating/README.md
+++ b/src/components/ebay-star-rating/README.md
@@ -14,12 +14,15 @@
 
 ```marko
 <ebay-star-rating-1/>
+<ebay-star-rating value="1"/>
 <ebay-star-rating-1-5/>
+<ebay-star-rating value="1-5"/>
 ```
 
 ## ebay-star-rating-{rating} Attributes
 
-| Name              | Type    | Stateful | Required | Description                                                                                 |
-| ----------------- | ------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
-| `no-skin-classes` | Boolean | No       | No       | Used for special cases where `icon` classes from Skin should not be applied                 |
-| `a11y-text`       | String  | No       | Yes      | text for non-decorative inline icon; icon is assumed to be decorative if this is not passed |
+| Name              | Type    | Stateful | Required | Description                                                                                                  |
+| ----------------- | ------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `no-skin-classes` | Boolean | No       | No       | Used for special cases where `icon` classes from Skin should not be applied                                  |
+| `a11y-text`       | String  | No       | Yes      | text for non-decorative inline icon; icon is assumed to be decorative if this is not passed                  |
+| `value`           | String  | No       | Yes      | For `<ebay-star-rating/>` only, assigns the amount of stars to be filled. Can be 2-5 for 2 and a half stars. |

--- a/src/components/ebay-star-rating/examples/02-dynaic-star-rating/template.marko
+++ b/src/components/ebay-star-rating/examples/02-dynaic-star-rating/template.marko
@@ -1,0 +1,21 @@
+<!--*
+ * Note: Due to limitations in Marko v4, this tag must be within a parent component.
+ * Below we have added an empty class to force this to be the case.-->
+class {}
+<!-- And so on ... Please refer to Skin for available icons-->
+style {
+    .star-icon-container {
+        display: flex;
+        row-gap: 10px;
+        flex-direction: column;
+        align-items: center;
+    }
+}
+
+<div.star-icon-container>
+    <ebay-star-rating value="0"/>
+    <ebay-star-rating value="0-5"/>
+    <ebay-star-rating value="2"/>
+    <ebay-star-rating value="3-5"/>
+    <ebay-star-rating value="5"/>
+</div>

--- a/src/components/ebay-star-rating/index.marko
+++ b/src/components/ebay-star-rating/index.marko
@@ -1,0 +1,11 @@
+import processHtmlAttributes from "../../common/html-attributes"
+
+static var ignoredAttributes = ["class", "value", "a11yText"];
+$ var starText = input.a11yStarText || [];
+
+<div role="img" aria-label=input.a11yText class=["star-rating", input.class] data-stars=input.value ...processHtmlAttributes(input, ignoredAttributes)>
+    <for|i| from=1 to=5>
+        <ebay-star-dynamic-icon class="star-rating__icon">
+        </ebay-star-dynamic-icon>
+    </for>
+</div>

--- a/src/components/ebay-star-rating/marko-tag.json
+++ b/src/components/ebay-star-rating/marko-tag.json
@@ -1,0 +1,10 @@
+{
+  "attribute-groups": ["html-attributes"],
+  "@*": {
+    "targetProperty": null,
+    "type": "expression"
+  },
+  "@html-attributes": "expression",
+  "@value": "#html-value",
+  "@a11y-text": "string"
+}

--- a/src/components/ebay-star-rating/star-rating.stories.js
+++ b/src/components/ebay-star-rating/star-rating.stories.js
@@ -1,6 +1,8 @@
+import { tagToString } from '../../../.storybook/storybook-code-source';
 import Readme from './README.md';
-import Component from './examples/01-star-rating/template.marko';
+import fixed from './examples/01-star-rating/template.marko';
 import code from './examples/01-star-rating/template.marko?raw';
+import component from './index.marko';
 
 const Template = (args) => ({
     input: {
@@ -15,7 +17,7 @@ const Template = (args) => ({
 
 export default {
     title: 'ebay-star-rating',
-    component: Component,
+    component: component,
     parameters: {
         docs: {
             description: {
@@ -24,12 +26,37 @@ export default {
         },
     },
 
-    argTypes: {},
+    argTypes: {
+        value: {
+            control: { type: 'select' },
+            options: ['0', '1', '1-5', '2', '2-5', '3', '3-5', '4', '4-5', '5'],
+            description:
+                'Only for <ebay-star-rating/>. 1 - 5, depending on how many starts are selected. If 0 or null defaults to no stars selected. Can use 2-5 for 2 and a half stars',
+        },
+        a11yText: {
+            description: 'The aria label for the outer container.',
+        },
+    },
 };
 
-export const Standard = Template.bind({});
-Standard.args = {};
-Standard.parameters = {
+export const DynamicStars = Template.bind({});
+DynamicStars.args = {
+    value: '3-5',
+};
+DynamicStars.parameters = {
+    docs: {
+        source: {
+            code: tagToString('ebay-star-rating', DynamicStars.args),
+        },
+    },
+};
+
+export const FixedStars = (args) => ({
+    input: args,
+    component: fixed,
+});
+FixedStars.args = {};
+FixedStars.parameters = {
     docs: {
         source: {
             code,


### PR DESCRIPTION
## Description
* New component based on https://github.com/eBay/skin/pull/1725

## Context
* Most of the component is similar to radio. 
* __NOTE__ in draft mode because still waiting on skin part to be merged. But wanted to verify this current approach was okay.
* ~Questions: Should we add an example with fieldset? Also do we want fieldset to wrap the star-rating?~ Added fieldset example and removed `role` if there is no `a11yText`.

## References
https://github.com/eBay/ebayui-core/issues/1594

## Screenshots
<img width="204" alt="Screen Shot 2022-04-20 at 3 48 48 PM" src="https://user-images.githubusercontent.com/1755269/164337851-6d41987c-4096-4168-aed3-7af13c527d0f.png">

<img width="226" alt="Screen Shot 2022-04-20 at 3 48 59 PM" src="https://user-images.githubusercontent.com/1755269/164337824-203b374e-1e97-4183-a334-cb53903af030.png">

