### PR TITLE
fix: reset ebay-select on form reset

### DIFF
--- a/src/components/ebay-select/component.js
+++ b/src/components/ebay-select/component.js
@@ -36,12 +36,11 @@ export default {
     onMount() {
         this._setupMakeup();
 
-        const selectedOnMount = this.el.querySelector('select').selectedIndex;
-
         const parentForm = this.el.closest('form');
         if (parentForm) {
+            const { selectedIndex } = this.el.querySelector('select');
             this.subscribeTo(parentForm).on('reset', () => {
-                this.handleChange({ target: { selectedIndex: selectedOnMount } });
+                this.handleChange({ target: { selectedIndex } });
             });
         }
     },

--- a/src/components/ebay-select/component.js
+++ b/src/components/ebay-select/component.js
@@ -38,7 +38,7 @@ export default {
 
         const parentForm = this.el.closest('form');
         if (parentForm) {
-            const { selectedIndex } = this.el.querySelector('select');
+            const { selectedIndex } = document.getElementById(this.getElId('select'));
             this.subscribeTo(parentForm).on('reset', () => {
                 this.handleChange({ target: { selectedIndex } });
             });

--- a/src/components/ebay-select/component.js
+++ b/src/components/ebay-select/component.js
@@ -35,10 +35,13 @@ export default {
 
     onMount() {
         this._setupMakeup();
+
+        const selectedOnMount = this.el.querySelector('select').selectedIndex;
+
         const parentForm = this.el.closest('form');
         if (parentForm) {
             this.subscribeTo(parentForm).on('reset', () => {
-                this.handleChange({ target: { selectedIndex: 0 } });
+                this.handleChange({ target: { selectedIndex: selectedOnMount } });
             });
         }
     },

--- a/src/components/ebay-select/component.js
+++ b/src/components/ebay-select/component.js
@@ -35,6 +35,12 @@ export default {
 
     onMount() {
         this._setupMakeup();
+        const parentForm = this.el.closest('form');
+        if (parentForm) {
+            this.subscribeTo(parentForm).on('reset', () => {
+                this.handleChange({ target: { selectedIndex: 0 } });
+            });
+        }
     },
 
     onUpdate() {

--- a/src/components/ebay-select/examples/08-in-form/template.marko
+++ b/src/components/ebay-select/examples/08-in-form/template.marko
@@ -10,7 +10,6 @@
     <ebay-button type="reset">
       Reset
     </ebay-button>
-    &nbsp
     <ebay-button type="submit">
       Submit
     </ebay-button>

--- a/src/components/ebay-select/examples/08-in-form/template.marko
+++ b/src/components/ebay-select/examples/08-in-form/template.marko
@@ -1,0 +1,18 @@
+<form style="text-align: center;">
+  <div>
+      <ebay-select name='formFieldName'>
+          <@option value='1' text='Option 1'/>
+          <@option value='2' text='Option 2'/>
+          <@option value='3' text='Option 3'/>
+      </ebay-select>
+  </div>
+  <div style="padding: 1em;">
+    <ebay-button type="reset">
+      Reset
+    </ebay-button>
+    &nbsp
+    <ebay-button type="submit">
+      Submit
+    </ebay-button>
+  </div>
+</form>

--- a/src/components/ebay-select/select.stories.js
+++ b/src/components/ebay-select/select.stories.js
@@ -3,6 +3,8 @@ import Readme from './README.md';
 import Component from './index.marko';
 import WithLabelTemplate from './examples/07-external-label/template.marko';
 import WithLabelCode from './examples/07-external-label/template.marko?raw';
+import InFormTemplate from './examples/08-in-form/template.marko';
+import InFormCode from './examples/08-in-form/template.marko';
 
 const Template = (args) => ({
     input: {
@@ -136,6 +138,35 @@ ExternalLabel.parameters = {
     docs: {
         source: {
             code: WithLabelCode,
+        },
+    },
+};
+
+export const InForm = (args) => ({
+    input: args,
+    component: InFormTemplate,
+});
+
+InForm.args = {
+    options: [
+        {
+            text: 'option 1',
+            value: 'option 1',
+        },
+        {
+            text: 'option 2',
+            value: 'option 2',
+        },
+        {
+            text: 'option 3',
+            value: 'option 3',
+        },
+    ],
+};
+InForm.parameters = {
+    docs: {
+        source: {
+            code: InFormCode,
         },
     },
 };


### PR DESCRIPTION
- Fixes #1714 

## Description
The `ebay-select` component did not reset when the form it was wrapped in received a "reset" event. This has been fixed.
