### PR TITLE
feat(inline notice, page notice, section notice): integrated skin changes for small icons

### DIFF
--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -31,19 +31,19 @@ $ var prefixClass = input.prefixClass;
         <${input.headerRoot || "div"} class=`${prefixClass}__header` id:scoped="status"
         >
             <if(status === "confirmation" || status === "celebration")>
-                <ebay-confirmation-filled-icon
+                <ebay-confirmation-filled-small-icon
                     a11y-text=(input.a11yIconText || input.a11yText)
                     a11y-variant="label"
                     class=input.iconClass/>
             </if>
             <else-if(status === "attention")>
-                <ebay-attention-filled-icon
+                <ebay-attention-filled-small-icon
                     a11y-variant="label"
                     a11y-text=(input.a11yIconText || input.a11yText)
                     class=input.iconClass/>
             </else-if>
             <else-if(status === "information")>
-                <ebay-information-filled-icon
+                <ebay-information-filled-small-icon
                     a11y-variant="label"
                     a11y-text=(input.a11yIconText || input.a11yText)
                     class=input.iconClass/>
@@ -77,7 +77,7 @@ $ var prefixClass = input.prefixClass;
                 class="fake-link page-notice__dismiss"
                 onClick("handleDismissClick")
                 onKeydown("handleDismissKeydown")>
-                <ebay-close-icon class="icon icon--close-small"/>
+                <ebay-close-small-icon class="icon icon--close-small"/>
             </button>
         </div>
     </if>

--- a/src/components/components/ebay-notice-base/test/test.server.js
+++ b/src/components/components/ebay-notice-base/test/test.server.js
@@ -19,7 +19,7 @@ describe('notice-icon', () => {
         const content = getByText(input.renderBody.text);
         expect(content).has.class(`${input.prefixClass}__main`);
 
-        expect(getByLabelText(input.a11yText)).has.class('icon--attention-filled');
+        expect(getByLabelText(input.a11yText)).has.class('icon--attention-filled-small');
     });
 
     it('renders inline version', async () => {
@@ -31,7 +31,7 @@ describe('notice-icon', () => {
         expect(status.parentElement).has.class(input.class);
         expect(status.parentElement).has.tagName('DIV');
 
-        expect(getByLabelText(input.a11yText)).has.class('icon--information-filled');
+        expect(getByLabelText(input.a11yText)).has.class('icon--information-filled-small');
         expect(getByLabelText(input.a11yText)).has.class('notice-class');
     });
 


### PR DESCRIPTION
## Description
Integrating skin changes of using small icons.

## References
#1717 

## Screenshots
<img width="385" alt="image" src="https://user-images.githubusercontent.com/1675667/185233978-eec215e1-1266-4f95-9397-f7669761c87d.png">

More screenshots can be found in companion Skin issue (see issue description).
