### PR TITLE
PIEACC-587: added optional label for the listbox-button el

### DIFF
--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -58,7 +58,12 @@ $ var displayText = selectedText || unselectedText;
                 <span class="expand-btn__text">${input.prefixLabel} ${displayText}</span>
             </else-if>
             <else>
-                <span id=labelId class="expand-btn__text">${displayText}</span>
+                <span>
+                    <if(input.label)>
+                        <span class="clipped">${input.label}</span>
+                    </if>
+                    <span id=labelId class="expand-btn__text">${displayText}</span>
+                </span>
             </else>
             <ebay-dropdown-icon/>
         </span>


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
Added optional label to announce to know the context

## Context
In feedback-ratings-filter component, added the label(shouldn't be visible in the UI), provides an additional context for the dropdown.

## References
https://jirap.corp.ebay.com/browse/PIEACC-587
Related PR: https://github.corp.ebay.com/ebay-toronto/vi-component-feedback/pull/122

## Screenshots

<img width="1792" alt="PIEACC-587-after" src="https://user-images.githubusercontent.com/64549036/168897616-023a059b-abe2-48bc-88b4-0fb5af6de1e5.png">
<img width="1792" alt="PIEACC-587-before" src="https://user-images.githubusercontent.com/64549036/168897620-aa464438-f718-4591-bd34-a27a517586a0.png">

