### PR TITLE
Issue #1698 - Ignore values in `ebay-tourtip`

### DIFF
--- a/src/components/ebay-tourtip/index.marko
+++ b/src/components/ebay-tourtip/index.marko
@@ -10,7 +10,9 @@ static var ignoredAttributes = [
     "a11yCloseText",
     "host",
     "toJSON",
-    "open"
+    "open",
+    "heading",
+    "content"
 ];
 
 $ input.toJSON = noop;


### PR DESCRIPTION
- Resolves #1698 

## Description
Added `heading` and `content` to the ignore list for `ebay-tourtip`.

## Context
`action` is already ignored in `ebay-snackbar-dialog`, so I did not have to remove that as well.