### PR TITLE
feat(star-rating): added dynamic star rating (static)

### DIFF
--- a/src/components/ebay-star-rating/README.md
+++ b/src/components/ebay-star-rating/README.md
@@ -14,12 +14,15 @@
 
 ```marko
 <ebay-star-rating-1/>
+<ebay-star-rating value="1"/>
 <ebay-star-rating-1-5/>
+<ebay-star-rating value="1-5"/>
 ```
 
 ## ebay-star-rating-{rating} Attributes
 
-| Name              | Type    | Stateful | Required | Description                                                                                 |
-| ----------------- | ------- | -------- | -------- | ------------------------------------------------------------------------------------------- |
-| `no-skin-classes` | Boolean | No       | No       | Used for special cases where `icon` classes from Skin should not be applied                 |
-| `a11y-text`       | String  | No       | Yes      | text for non-decorative inline icon; icon is assumed to be decorative if this is not passed |
+| Name              | Type    | Stateful | Required | Description                                                                                                  |
+| ----------------- | ------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `no-skin-classes` | Boolean | No       | No       | Used for special cases where `icon` classes from Skin should not be applied                                  |
+| `a11y-text`       | String  | No       | Yes      | text for non-decorative inline icon; icon is assumed to be decorative if this is not passed                  |
+| `value`           | String  | No       | Yes      | For `<ebay-star-rating/>` only, assigns the amount of stars to be filled. Can be 2-5 for 2 and a half stars. |

--- a/src/components/ebay-star-rating/examples/02-dynaic-star-rating/template.marko
+++ b/src/components/ebay-star-rating/examples/02-dynaic-star-rating/template.marko
@@ -1,0 +1,21 @@
+<!--*
+ * Note: Due to limitations in Marko v4, this tag must be within a parent component.
+ * Below we have added an empty class to force this to be the case.-->
+class {}
+<!-- And so on ... Please refer to Skin for available icons-->
+style {
+    .star-icon-container {
+        display: flex;
+        row-gap: 10px;
+        flex-direction: column;
+        align-items: center;
+    }
+}
+
+<div.star-icon-container>
+    <ebay-star-rating value="0"/>
+    <ebay-star-rating value="0-5"/>
+    <ebay-star-rating value="2"/>
+    <ebay-star-rating value="3-5"/>
+    <ebay-star-rating value="5"/>
+</div>

--- a/src/components/ebay-star-rating/index.marko
+++ b/src/components/ebay-star-rating/index.marko
@@ -1,0 +1,11 @@
+import processHtmlAttributes from "../../common/html-attributes"
+
+static var ignoredAttributes = ["class", "value", "a11yText"];
+$ var starText = input.a11yStarText || [];
+
+<div role="img" aria-label=input.a11yText class=["star-rating", input.class] data-stars=input.value ...processHtmlAttributes(input, ignoredAttributes)>
+    <for|i| from=1 to=5>
+        <ebay-star-dynamic-icon class="star-rating__icon">
+        </ebay-star-dynamic-icon>
+    </for>
+</div>

--- a/src/components/ebay-star-rating/marko-tag.json
+++ b/src/components/ebay-star-rating/marko-tag.json
@@ -1,0 +1,10 @@
+{
+  "attribute-groups": ["html-attributes"],
+  "@*": {
+    "targetProperty": null,
+    "type": "expression"
+  },
+  "@html-attributes": "expression",
+  "@value": "#html-value",
+  "@a11y-text": "string"
+}

--- a/src/components/ebay-star-rating/star-rating.stories.js
+++ b/src/components/ebay-star-rating/star-rating.stories.js
@@ -1,6 +1,8 @@
+import { tagToString } from '../../../.storybook/storybook-code-source';
 import Readme from './README.md';
-import Component from './examples/01-star-rating/template.marko';
+import fixed from './examples/01-star-rating/template.marko';
 import code from './examples/01-star-rating/template.marko?raw';
+import component from './index.marko';
 
 const Template = (args) => ({
     input: {
@@ -15,7 +17,7 @@ const Template = (args) => ({
 
 export default {
     title: 'ebay-star-rating',
-    component: Component,
+    component: component,
     parameters: {
         docs: {
             description: {
@@ -24,12 +26,37 @@ export default {
         },
     },
 
-    argTypes: {},
+    argTypes: {
+        value: {
+            control: { type: 'text' },
+            description:
+                'Only for <ebay-star-rating/>. 1 - 5, depending on how many starts are selected. If 0 or null defaults to no stars selected. Can use 2-5 for 2 and a half stars',
+        },
+        a11yText: {
+            control: { type: 'text' },
+            description: 'The aria label for the outer container.',
+        },
+    },
 };
 
-export const Standard = Template.bind({});
-Standard.args = {};
-Standard.parameters = {
+export const DynamicStars = Template.bind({});
+DynamicStars.args = {
+    value: '3-5',
+};
+DynamicStars.parameters = {
+    docs: {
+        source: {
+            code: tagToString('ebay-star-rating', DynamicStars.args),
+        },
+    },
+};
+
+export const FixedStars = (args) => ({
+    input: args,
+    component: fixed,
+});
+FixedStars.args = {};
+FixedStars.parameters = {
     docs: {
         source: {
             code,

--- a/src/components/ebay-star-rating/star-rating.stories.js
+++ b/src/components/ebay-star-rating/star-rating.stories.js
@@ -28,12 +28,12 @@ export default {
 
     argTypes: {
         value: {
-            control: { type: 'text' },
+            control: { type: 'select' },
+            options: ['0', '1', '1-5', '2', '2-5', '3', '3-5', '4', '4-5', '5'],
             description:
                 'Only for <ebay-star-rating/>. 1 - 5, depending on how many starts are selected. If 0 or null defaults to no stars selected. Can use 2-5 for 2 and a half stars',
         },
         a11yText: {
-            control: { type: 'text' },
             description: 'The aria label for the outer container.',
         },
     },


### PR DESCRIPTION
## Description
Static star rating, using the `data-stars` value to show stars. It allows teams to do something like`<ebay-star-rating value=input.stars>`

## Context
Still kept icon version of stars around. 

## References
https://github.com/eBay/ebayui-core/issues/1640

## Screenshots
<img width="1423" alt="Screen Shot 2022-04-20 at 9 24 13 PM" src="https://user-images.githubusercontent.com/1755269/164372183-278c7e92-3571-45dd-99ef-6de7042beec4.png">

