### PR TITLE
fix(listbox-button): default collapseOnSelect to true

### DIFF
--- a/src/components/ebay-listbox-button/component.js
+++ b/src/components/ebay-listbox-button/component.js
@@ -38,6 +38,7 @@ export default {
             -1,
             input.options.findIndex((option) => option.selected)
         );
+        input.collapseOnSelect = input.collapseOnSelect !== false;
     },
 
     onMount() {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->
- Fixes #1746 

## Description
Default `collapseOnSelect` to true in `ebay-listbox-button`.
