### PR TITLE
refactor(carousel): removed live status region #1630

### DIFF
--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -21,24 +21,23 @@ This component will bundle different resources depending on Lasso flags provided
 
 ## ebay-carousel Attributes
 
-| Name                 | Type   | Stateful | Required | Description                                                                                                                                                           |
-| -------------------- | ------ | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `a11y-heading-text`  | String | No       | No       | a11y heading text used to describe the carousel (continuous only)                                                                                                     |
-| `a11y-heading-tag`   | String | No       | No       | use h1-h6 when there isn't a visible heading before the carousel (continuous only) (default: "h2")                                                                    |
-| `a11y-previous-text` | String | No       | Yes      | a11y text for previous control (default: "Previous Slide")                                                                                                            |
-| `a11y-next-text`     | String | No       | Yes      | a11y text for next control (default: "Next Slide")                                                                                                                    |
-| `index`              | String | Yes      | No       | 0-based index position                                                                                                                                                |
-| `items-per-slide`    | String | No       | No       | automatically fit a number of items for each carousel slide and enable slide controls. If set to a whole number, will default to x.1 where x is the whole number set. |
-| `gap`                | String | No       | No       | override the margin between carousel items in pixels (default: "16")                                                                                                  |
-| `image-treatment`    | String | No       | No       | `none` (default), or `matte`. If "matte", image treatment styles are applied. Default is false.                                                                       |
+| Name                   | Type   | Stateful | Required | Description                                                                                                                                                           |
+| ---------------------- | ------ | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aria-label`           | String | No       | No       | a11y label text for component                                                                                                                                         |
+| `aria-labelledby`      | String | No       | No       | id(s) of element(s) containing a11y label text for component                                                                                                          |
+| `aria-roledescription` | String | No       | Yes      | a11y role description for component (default: "Carousel")                                                                                                             |
+| `a11y-previous-text`   | String | No       | Yes      | a11y text for previous control (default: "Previous Slide")                                                                                                            |
+| `a11y-next-text`       | String | No       | Yes      | a11y text for next control (default: "Next Slide")                                                                                                                    |
+| `index`                | String | Yes      | No       | 0-based index position                                                                                                                                                |
+| `items-per-slide`      | String | No       | No       | automatically fit a number of items for each carousel slide and enable slide controls. If set to a whole number, will default to x.1 where x is the whole number set. |
+| `gap`                  | String | No       | No       | override the margin between carousel items in pixels (default: "16")                                                                                                  |
+| `image-treatment`      | String | No       | No       | `none` (default), or `matte`. If "matte", image treatment styles are applied. Default is false.                                                                       |
 
 ### Additional Attributes for when items-per-slide is set
 
-| Name               | Type              | Stateful | Required | Description                                                                                                                       |
-| ------------------ | ----------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `a11y-status-text` | String            | No       | Yes      | status text (default: "Showing Slide {currentSlide} of {totalSlides}")                                                            |
-| `a11y-status-tag`  | String            | No       | Yes      | use h1-h6 when there isn't a visible heading before the carousel (default: "span")                                                |
-| `autoplay`         | Boolean or Number | No       | No       | automatically slides the carousel on an interval. If a number is supplied that is used as the interval in ms, defaults to 4000ms. |
+| Name       | Type              | Stateful | Required | Description                                                                                                                       |
+| ---------- | ----------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `autoplay` | Boolean or Number | No       | No       | automatically slides the carousel on an interval. If a number is supplied that is used as the interval in ms, defaults to 4000ms. |
 
 ### Additional Attributes for when autoplay is set
 
@@ -81,3 +80,4 @@ This component will bundle different resources depending on Lasso flags provided
 -   The `carousel` will manipulate the `tabindex` property of nested focusable elements inside `<@item>`.
 -   The `autoplay` carousel currently does not support native scrolling and will use transforms instead.
 -   The `items-per-slide` attribute can be set to a float such as `3.5` to show 3 items, and half of the 4th item. If `items-per-slide` are set as a whole number, it will automatically be set as a x.1 peek if carousel is not autoplay.
+-   Use one of `aria-label` or `aria-labelledby` to label the component

--- a/src/components/ebay-carousel/carousel.stories.js
+++ b/src/components/ebay-carousel/carousel.stories.js
@@ -98,27 +98,33 @@ export default {
                 },
             },
         },
-        'a11y-heading-text': {
-            description:
-                'Text to announce as heading. Used when there is no external heading for carousel',
-            table: {
-                defaultValue: {
-                    summary: '',
-                },
 
+        'aria-label': {
+            description: 'a11y label text for component',
+            table: {
                 category: 'accessibility attributes',
             },
+            control: { type: 'text' },
         },
-        'a11y-heading-tag': {
-            description:
-                "h1-h6 when there isn't a visible heading before the carousel (continuous only)",
+
+        'aria-labelledby': {
+            description: 'id of element containing a11y label text for component',
+            table: {
+                category: 'accessibility attributes',
+            },
+            control: { type: 'text' },
+        },
+
+        'aria-roledescription': {
+            description: 'a11y role description for component',
             table: {
                 defaultValue: {
-                    summary: 'h2',
+                    summary: 'Carousel',
                 },
 
                 category: 'accessibility attributes',
             },
+            control: { type: 'text' },
         },
 
         'a11y-next-text': {
@@ -229,10 +235,9 @@ continuous.args = {
     index: 0,
     gap: 16,
     items: getItems(10),
-    'a11y-heading-text': '',
-    'a11y-heading-tag': '',
     'a11y-previous-text': '',
     'a11y-next-text': '',
+    'aria-label': 'Continuous',
 };
 
 continuous.parameters = {
@@ -248,10 +253,9 @@ continuousVariedWidth.args = {
     index: 0,
     gap: 16,
     items: getItems(10, 'none', false, 'variable'),
-    'a11y-heading-text': '',
-    'a11y-heading-tag': '',
     'a11y-previous-text': '',
     'a11y-next-text': '',
+    'aria-label': 'Continuous, Varied Width',
 };
 
 continuousVariedWidth.parameters = {
@@ -269,10 +273,9 @@ imageTreatment.args = {
     imageTreatment: 'matte',
     items: getItems(10, 'matte'),
     itemWidth: 'fixed',
-    'a11y-heading-text': '',
-    'a11y-heading-tag': '',
     'a11y-previous-text': '',
     'a11y-next-text': '',
+    'aria-label': 'Image treatment',
 };
 
 imageTreatment.parameters = {
@@ -291,6 +294,7 @@ itemsPerSlide.args = {
     'a11y-previous-text': null,
     'a11y-next-text': null,
     itemsPerSlide: '2',
+    'aria-label': 'Items Per Slide',
 };
 itemsPerSlide.parameters = {
     controls: { exclude: ['autoplay'] },
@@ -310,6 +314,7 @@ autoplay.args = {
     'a11y-next-text': null,
     itemsPerSlide: '1',
     autoplay: true,
+    'aria-label': 'Autoplay',
 };
 
 autoplay.parameters = {

--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -23,16 +23,13 @@ function getTemplateData(state) {
     const bothControlsDisabled = isAnimating(state)
         ? state.bothControlsDisabled
         : prevControlDisabled && nextControlDisabled;
-    let slide, itemWidth, totalSlides, a11yStatusText;
+    let slide, itemWidth, totalSlides;
 
     if (itemsPerSlide) {
         const itemsInSlide = itemsPerSlide + state.peek;
         slide = getSlide(state);
         itemWidth = `calc(${100 / itemsInSlide}% - ${((itemsInSlide - 1) * gap) / itemsInSlide}px)`;
         totalSlides = getSlide(state, items.length);
-        a11yStatusText = state.a11yStatusText
-            .replace('{currentSlide}', slide + 1)
-            .replace('{totalSlides}', totalSlides);
     }
 
     items.forEach((item, i) => {
@@ -62,7 +59,6 @@ function getTemplateData(state) {
         offset: hasOverride ? config.offsetOverride : offset,
         disableTransition: hasOverride,
         totalSlides,
-        a11yStatusText,
         prevControlDisabled,
         nextControlDisabled,
         bothControlsDisabled,
@@ -482,10 +478,6 @@ export default {
                 'itemsPerSlide',
                 'a11yPreviousText',
                 'a11yNextText',
-                'a11yStatusText',
-                'a11yStatusTag',
-                'a11yHeadingText',
-                'a11yHeadingTag',
                 'a11yPlayText',
                 'a11yPauseText',
                 'items',
@@ -503,12 +495,9 @@ export default {
             itemsPerSlide: parseFloat(input.itemsPerSlide, 10) || undefined,
             a11yPreviousText: input.a11yPreviousText || 'Previous Slide',
             a11yNextText: input.a11yNextText || 'Next Slide',
-            a11yStatusText: input.a11yStatusText || 'Showing Slide {currentSlide} of {totalSlides}',
-            a11yStatusTag: input.a11yStatusTag || 'span',
-            a11yHeadingText: input.a11yHeadingText,
-            a11yHeadingTag: input.a11yHeadingTag || 'h2',
             a11yPauseText: input.a11yPauseText || 'Pause',
             a11yPlayText: input.a11yPlayText || 'Play',
+            ariaRoleDescription: input['aria-roledescription'] || 'Carousel',
         };
 
         const itemSkippedAttributes = ['class', 'style', 'key'];

--- a/src/components/ebay-carousel/examples/01-continuous/template.marko
+++ b/src/components/ebay-carousel/examples/01-continuous/template.marko
@@ -6,8 +6,6 @@ $ const {
     itemWidth,
     a11yPreviousText,
     a11yNextText,
-    a11yStatusText,
-    a11yStatusTag,
     images,
     gap,
     getItemWidth
@@ -31,9 +29,7 @@ $ const {
     gap=gap
     image-treatment=imageTreatment
     a11y-previous-text=a11yPreviousText
-    a11y-next-text=a11yNextText
-    a11y-status-text=a11yStatusText
-    a11y-status-tag=a11yStatusTag>
+    a11y-next-text=a11yNextText>
     <for|i| from=0 to=(items - 1)>
         <if(imageTreatment === "matte" && images[i])>
             <@item>

--- a/src/components/ebay-carousel/examples/02-item-per-slide/template.marko
+++ b/src/components/ebay-carousel/examples/02-item-per-slide/template.marko
@@ -6,8 +6,6 @@ $ const {
     gap,
     a11yPreviousText,
     a11yNextText,
-    a11yStatusText,
-    a11yStatusTag,
 } = knobs('itemsPerSlide');
 <style>
     .demo2-card {
@@ -23,9 +21,7 @@ $ const {
 
 <ebay-carousel gap=gap items-per-slide=itemsPerSlide index=index
     a11y-previous-text=a11yPreviousText
-    a11y-next-text=a11yNextText
-    a11y-status-text=a11yStatusText
-    a11y-status-tag=a11yStatusTag>
+    a11y-next-text=a11yNextText>
     <for|i| from=0 to=(items - 1)>
         <@item class=`demo2-card`>Card ${i + 1}</@item>
     </for>

--- a/src/components/ebay-carousel/examples/03-autoplay/template.marko
+++ b/src/components/ebay-carousel/examples/03-autoplay/template.marko
@@ -7,8 +7,6 @@ $ const {
     gap,
     a11yPreviousText,
     a11yNextText,
-    a11yStatusText,
-    a11yStatusTag,
     autoplay,
     paused,
     a11yPauseText,
@@ -34,8 +32,6 @@ $ const {
     autoplay=(autoplay || true)
     a11y-previous-text=a11yPreviousText
     a11y-next-text=a11yNextText
-    a11y-status-text=a11yStatusText
-    a11y-status-tag=a11yStatusTag
     a11y-play-text=a11yPlayText
     a11y-pause-text=a11yPauseText
     >

--- a/src/components/ebay-carousel/index.marko
+++ b/src/components/ebay-carousel/index.marko
@@ -1,15 +1,11 @@
 $ var data = component.getTemplateData(state, input);
 $ var config = data.config;
-$ var discrete = data.totalSlides >= 1;
-$ var statusId = (discrete && "carousel-status-" + component.id) || (
-   data.a11yStatusText || data.a11yHeadingText && component.getElId("carousel"));
 
 <div ...data.htmlAttributes
     class=data.classes
     style=data.style
-    aria-labelledby=statusId
-    role="group"
-    aria-roledescription="carousel">
+    aria-roledescription=data.ariaRoleDescription
+    role="group">
    <div
         class=[
             "carousel__container",
@@ -24,25 +20,6 @@ $ var statusId = (discrete && "carousel-status-" + component.id) || (
         onTouchend(data.autoplayInterval && "handleEndInteraction")
         key="container"
         id:scoped="container">
-        <if(data.a11yStatusText || data.a11yHeadingText)>
-            <${discrete ? data.a11yStatusTag : data.a11yHeadingTag}
-                id=statusId
-                class="clipped"
-                aria-live=(
-                    discrete
-                        ? data.autoplayInterval && !data.paused
-                            ? "off"
-                            : "polite"
-                        : false
-                )>
-                <if(discrete)>
-                    <span>${data.a11yStatusText}</span>
-                </if>
-                <else>
-                    <span>${data.a11yHeadingText}</span>
-                </else>
-            </>
-        </if>
         <button
             class=[
                 "carousel__control",

--- a/src/components/ebay-carousel/test/mock/index.js
+++ b/src/components/ebay-carousel/test/mock/index.js
@@ -4,8 +4,6 @@ export const discrete1PerSlide0Items = {
     itemsPerSlide: 1,
     a11yPreviousText: 'prev',
     a11yNextText: 'next',
-    a11yStatusText: '{currentSlide} of {totalSlides}',
-    a11yStatusTag: 'h2',
     items: [],
 };
 

--- a/src/components/ebay-carousel/test/test.browser.js
+++ b/src/components/ebay-carousel/test/test.browser.js
@@ -276,10 +276,6 @@ describe('given a discrete carousel', () => {
             );
             expect(component.getByLabelText(input.a11yNextText)).has.attr('aria-disabled', 'true');
         });
-
-        it('then has the appropriate heading', () => {
-            expect(component.getByRole('heading')).has.text('1 of 1');
-        });
     });
 
     describe('with 1 item per slide and 3 items at the beginning', () => {
@@ -303,10 +299,6 @@ describe('given a discrete carousel', () => {
             );
         });
 
-        it('then has the appropriate heading', () => {
-            expect(component.getByRole('heading')).has.text('1 of 3');
-        });
-
         describe('when it is rerendered to show the second item', () => {
             beforeEach(async () => {
                 await component.rerender(Object.assign({}, input, { index: 1 }));
@@ -316,10 +308,6 @@ describe('given a discrete carousel', () => {
             it('then it moved to the second item', () => {
                 const secondItem = component.getByText(input.items[1].renderBody.text);
                 assertAtStartOfSlide(secondItem);
-            });
-
-            it('then has the appropriate heading', () => {
-                expect(component.getByRole('heading')).has.text('2 of 3');
             });
         });
 
@@ -409,10 +397,6 @@ describe('given a discrete carousel', () => {
                     'aria-disabled'
                 );
             });
-
-            it('then has updated the heading', () => {
-                expect(component.getByRole('heading')).has.text('2 of 3');
-            });
         }
     });
 
@@ -472,10 +456,6 @@ describe('given a discrete carousel', () => {
             );
         });
 
-        it('then has the appropriate heading', () => {
-            expect(component.getByRole('heading')).has.text('1 of 3');
-        });
-
         describe('when next button is clicked', () => {
             beforeEach(async () => {
                 fireEvent.click(component.getByLabelText(input.a11yNextText));
@@ -498,10 +478,6 @@ describe('given a discrete carousel', () => {
                 const secondItem = component.getByText(input.items[2].renderBody.text);
                 assertAtStartOfSlide(secondItem);
             });
-
-            it('then has updated the heading', () => {
-                expect(component.getByRole('heading')).has.text('2 of 3');
-            });
         }
     });
 
@@ -517,10 +493,6 @@ describe('given a discrete carousel', () => {
                     'aria-disabled'
                 )
             );
-        });
-
-        it('then has the appropriate heading', () => {
-            expect(component.getByRole('heading')).has.text('1 of 2');
         });
 
         it('then it shows part of the next slide', () => {
@@ -549,10 +521,6 @@ describe('given a discrete carousel', () => {
             it('then it moved to the third item', () => {
                 const secondItem = component.getByText(input.items[2].renderBody.text);
                 assertAtStartOfSlide(secondItem);
-            });
-
-            it('then has the appropriate heading', () => {
-                expect(component.getByRole('heading')).has.text('2 of 2');
             });
         });
     });
@@ -632,7 +600,7 @@ describe('given a discrete carousel', () => {
 
         describe('when it is interacted with', () => {
             beforeEach(async () => {
-                await fireEvent.mouseOver(component.getByRole('heading'));
+                await fireEvent.mouseOver(component.getByRole('list'));
             });
 
             it('then the autoplay does not run', async () => {
@@ -642,7 +610,7 @@ describe('given a discrete carousel', () => {
 
             describe('when the interaction has finished', () => {
                 beforeEach(async () => {
-                    await fireEvent.mouseOut(component.getByRole('heading'));
+                    await fireEvent.mouseOut(component.getByRole('list'));
                 });
 
                 it('then it does autoplay', async () => {
@@ -655,10 +623,6 @@ describe('given a discrete carousel', () => {
             it('then it is displaying the first item', () => {
                 const firstItem = component.getByText(input.items[0].renderBody.text);
                 assertAtStartOfSlide(firstItem);
-            });
-
-            it('then it has the appropriate heading', () => {
-                expect(component.getByRole('heading')).has.text('1 of 3');
             });
         }
     });

--- a/src/components/ebay-carousel/test/test.server.js
+++ b/src/components/ebay-carousel/test/test.server.js
@@ -10,12 +10,9 @@ describe('carousel', () => {
     describe('with discrete items per slide', () => {
         it('renders base version', async () => {
             const input = mock.discrete1PerSlide3Items;
-            const { queryByText, getByText } = await render(template, input);
-            const statusEl = getByText(/\d+ of \d+/).parentElement;
+            const { queryByText, getByRole } = await render(template, input);
 
-            expect(statusEl).has.property('tagName', input.a11yStatusTag.toUpperCase());
-            expect(statusEl).has.text('1 of 3');
-            expect(statusEl).has.attr('aria-live', 'polite');
+            expect(getByRole('group')).to.have.attr('aria-roledescription');
 
             input.items.forEach((item) =>
                 expect(queryByText(item.renderBody.text)).not.to.equal(null)
@@ -64,9 +61,6 @@ describe('carousel', () => {
         it('renders base version', async () => {
             const input = mock.continuous6Items;
             const { queryByText, queryByLabelText, getByLabelText } = await render(template, input);
-
-            // Status text is only used for discrete carousels.
-            expect(queryByText(/\d+ of \d+/)).equals(null);
 
             // Also it should not have the dot controls.
             expect(queryByLabelText(/go to slide/)).equals(null);


### PR DESCRIPTION
## Description

Removes aria live status region and offscreen heading from all carousels. Responsibility for heading structure and labelling is now owned by the app. To help achieve this, two new attributes were added and documented:

* `aria-label`
* `aria-labelledby`

I also opened up `aria-roledescription` for text localization.

## Context

The live status region is a leftover from when we had visible pagination dots as part of the carousel.  It was a way to convey slide position. We no longer need it.

## References

Fixes #1630

