### PR TITLE
feat(confirm-dialog): add id for cancel button

### DIFF
--- a/src/components/ebay-confirm-dialog/index.marko
+++ b/src/components/ebay-confirm-dialog/index.marko
@@ -1,3 +1,4 @@
+$ var cancelId = component.getElId("confirm-dialog-cancel");
 $ var confirmId = component.getElId("confirm-dialog-confirm");
 $ var mainId = component.getElId("confirm-dialog-main");
 <ebay-dialog-base
@@ -12,7 +13,10 @@ $ var mainId = component.getElId("confirm-dialog-main");
     window-class=["confirm-dialog__window--fade"]
     button-position="hidden">
     <@footer>
-        <ebay-button on-click("emit", "reject") class="confirm-dialog__reject">
+        <ebay-button
+            on-click("emit", "reject")
+            id=cancelId
+            class="confirm-dialog__reject">
             ${input.rejectText}
         </ebay-button>
         <ebay-button


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
Added support for id on cancel button
Fixes this issue: https://github.com/eBay/ebayui-core/issues/1697

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Similar to the id for confirm button
