### PR TITLE
docs: removed deprecated uses of defaultValue

### DIFF
--- a/src/components/ebay-progress-stepper/progress-stepper.stories.js
+++ b/src/components/ebay-progress-stepper/progress-stepper.stories.js
@@ -42,8 +42,10 @@ export default {
                 'Specify whether to auto wrap @step body text with a paragraph tag (default: true)',
         },
         a11yHeadingTag: {
-            defaultValue: {
-                summary: 'h2',
+            table: {
+                defaultValue: {
+                    summary: 'h2',
+                },
             },
             control: { type: 'text' },
             description: 'heading tag for progress stepper',

--- a/src/components/ebay-video/video.stories.js
+++ b/src/components/ebay-video/video.stories.js
@@ -34,7 +34,9 @@ export default {
         },
         volume: {
             type: 'number',
-            defaultValue: 0,
+            table: {
+                defaultValue: 0,
+            },
             control: { type: 'number', min: 0, max: 1, step: 0.1 },
         },
         muted: {


### PR DESCRIPTION
- Fixes #1726 

## Description
Turns out we were only breaking their rules in two of the storybook files, most of our uses of `defaultValue` are not actually deprecated.