### PR TITLE
fix: documentation bugs and input ignored attribute

### DIFF
--- a/src/components/ebay-page-notice/README.md
+++ b/src/components/ebay-page-notice/README.md
@@ -36,6 +36,6 @@ The `<ebay-page-notice>` is a tag used to create a custom-designed notice elemen
 
 ## Examples and Documentation
 
--   [Storybook](https://ebay.github.io/ebayui-core/?path=/story/ebay-page-notice)
--   [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/ebay-page-notice)
+-   [Storybook](https://ebay.github.io/ebayui-core/?path=/story/notices-tips-ebay-page-notice)
+-   [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/notices-tips-ebay-page-notice)
 -   [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-page-notice/examples)

--- a/src/components/ebay-page-notice/examples/basic.marko
+++ b/src/components/ebay-page-notice/examples/basic.marko
@@ -1,0 +1,10 @@
+<ebay-page-notice ...input>
+    <p><strong>Error:</strong> Please take another look at the following:</p>
+    <p>
+        <a href='#'>Card number</a>
+        ,
+        <a href='#'>Expiration date</a>
+         &amp;
+        <a href='#'>Security code</a>
+    </p>
+</ebay-page-notice>

--- a/src/components/ebay-page-notice/examples/body.marko
+++ b/src/components/ebay-page-notice/examples/body.marko
@@ -1,9 +1,0 @@
-<p>
-    <strong>Error:</strong> Please take another look at the following:
-</p>
-<p>
-    <a href="#">Card number</a>,
-    <a href="#">Expiration date</a>
-    &amp;
-    <a href="#">Security code</a>
-</p>

--- a/src/components/ebay-page-notice/examples/title.marko
+++ b/src/components/ebay-page-notice/examples/title.marko
@@ -1,1 +1,0 @@
-<div>Celebration title</div>

--- a/src/components/ebay-page-notice/page-notice.stories.js
+++ b/src/components/ebay-page-notice/page-notice.stories.js
@@ -1,19 +1,14 @@
 import { tagToString } from '../../../.storybook/storybook-code-source';
+import { addRenderBodies } from '../../../.storybook/utils';
 import Readme from './README.md';
 import Component from './index.marko';
-import renderBody from './examples/body.marko';
-import title from './examples/title.marko';
 import withAction from './examples/with-action.marko';
 import withActionCode from './examples/with-action.marko?raw';
 import withDismiss from './examples/with-dismiss.marko';
 import withDismissCode from './examples/with-dismiss.marko?raw';
 
 const Template = (args) => ({
-    input: {
-        ...args,
-        renderBody,
-        title: args.status === 'celebration' && title,
-    },
+    input: addRenderBodies(args),
 });
 
 export default {
@@ -95,8 +90,8 @@ export default {
     },
 };
 
-export const Standard = Template.bind({});
-Standard.args = {
+export const Basic = Template.bind({});
+Basic.args = {
     a11yText: 'attention',
     a11yIconText: '',
     a11yDismissText: '',
@@ -104,11 +99,22 @@ Standard.args = {
     icon: null,
     cta: null,
     dismissed: false,
+    title: {
+        renderBody: 'An error has occurred',
+    },
+    renderBody: `<p><strong>Error:</strong> Please take another look at the following:</p>
+    <p>
+        <a href='#'>Card number</a>
+        ,
+        <a href='#'>Expiration date</a>
+         &amp;
+        <a href='#'>Security code</a>
+    </p>`,
 };
-Standard.parameters = {
+Basic.parameters = {
     docs: {
         source: {
-            code: tagToString('ebay-page-notice', Standard.args),
+            code: tagToString('ebay-page-notice', Basic.args),
         },
     },
 };

--- a/src/components/ebay-section-notice/README.md
+++ b/src/components/ebay-section-notice/README.md
@@ -11,32 +11,8 @@ The `<ebay-section-notice>` is a tag used to create a custom-designed notice ele
 
 This notice should be used at the top of various sections to display information needed.
 
-## ebay-section-notice Usage
+## Examples and Documentation
 
-```marko
-<ebay-section-notice a11y-text="Attention" status="attention">
-    <p>Couldn't load all the items, please try again later.</p>
-</ebay-section-notice>
-```
-
-```marko
-<ebay-section-notice a11y-text="Attention" status="attention">
-    <p>Couldn't load all the items, please try again later.</p>
-    <@footer><ebay-fake-link>Try again</ebay-fake-link></@footer>
-</ebay-section-notice>
-```
-
-## ebay-section-notice Sub-tags
-
-| Tag         | Required | Description                             |
-| ----------- | -------- | --------------------------------------- |
-| `<@footer>` | No       | The footer content (for ebay-fake-link) |
-
-## ebay-section-notice Attributes
-
-| Name                    | Type   | Stateful | Required | Description                                                                                        |
-| ----------------------- | ------ | -------- | -------- | -------------------------------------------------------------------------------------------------- |
-| `status`                | String | No       | No       | "attention" "confirmation" "information". The default will render with grey background and no icon |
-| `a11y-text`             | String | No       | Yes      | the description for the notice icon for a11y users.                                                |
-| `a11y-role-description` | String | No       | Yes      | The roledescription to announce the component type for a11y users. Defaults to "Notice".           |
-| `icon`                  | String | Yes      | No       | "default" (matches whatever is specified by the "status") or "none"                                |
+-   [Storybook](https://ebay.github.io/ebayui-core/?path=/story/notices-tips-ebay-section-notice)
+-   [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/notices-tips-ebay-section-notice)
+-   [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-section-notice/examples)

--- a/src/components/ebay-section-notice/examples/base.marko
+++ b/src/components/ebay-section-notice/examples/base.marko
@@ -1,0 +1,11 @@
+<ebay-section-notice ...input>
+    <p>
+        <strong>Error:</strong> Please take another look at the following:
+    </p>
+    <p>
+        <a href="#">Card number</a>,
+        <a href="#">Expiration date</a>
+        &amp;
+        <a href="#">Security code</a>
+    </p>
+</ebay-section-notice>

--- a/src/components/ebay-section-notice/examples/body.marko
+++ b/src/components/ebay-section-notice/examples/body.marko
@@ -1,9 +1,0 @@
-<p>
-    <strong>Error:</strong> Please take another look at the following:
-</p>
-<p>
-    <a href="#">Card number</a>,
-    <a href="#">Expiration date</a>
-    &amp;
-    <a href="#">Security code</a>
-</p>

--- a/src/components/ebay-section-notice/examples/button.marko
+++ b/src/components/ebay-section-notice/examples/button.marko
@@ -1,1 +1,0 @@
-<ebay-fake-link>Footer</ebay-fake-link>

--- a/src/components/ebay-section-notice/examples/title.marko
+++ b/src/components/ebay-section-notice/examples/title.marko
@@ -1,1 +1,0 @@
-<div>Celebration title</div>

--- a/src/components/ebay-section-notice/examples/with-action.marko
+++ b/src/components/ebay-section-notice/examples/with-action.marko
@@ -1,0 +1,14 @@
+<ebay-section-notice ...input>
+    <@footer>
+        <ebay-fake-link>Footer</ebay-fake-link>
+    </@footer>
+    <p>
+        <strong>Error:</strong> Please take another look at the following:
+    </p>
+    <p>
+        <a href="#">Card number</a>,
+        <a href="#">Expiration date</a>
+        &amp;
+        <a href="#">Security code</a>
+    </p>
+</ebay-section-notice>

--- a/src/components/ebay-section-notice/section-notice.stories.js
+++ b/src/components/ebay-section-notice/section-notice.stories.js
@@ -1,16 +1,12 @@
 import { tagToString } from '../../../.storybook/storybook-code-source';
+import { addRenderBodies } from '../../../.storybook/utils';
 import Readme from './README.md';
 import Component from './index.marko';
-import footer from './examples/button.marko';
-import renderBody from './examples/body.marko';
-import title from './examples/title.marko';
+import withAction from './examples/with-action.marko';
+import withActionCode from './examples/with-action.marko?raw';
 
 const Template = (args) => ({
-    input: {
-        ...args,
-        renderBody,
-        title: args.status === 'celebration' && title,
-    },
+    input: addRenderBodies(args),
 });
 
 export default {
@@ -57,7 +53,13 @@ export default {
             },
             description: 'The roledescription to announce the component type for a11y users.',
         },
-
+        title: {
+            name: '@title',
+            description: 'The title content to be displayed.',
+            table: {
+                category: '@attribute tags',
+            },
+        },
         footer: {
             name: '@footer',
             description: 'The footer content to be displayed. Used to show a CTA button generally',
@@ -68,36 +70,54 @@ export default {
     },
 };
 
-export const Standard = Template.bind({});
-Standard.args = {
+export const Basic = Template.bind({});
+Basic.args = {
     a11yText: 'attention',
     status: 'attention',
     a11yRoleDescription: 'Notice',
+    renderBody: '<p>Section notice info. Things you need to know.</p>',
 };
-Standard.parameters = {
+Basic.parameters = {
     docs: {
         source: {
-            code: tagToString('ebay-section-notice', Standard.args),
+            code: tagToString('ebay-section-notice', Basic.args),
+        },
+    },
+};
+
+export const WithTitle = Template.bind({});
+WithTitle.args = {
+    a11yText: 'attention',
+    status: 'attention',
+    a11yRoleDescription: 'Notice',
+    title: {
+        renderBody: 'Section notice title',
+    },
+    renderBody: '<p>Section notice info. Things you need to know.</p>',
+};
+
+WithTitle.parameters = {
+    docs: {
+        source: {
+            code: tagToString('ebay-section-notice', WithTitle.args),
         },
     },
 };
 
 export const WithAction = (args) => ({
-    input: {
-        ...args,
-        renderBody,
-    },
+    input: args,
+    component: withAction,
 });
+
 WithAction.args = {
     a11yText: 'attention',
     status: 'attention',
-    footer,
 };
 
 WithAction.parameters = {
     docs: {
         source: {
-            code: tagToString('ebay-section-notice', WithAction.args),
+            code: withActionCode,
         },
     },
 };

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -15,6 +15,7 @@ static var ignoredAttributes = [
     "floatingLabel",
     "prefixIcon",
     "postfixIcon",
+    "inputSize",
     "toJSON"
 ];
 


### PR DESCRIPTION
## Description
* Cleaned up and fixed page notice and section notice stories. Also cleaned up readmes and examples
* Added `inputSize` to ignore list of textbox

## References
https://github.com/eBay/ebayui-core/issues/1779
#1768