### PR TITLE
fix(ebay-filter-menu-button, ebay-listbox-button): ESC key closes menu and returns focus to button

### DIFF
--- a/src/components/ebay-filter-menu-button/component.js
+++ b/src/components/ebay-filter-menu-button/component.js
@@ -28,6 +28,7 @@ export default Object.assign({}, menuUtils, {
     },
 
     handleCollapse({ originalEvent }) {
+        this.getEl('button').focus();
         this._emitComponentEvent('collapse', originalEvent);
     },
 

--- a/src/components/ebay-filter-menu-button/index.marko
+++ b/src/components/ebay-filter-menu-button/index.marko
@@ -20,6 +20,7 @@ static var ignoredAttributes = [
     onExpander-expand("handleExpand")
     onExpander-collapse("handleCollapse")>
     <button
+        key="button"
         type="button"
         class="filter-menu-button__button"
         disabled=input.disabled

--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -21,6 +21,10 @@ export default {
         this.emit('change', event);
     },
 
+    handleListboxEscape() {
+        this._expander.expanded = false;
+    },
+
     onCreate() {
         this.state = {
             selectedIndex: -1,

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -70,7 +70,8 @@ $ var displayText = selectedText || unselectedText;
         name=input.name
         tabindex=-1
         list-selection=input.listSelection
-        on-change("handleListboxChange")>
+        on-change("handleListboxChange")
+        on-escape("handleListboxEscape")>
         <for|option| of=(input.options || [])>
             <@option ...option selected=(selectedOption === option)/>
         </for>

--- a/src/components/ebay-listbox/component.js
+++ b/src/components/ebay-listbox/component.js
@@ -35,6 +35,10 @@ export default class {
     }
 
     handleKeyDown(originalEvent) {
+        eventUtils.handleEscapeKeydown(originalEvent, () => {
+            this.emit('escape');
+        });
+
         eventUtils.handleActionKeydown(originalEvent, () =>
             this.handleChange(this._activeDescendant.index, false)
         );


### PR DESCRIPTION
- Fixes #1730 

## Description
<!--- What are the changes? -->
Pressing the `esc` key while the menu is open in `ebay-filter-menu-button` and `ebay-listbox-button` now closes the menu and returns focus to the button.
