### PR TITLE
Issues #1636 and #1703 - Changes to `ebay-listbox-button`

### DIFF
--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -12,12 +12,18 @@ export default {
     },
 
     handleListboxChange(event) {
-        if (event.wasClicked) {
-            this._expander.expanded = false;
-        }
         const selectedIndex = event.index;
         this.state.selectedIndex = selectedIndex;
         this.emit('change', event);
+    },
+
+    handleListboxSelect(event) {
+        if (this.input.collapseOnSelect) {
+            this._expander.expanded = false;
+            if (!event.wasClicked) this.el.firstChild.focus();
+        } else if (event.wasClicked) {
+            document.activeElement.blur();
+        }
     },
 
     onCreate() {

--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -8,22 +8,17 @@ export default {
     },
 
     handleCollapse() {
+        this.getEl('button').focus();
         this.emit('collapse');
     },
 
     handleListboxChange(event) {
+        if (this.input.collapseOnSelect) {
+            this._expander.expanded = false;
+        }
         const selectedIndex = event.index;
         this.state.selectedIndex = selectedIndex;
         this.emit('change', event);
-    },
-
-    handleListboxSelect(event) {
-        if (this.input.collapseOnSelect) {
-            this._expander.expanded = false;
-            if (!event.wasClicked) setTimeout(() => this.getEl('button').focus(), 0);
-        } else if (event.wasClicked) {
-            document.activeElement.blur();
-        }
     },
 
     onCreate() {

--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -20,7 +20,7 @@ export default {
     handleListboxSelect(event) {
         if (this.input.collapseOnSelect) {
             this._expander.expanded = false;
-            if (!event.wasClicked) this.el.firstChild.focus();
+            if (!event.wasClicked) setTimeout(() => this.getEl('button').focus(), 0);
         } else if (event.wasClicked) {
             document.activeElement.blur();
         }

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -13,7 +13,8 @@ static var ignoredAttributes = [
     "prefixLabel",
     "prefixId",
     "unselectedText",
-    "floatingLabel"
+    "floatingLabel",
+    "collapseOnSelect"
 ];
 
 $ var selectedOption = input.options[state.selectedIndex];
@@ -69,7 +70,8 @@ $ var displayText = selectedText || unselectedText;
         name=input.name
         tabindex=-1
         list-selection=input.listSelection
-        on-change("handleListboxChange")>
+        on-change("handleListboxChange")
+        on-select("handleListboxSelect")>
         <for|option| of=(input.options || [])>
             <@option ...option selected=(selectedOption === option)/>
         </for>

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -70,8 +70,7 @@ $ var displayText = selectedText || unselectedText;
         name=input.name
         tabindex=-1
         list-selection=input.listSelection
-        on-change("handleListboxChange")
-        on-select("handleListboxSelect")>
+        on-change("handleListboxChange")>
         <for|option| of=(input.options || [])>
             <@option ...option selected=(selectedOption === option)/>
         </for>

--- a/src/components/ebay-listbox-button/listbox-button.stories.js
+++ b/src/components/ebay-listbox-button/listbox-button.stories.js
@@ -42,6 +42,11 @@ export default {
             description:
                 'will truncate the text of the button onto a single line, and adds an ellipsis, when the buttons text overflows',
         },
+        collapseOnSelect: {
+            type: 'boolean',
+            control: { type: 'boolean' },
+            description: 'When an option is selected, the dropdown menu collapses into the button',
+        },
         listSelection: {
             table: {
                 defaultValue: {

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -7,6 +7,7 @@
   "@html-attributes": "expression",
   "@grow": "boolean",
   "@borderless": "boolean",
+  "@collapseOnSelect": "boolean",
   "@fluid": "boolean",
   "@invalid": "boolean",
   "@truncate": "boolean",

--- a/src/components/ebay-listbox/component.js
+++ b/src/components/ebay-listbox/component.js
@@ -12,19 +12,17 @@ export default class {
     }
 
     handleChange(index, wasClicked) {
+        const details = { index, wasClicked };
         if (this.state.selectedIndex !== index) {
             const option = this.input.options[index];
-            const el = this.getEls('option')[index];
+            details.selected = [option.value];
+            details.el = this.getEls('option')[index];
             this.state.selectedIndex = index;
             this.once('update', () => {
-                this.emit('change', {
-                    index,
-                    selected: [option.value],
-                    el,
-                    wasClicked,
-                });
+                this.emit('change', details);
             });
         }
+        this.emit('select', details);
     }
 
     handleClick(index) {

--- a/src/components/ebay-listbox/component.js
+++ b/src/components/ebay-listbox/component.js
@@ -12,17 +12,18 @@ export default class {
     }
 
     handleChange(index, wasClicked) {
-        const details = { index, wasClicked };
         if (this.state.selectedIndex !== index) {
             const option = this.input.options[index];
-            details.selected = [option.value];
-            details.el = this.getEls('option')[index];
             this.state.selectedIndex = index;
             this.once('update', () => {
-                this.emit('change', details);
+                this.emit('change', {
+                    index,
+                    wasClicked,
+                    selected: [option.value],
+                    el: this.getEls('option')[index],
+                });
             });
         }
-        this.emit('select', details);
     }
 
     handleClick(index) {


### PR DESCRIPTION
- Resolves #1636
- Resolves #1703 

## Description
- Added boolean argument `collapseOnSelect` to `ebay-listbox-button`.
- Modified `ebay-listbox` to emit a `select` event in addition to the `change` event in the case that the same option was selected again.
- When an option is selected with the keyboard and `collapseOnSelect` is on, focus returns to the original button

## Context
Moving focus back to the button _only_ on button press and not on click was an opinion-based decision, I would like to hear if you all agree.
