### PR TITLE
feat(page-notice): added support for dismiss button

### DIFF
--- a/src/components/components/ebay-notice-base/component.js
+++ b/src/components/components/ebay-notice-base/component.js
@@ -1,0 +1,19 @@
+module.exports = {
+    onCreate() {
+        this.state = {
+            dismissed: false,
+        };
+    },
+    handleDismissClick: forwardEvent('on-dismiss'),
+    handleDismissKeydown: forwardEvent('on-dismiss'),
+};
+
+function forwardEvent(eventName) {
+    return function (value, originalEvent) {
+        this.state.dismissed = true;
+        this.emit(eventName, {
+            originalEvent,
+            value: value,
+        });
+    };
+}

--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -15,11 +15,13 @@ static var ignoredAttributes = [
     "footer",
     "type",
     "mainRoot",
-    "noA11yLabel"
+    "noA11yLabel",
+    "a11yDismissText"
 ];
 
 $ var status = input.status;
 $ var prefixClass = input.prefixClass;
+<if(!state.dismissed)>
 <${input.root || "section"}
     aria-labelledby=(!input.noA11yLabel && component.elId('status'))
     aria-roledescription=input.a11yRoleDescription
@@ -48,6 +50,11 @@ $ var prefixClass = input.prefixClass;
             </else-if>
         </>
     </if>
+    <if(input.cta)>
+        <p class="page-notice__cta">
+            $!{input.cta}
+        </p>
+    </if>
     <${input.mainRoot || "div"} class=`${prefixClass}__main`>
         <if(input.title)>
             <${input.title.as || "h2"}
@@ -58,9 +65,21 @@ $ var prefixClass = input.prefixClass;
         </if>
         <${input.renderBody}/>
     </>
-    <if(input.footer)>
+    <if(input.footer && !input.a11yDismissText)>
         <div class=`${prefixClass}__footer`>
             <${input.footer}/>
         </div>
     </if>
+    <if(input.a11yDismissText)>
+        <div class=`${prefixClass}__footer`>
+            <button
+                aria-label=`${input.a11yDismissText}`
+                class="fake-link page-notice__dismiss"
+                onClick("handleDismissClick")
+                onKeydown("handleDismissKeydown")>
+                <ebay-close-icon class="icon icon--close-small"/>
+            </button>
+        </div>
+    </if>
 </>
+</if>

--- a/src/components/ebay-page-notice/README.md
+++ b/src/components/ebay-page-notice/README.md
@@ -34,8 +34,10 @@ The `<ebay-page-notice>` is a tag used to create a custom-designed notice elemen
 
 ## ebay-page-notice Attributes
 
-| Name             | Type   | Stateful | Required | Description                                                                                    |
-| ---------------- | ------ | -------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `status`         | String | No       | No       | "attention" (default for "page" and "inline"), "confirmation" "information", or "celebration". |
-| `a11y-icon-text` | String | No       | Yes      | adding description for the notice for a11y users                                               |
-| `icon`           | String | Yes      | No       | "default" (matches whatever is specified by the "status") or "none"                            |
+| Name              | Type   | Stateful | Required | Description                                                                                    |
+| ----------------- | ------ | -------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `status`          | String | No       | No       | "attention" (default for "page" and "inline"), "confirmation" "information", or "celebration". |
+| `a11y-icon-text`  | String | No       | Yes      | adding description for the notice for a11y users                                               |
+| `icon`            | String | Yes      | No       | "default" (matches whatever is specified by the "status") or "none"                            |
+| `cta`             | String | No       | No       | adding a dedicated CTA link in notice with full anchor tag in HTML                             |
+| `a11yDismissText` | String | No       | No       | adding a dismiss button to dismiss the notice                                                  |

--- a/src/components/ebay-page-notice/index.marko
+++ b/src/components/ebay-page-notice/index.marko
@@ -1,3 +1,5 @@
+class {}
+
 $ var status = input.status || 'attention';
 
 <ebay-notice-base
@@ -6,4 +8,5 @@ $ var status = input.status || 'attention';
     status=status
     role="region"
     prefixClass="page-notice"
+    on-dismiss('emit', 'on-dismiss')
 />

--- a/src/components/ebay-page-notice/page-notice.stories.js
+++ b/src/components/ebay-page-notice/page-notice.stories.js
@@ -32,7 +32,7 @@ export default {
                 },
             },
 
-            description: 'The icon used and status of the noptice',
+            description: 'The icon used and status of the notice',
             options: ['attention', 'confirmation', 'information', 'celebration'],
             type: 'select',
         },
@@ -49,7 +49,10 @@ export default {
         a11yIconText: {
             description: 'adding description for the icon in the notice for a11y users',
         },
-
+        a11yDismissText: {
+            description:
+                'This adds a dismiss icon allowing the notice to be dismissed/hidden and sets the a11y text on the icon',
+        },
         title: {
             name: '@title',
             description: 'The title content to be displayed. Used mostly for celebration notice',
@@ -59,9 +62,23 @@ export default {
         },
         footer: {
             name: '@footer',
-            description: 'The footer content to be displayed. Used to show a CTA button generally',
+            description:
+                'The footer content to be displayed. Used to show the dismiss button generally',
             table: {
                 category: '@attribute tags',
+            },
+        },
+        cta: {
+            description: 'This adds a CTA link using full HTML anchor tag',
+        },
+        onDismiss: {
+            action: 'on-dismiss',
+            description: 'Triggered on notice dismiss',
+            table: {
+                category: 'Events',
+                defaultValue: {
+                    summary: '{ originalEvent }',
+                },
             },
         },
     },
@@ -70,8 +87,11 @@ export default {
 export const Standard = Template.bind({});
 Standard.args = {
     a11yText: 'attention',
+    a11yIconText: '',
+    a11yDismissText: '',
     status: null,
     icon: null,
+    cta: null,
 };
 Standard.parameters = {
     docs: {
@@ -90,6 +110,25 @@ export const WithAction = (args) => ({
 });
 WithAction.args = {
     a11yText: 'attention',
+    a11yIconText: '',
+    a11yDismissText: '',
     status: null,
     icon: null,
+};
+
+export const WithDismiss = (args) => ({
+    input: {
+        ...args,
+        title,
+        renderBody,
+        footer,
+    },
+});
+WithDismiss.args = {
+    a11yText: 'information',
+    a11yIconText: '',
+    a11yDismissText: 'Dismiss Notice',
+    status: 'information',
+    icon: null,
+    cta: `<a href="https://www.ebay.com">Opt in</a>`,
 };


### PR DESCRIPTION
## Description
Adds support for the dismiss button/icon and CTA link(s) for page notice.

## Context
We needed to maintain some semblance of consistency with regard to markup to align with styling and also keeping things backwards compatible to avoid breaking changes. As such...

1. I introduced a CTA option for users to add main call to action links.
2. I added support for a dismiss button/icon that hides the notice when clicked.

## References
#1709 

## Screenshots
<img width="594" alt="image" src="https://user-images.githubusercontent.com/1675667/179845476-0219cda3-f8b6-4872-ab84-e743cd32afc5.png">

