### PR TITLE
feat: synced dialog with new skin changes

### DIFF
--- a/src/components/components/ebay-dialog-base/index.marko
+++ b/src/components/components/ebay-dialog-base/index.marko
@@ -18,6 +18,7 @@ static var ignoredAttributes = [
     "closeButton",
     "closeButtonClass",
     "ignoreEscape",
+    "slideFrom",
     "windowType",
     "mainId",
     "ariaLabelledby",
@@ -33,7 +34,7 @@ static var ignoredAttributes = [
 
 static var ignoredHeaderAttributes = ["id", "as", "class"];
 
-$ var buttonPosition = input.buttonPosition || "left";
+$ var buttonPosition = input.buttonPosition || "right";
 $ var baseEl = input.baseEl || "div";
 $ var header = input.header;
 <macro name="header-content">
@@ -56,7 +57,7 @@ $ var header = input.header;
                 <${input.closeButton}/>
             </if>
             <else>
-                <ebay-close-icon/>
+                <ebay-close-small-icon/>
             </else>
         </button>
     </if>

--- a/src/components/ebay-drawer-dialog/index.marko
+++ b/src/components/ebay-drawer-dialog/index.marko
@@ -6,7 +6,6 @@ $ var handleLabel = (!state.expanded ?
     ...input
     open=input.open
     classPrefix="drawer-dialog"
-    buttonPosition="right"
     key="dialog"
     on-scroll('handleScroll')
     on-open("emit", "open")

--- a/src/components/ebay-fullscreen-dialog/README.md
+++ b/src/components/ebay-fullscreen-dialog/README.md
@@ -14,25 +14,8 @@
 </ebay-fullscreen-dialog>
 ```
 
-## Attributes
+## Links
 
-| Name              | Type    | Stateful | Required | Description                                                                                     |
-| ----------------- | ------- | -------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `open`            | Boolean | Yes      | No       | Whether dialog is open.                                                                         |
-| `focus`           | String  | No       | No       | An id for an element which will receive focus when the dialog opens (defaults to close button). |
-| `a11y-close-text` | String  | No       | Yes      | A11y text for close button and mask.                                                            |
-
-## Events
-
-| Event   | Data | Description   |
-| ------- | ---- | ------------- |
-| `open`  |      | dialog opened |
-| `close` |      | dialog closed |
-
-## <@header>
-
-Will render a header content for fullscreen dialog. Will always render the header element even if this is not present
-
-## <@footer>
-
-Will render the footer content for fullscreen dialog. If not present then will not have any footer.
+-   (Storybook)[https://ebay.github.io/ebayui-core/?path=/story/ebay-fullscreen-dialog]
+-   (Storybook Docs)[https://ebay.github.io/ebayui-core/?path=/docs/ebay-fullscreen-dialog]
+-   (Code Examples)[https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-fullscreen-dialog/examples]

--- a/src/components/ebay-fullscreen-dialog/examples/01-basic/template.marko
+++ b/src/components/ebay-fullscreen-dialog/examples/01-basic/template.marko
@@ -1,9 +1,4 @@
-<ebay-fullscreen-dialog a11y-close-text="Close Dialog" open=state.open on-close('closeDialog') on-open('emit', 'open')>
-    <@header><${input.header.renderBody}/></@header>
-    <${input.renderBody}/>
-    <@footer>
-      <${input.footer.renderBody}/>
-    </@footer>
+<ebay-fullscreen-dialog a11y-close-text="Close Dialog" open=state.open on-close('closeDialog') on-open('emit', 'open') ...input>
 </ebay-fullscreen-dialog>
 
 <ebay-button on-click('openDialog')>

--- a/src/components/ebay-fullscreen-dialog/fullsceen-dialog.stories.js
+++ b/src/components/ebay-fullscreen-dialog/fullsceen-dialog.stories.js
@@ -32,6 +32,17 @@ export default {
             description:
                 'An id for an element which will receive focus when the dialog opens (defaults to close button).',
         },
+        slideFrom: {
+            options: ['bottom', 'end'],
+            description:
+                'Either bottom or end. Where the panel slide begins from, either on the bottom or the end of the page.',
+            table: {
+                defaultValue: {
+                    summary: 'bottom',
+                },
+            },
+            type: { category: 'Options' },
+        },
         closeFocus: {
             control: { type: 'text' },
             description:
@@ -86,6 +97,7 @@ Standard.args = {
     footer: {
         renderBody: `Footer Text`,
     },
+    slideFrom: null,
 };
 
 Standard.parameters = {

--- a/src/components/ebay-fullscreen-dialog/index.marko
+++ b/src/components/ebay-fullscreen-dialog/index.marko
@@ -7,6 +7,6 @@
     on-close("emit", "close")
     class=input.class
     useHiddenProperty=true
-    window-class="fullscreen-dialog__window--slide">
+    window-class=(input.slideFrom === 'end' ? "fullscreen-dialog__window--slide-end" : "fullscreen-dialog__window--slide")>
     <${input.renderBody}/>
 </ebay-dialog-base>

--- a/src/components/ebay-fullscreen-dialog/marko-tag.json
+++ b/src/components/ebay-fullscreen-dialog/marko-tag.json
@@ -10,6 +10,9 @@
   "@close-focus": "string",
   "@a11y-close-text": "string",
   "@role": "never",
+  "@slideFrom": {
+    "enum": ["bottom", "end"]
+  },
   "@hidden": "never",
   "@header <header>": {
     "attribute-groups": ["html-attributes"],

--- a/src/components/ebay-fullscreen-dialog/test/__snapshots__/renders-defaults.expected.html
+++ b/src/components/ebay-fullscreen-dialog/test/__snapshots__/renders-defaults.expected.html
@@ -1,0 +1,66 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"fullscreen-dialog"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"fullscreen-dialog__window fullscreen-dialog__window--slide"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"fullscreen-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading Text[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn fullscreen-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-small"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-small"[39m
+                [33mviewBox[39m=[32m"0 0 14 14"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M8.47 6.977l5.29-5.27a.993.993 0 00-.053-1.352c-.37-.368-.96-.39-1.357-.052l-5.29 5.27L1.77.293a1.007 1.007 0 00-1.42 0 .998.998 0 000 1.415l5.3 5.27-5.3 5.27a.994.994 0 00.416 1.724c.365.088.75-.036.994-.32l5.3-5.27 5.29 5.27c.396.338.988.315 1.357-.052a.993.993 0 00.053-1.353l-5.29-5.27z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-small"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__main"[39m
+      [36m>[39m
+        [0mBody Content[0m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__footer"[39m
+      [36m>[39m
+        [0mFooter Text[0m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-fullscreen-dialog/test/__snapshots__/renders-open.expected.html
+++ b/src/components/ebay-fullscreen-dialog/test/__snapshots__/renders-open.expected.html
@@ -1,0 +1,65 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"fullscreen-dialog"[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"fullscreen-dialog__window fullscreen-dialog__window--slide"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"fullscreen-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading Text[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn fullscreen-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-small"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-small"[39m
+                [33mviewBox[39m=[32m"0 0 14 14"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M8.47 6.977l5.29-5.27a.993.993 0 00-.053-1.352c-.37-.368-.96-.39-1.357-.052l-5.29 5.27L1.77.293a1.007 1.007 0 00-1.42 0 .998.998 0 000 1.415l5.3 5.27-5.3 5.27a.994.994 0 00.416 1.724c.365.088.75-.036.994-.32l5.3-5.27 5.29 5.27c.396.338.988.315 1.357-.052a.993.993 0 00.053-1.353l-5.29-5.27z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-small"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__main"[39m
+      [36m>[39m
+        [0mBody Content[0m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__footer"[39m
+      [36m>[39m
+        [0mFooter Text[0m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-fullscreen-dialog/test/__snapshots__/renders-slide-end.expected.html
+++ b/src/components/ebay-fullscreen-dialog/test/__snapshots__/renders-slide-end.expected.html
@@ -1,0 +1,66 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"fullscreen-dialog"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"fullscreen-dialog__window fullscreen-dialog__window--slide-end"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"fullscreen-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading Text[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn fullscreen-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-small"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-small"[39m
+                [33mviewBox[39m=[32m"0 0 14 14"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M8.47 6.977l5.29-5.27a.993.993 0 00-.053-1.352c-.37-.368-.96-.39-1.357-.052l-5.29 5.27L1.77.293a1.007 1.007 0 00-1.42 0 .998.998 0 000 1.415l5.3 5.27-5.3 5.27a.994.994 0 00.416 1.724c.365.088.75-.036.994-.32l5.3-5.27 5.29 5.27c.396.338.988.315 1.357-.052a.993.993 0 00.053-1.353l-5.29-5.27z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-small"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__main"[39m
+      [36m>[39m
+        [0mBody Content[0m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__footer"[39m
+      [36m>[39m
+        [0mFooter Text[0m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-fullscreen-dialog/test/__snapshots__/renders-without-footer-and-header.expected.html
+++ b/src/components/ebay-fullscreen-dialog/test/__snapshots__/renders-without-footer-and-header.expected.html
@@ -1,0 +1,54 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"fullscreen-dialog"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"fullscreen-dialog__window fullscreen-dialog__window--slide"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__header"[39m
+      [36m>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn fullscreen-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-small"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-small"[39m
+                [33mviewBox[39m=[32m"0 0 14 14"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M8.47 6.977l5.29-5.27a.993.993 0 00-.053-1.352c-.37-.368-.96-.39-1.357-.052l-5.29 5.27L1.77.293a1.007 1.007 0 00-1.42 0 .998.998 0 000 1.415l5.3 5.27-5.3 5.27a.994.994 0 00.416 1.724c.365.088.75-.036.994-.32l5.3-5.27 5.29 5.27c.396.338.988.315 1.357-.052a.993.993 0 00.053-1.353l-5.29-5.27z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-small"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"fullscreen-dialog__main"[39m
+      [36m>[39m
+        [0mBody Content[0m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-fullscreen-dialog/test/test.server.js
+++ b/src/components/ebay-fullscreen-dialog/test/test.server.js
@@ -1,43 +1,25 @@
-import { expect, use } from 'chai';
-import { render } from '@marko/testing-library';
-import { testPassThroughAttributes } from '../../../common/test-utils/server';
-import template from '..';
-import * as mock from './mock';
+import { use } from 'chai';
+import { composeStories } from '@storybook/marko/dist/testing';
+import { snapshotHTML } from '../../../common/test-utils/snapshots';
+import * as stories from '../fullsceen-dialog.stories'; // import all stories from the stories file
+
+const { Standard } = composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
 
 use(require('chai-dom'));
 
-describe('dialog', () => {
-    it('renders basic version', async () => {
-        const input = mock.Dialog;
-        const { getByRole, getByLabelText, getByText } = await render(template, input);
-        const dialog = getByRole('dialog', { hidden: true });
+it('renders defaults', async () => {
+    await htmlSnap(Standard);
+});
 
-        expect(dialog).has.attr('hidden');
-        expect(dialog).has.class('fullscreen-dialog');
-        expect(getByLabelText(input.a11yCloseText)).has.class('fullscreen-dialog__close');
-        expect(getByText(input.renderBody.text)).has.class('fullscreen-dialog__main');
-    });
+it('renders without footer and header', async () => {
+    await htmlSnap(Standard, { header: null, footer: null });
+});
 
-    it('renders with header and footer', async () => {
-        const input = mock.headerFooterDialog;
-        const { getByRole, getByLabelText, getByText } = await render(template, input);
-        const dialog = getByRole('dialog', { hidden: true });
+it('renders open', async () => {
+    await htmlSnap(Standard, { open: true });
+});
 
-        expect(dialog).has.attr('hidden');
-        expect(dialog).has.class('fullscreen-dialog');
-        expect(getByLabelText(input.a11yCloseText)).has.class('fullscreen-dialog__close');
-        expect(getByText(input.renderBody.text)).has.class('fullscreen-dialog__main');
-        expect(getByText(input.header.renderBody.text).parentElement).has.class(
-            'fullscreen-dialog__header'
-        );
-        expect(getByText(input.footer.renderBody.text)).has.class('fullscreen-dialog__footer');
-    });
-
-    it('renders in open state', async () => {
-        const input = mock.fillDialogOpen;
-        const { getByRole } = await render(template, input);
-        expect(getByRole('dialog')).does.not.have.attr('hidden');
-    });
-
-    testPassThroughAttributes(template);
+it('renders slide end', async () => {
+    await htmlSnap(Standard, { slideFrom: 'end' });
 });

--- a/src/components/ebay-toast-dialog/index.marko
+++ b/src/components/ebay-toast-dialog/index.marko
@@ -8,7 +8,6 @@ $ var header = input.header || {};
     transitionEl="root"
     isModal=false
     classPrefix="toast-dialog"
-    buttonPosition="right"
     on-open("emit", "open")
     on-close("emit", "close")
     closeButtonClass = ["icon-btn--transparent"]


### PR DESCRIPTION
## Description
* Added small close button as the default
* Added `slide-from` attribute to fullscreen dialog (can be either `bottom` or `end)
* Forced all close buttons to be on right side
* Changed fullscreen dialog tests to use snapshots 

