### PR TITLE
feat(listbox-button): split label and value to reflect Skin DOM

### DIFF
--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -56,7 +56,8 @@ $ var displayText = selectedText || unselectedText;
                 <span class="btn__text">${displayText}</span>
             </if>
             <else-if (input.prefixLabel)>
-                <span class="btn__text">${input.prefixLabel} ${displayText}</span>
+                <span class="btn__label">${input.prefixLabel} </span>
+                <span class="btn__text">${displayText}</span>
             </else-if>
             <else>
                 <span id=labelId class="btn__text">${displayText}</span>

--- a/src/components/ebay-listbox-button/test/__snapshots__/renders-basic-version.expected.html
+++ b/src/components/ebay-listbox-button/test/__snapshots__/renders-basic-version.expected.html
@@ -1,0 +1,133 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"listbox-button"[39m
+  [36m>[39m
+    [36m<button[39m
+      [33maria-haspopup[39m=[32m"listbox"[39m
+      [33mclass[39m=[32m"listbox-button__control btn btn--form"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"btn__cell"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__label"[39m
+        [36m>[39m
+          [0mSelected: [0m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__text"[39m
+        [36m>[39m
+          [0m-[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--dropdown"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-dropdown"[39m
+              [33mviewBox[39m=[32m"1.35 5.7 21.6 12.58"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M12.186 18.285c-.451-.009-.809-.167-1.075-.441l-9.337-9.6a1.527 1.527 0 01-.424-.999v-.108c.015-.386.166-.741.424-1.008.56-.573 1.529-.57 2.082 0l8.294 8.53 8.292-8.532c.558-.57 1.526-.57 2.08 0 .265.27.416.629.428 1.01v.087c-.012.391-.165.75-.427 1.02l-9.333 9.6a1.443 1.443 0 01-1.004.441"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-dropdown"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</button>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"listbox__options listbox-button__listbox"[39m
+      [33mrole[39m=[32m"listbox"[39m
+      [33mtabindex[39m=[32m"-1"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 1[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-small"[39m
+              [33mviewBox[39m=[32m"0 0 12 9"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.714.29a1 1 0 00-1.41 0l-6.3 6.3-2.29-2.3a1.004 1.004 0 00-1.42 1.42l3 3a1 1 0 001.41 0l7-7a1 1 0 00.01-1.42z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<select[39m
+      [33mclass[39m=[32m"listbox__native"[39m
+      [33mhidden[39m=[32m""[39m
+    [36m>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+    [36m</select>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-listbox-button/test/__snapshots__/renders-fluid-layout.expected.html
+++ b/src/components/ebay-listbox-button/test/__snapshots__/renders-fluid-layout.expected.html
@@ -1,0 +1,133 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"listbox-button listbox-button--fluid"[39m
+  [36m>[39m
+    [36m<button[39m
+      [33maria-haspopup[39m=[32m"listbox"[39m
+      [33mclass[39m=[32m"listbox-button__control btn btn--form"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"btn__cell"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__label"[39m
+        [36m>[39m
+          [0mSelected: [0m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__text"[39m
+        [36m>[39m
+          [0m-[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--dropdown"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-dropdown"[39m
+              [33mviewBox[39m=[32m"1.35 5.7 21.6 12.58"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M12.186 18.285c-.451-.009-.809-.167-1.075-.441l-9.337-9.6a1.527 1.527 0 01-.424-.999v-.108c.015-.386.166-.741.424-1.008.56-.573 1.529-.57 2.082 0l8.294 8.53 8.292-8.532c.558-.57 1.526-.57 2.08 0 .265.27.416.629.428 1.01v.087c-.012.391-.165.75-.427 1.02l-9.333 9.6a1.443 1.443 0 01-1.004.441"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-dropdown"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</button>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"listbox__options listbox-button__listbox"[39m
+      [33mrole[39m=[32m"listbox"[39m
+      [33mtabindex[39m=[32m"-1"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 1[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-small"[39m
+              [33mviewBox[39m=[32m"0 0 12 9"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.714.29a1 1 0 00-1.41 0l-6.3 6.3-2.29-2.3a1.004 1.004 0 00-1.42 1.42l3 3a1 1 0 001.41 0l7-7a1 1 0 00.01-1.42z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<select[39m
+      [33mclass[39m=[32m"listbox__native"[39m
+      [33mhidden[39m=[32m""[39m
+    [36m>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+    [36m</select>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-listbox-button/test/__snapshots__/renders-truncated-layout.expected.html
+++ b/src/components/ebay-listbox-button/test/__snapshots__/renders-truncated-layout.expected.html
@@ -1,0 +1,133 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"listbox-button"[39m
+  [36m>[39m
+    [36m<button[39m
+      [33maria-haspopup[39m=[32m"listbox"[39m
+      [33mclass[39m=[32m"listbox-button__control btn btn--form btn--truncated"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"btn__cell"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__label"[39m
+        [36m>[39m
+          [0mSelected: [0m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__text"[39m
+        [36m>[39m
+          [0m-[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--dropdown"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-dropdown"[39m
+              [33mviewBox[39m=[32m"1.35 5.7 21.6 12.58"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M12.186 18.285c-.451-.009-.809-.167-1.075-.441l-9.337-9.6a1.527 1.527 0 01-.424-.999v-.108c.015-.386.166-.741.424-1.008.56-.573 1.529-.57 2.082 0l8.294 8.53 8.292-8.532c.558-.57 1.526-.57 2.08 0 .265.27.416.629.428 1.01v.087c-.012.391-.165.75-.427 1.02l-9.333 9.6a1.443 1.443 0 01-1.004.441"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-dropdown"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</button>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"listbox__options listbox-button__listbox"[39m
+      [33mrole[39m=[32m"listbox"[39m
+      [33mtabindex[39m=[32m"-1"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 1[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-small"[39m
+              [33mviewBox[39m=[32m"0 0 12 9"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.714.29a1 1 0 00-1.41 0l-6.3 6.3-2.29-2.3a1.004 1.004 0 00-1.42 1.42l3 3a1 1 0 001.41 0l7-7a1 1 0 00.01-1.42z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<select[39m
+      [33mclass[39m=[32m"listbox__native"[39m
+      [33mhidden[39m=[32m""[39m
+    [36m>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+    [36m</select>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-listbox-button/test/__snapshots__/renders-with-floating-label.expected.html
+++ b/src/components/ebay-listbox-button/test/__snapshots__/renders-with-floating-label.expected.html
@@ -1,0 +1,133 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"listbox-button"[39m
+  [36m>[39m
+    [36m<button[39m
+      [33maria-haspopup[39m=[32m"listbox"[39m
+      [33mclass[39m=[32m"listbox-button__control btn btn--form btn--floating-label"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"btn__cell"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__floating-label btn__floating-label--animate btn__floating-label--inline"[39m
+        [36m>[39m
+          [0mfloating label[0m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__text"[39m
+        [36m>[39m
+          [0m-[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--dropdown"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-dropdown"[39m
+              [33mviewBox[39m=[32m"1.35 5.7 21.6 12.58"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M12.186 18.285c-.451-.009-.809-.167-1.075-.441l-9.337-9.6a1.527 1.527 0 01-.424-.999v-.108c.015-.386.166-.741.424-1.008.56-.573 1.529-.57 2.082 0l8.294 8.53 8.292-8.532c.558-.57 1.526-.57 2.08 0 .265.27.416.629.428 1.01v.087c-.012.391-.165.75-.427 1.02l-9.333 9.6a1.443 1.443 0 01-1.004.441"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-dropdown"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</button>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"listbox__options listbox-button__listbox"[39m
+      [33mrole[39m=[32m"listbox"[39m
+      [33mtabindex[39m=[32m"-1"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 1[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-small"[39m
+              [33mviewBox[39m=[32m"0 0 12 9"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.714.29a1 1 0 00-1.41 0l-6.3 6.3-2.29-2.3a1.004 1.004 0 00-1.42 1.42l3 3a1 1 0 001.41 0l7-7a1 1 0 00.01-1.42z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<select[39m
+      [33mclass[39m=[32m"listbox__native"[39m
+      [33mhidden[39m=[32m""[39m
+    [36m>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+    [36m</select>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-listbox-button/test/__snapshots__/renders-with-prefix-id.expected.html
+++ b/src/components/ebay-listbox-button/test/__snapshots__/renders-with-prefix-id.expected.html
@@ -1,0 +1,134 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"listbox-button"[39m
+  [36m>[39m
+    [36m<button[39m
+      [33maria-haspopup[39m=[32m"listbox"[39m
+      [33maria-labelledby[39m=[32m"prefixId s0-label"[39m
+      [33mclass[39m=[32m"listbox-button__control btn btn--form"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"btn__cell"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__label"[39m
+        [36m>[39m
+          [0mSelected: [0m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__text"[39m
+        [36m>[39m
+          [0m-[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--dropdown"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-dropdown"[39m
+              [33mviewBox[39m=[32m"1.35 5.7 21.6 12.58"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M12.186 18.285c-.451-.009-.809-.167-1.075-.441l-9.337-9.6a1.527 1.527 0 01-.424-.999v-.108c.015-.386.166-.741.424-1.008.56-.573 1.529-.57 2.082 0l8.294 8.53 8.292-8.532c.558-.57 1.526-.57 2.08 0 .265.27.416.629.428 1.01v.087c-.012.391-.165.75-.427 1.02l-9.333 9.6a1.443 1.443 0 01-1.004.441"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-dropdown"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</button>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"listbox__options listbox-button__listbox"[39m
+      [33mrole[39m=[32m"listbox"[39m
+      [33mtabindex[39m=[32m"-1"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 1[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-small"[39m
+              [33mviewBox[39m=[32m"0 0 12 9"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.714.29a1 1 0 00-1.41 0l-6.3 6.3-2.29-2.3a1.004 1.004 0 00-1.42 1.42l3 3a1 1 0 001.41 0l7-7a1 1 0 00.01-1.42z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<select[39m
+      [33mclass[39m=[32m"listbox__native"[39m
+      [33mhidden[39m=[32m""[39m
+    [36m>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+    [36m</select>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-listbox-button/test/__snapshots__/renders-with-prefix-label.expected.html
+++ b/src/components/ebay-listbox-button/test/__snapshots__/renders-with-prefix-label.expected.html
@@ -1,0 +1,133 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"listbox-button"[39m
+  [36m>[39m
+    [36m<button[39m
+      [33maria-haspopup[39m=[32m"listbox"[39m
+      [33mclass[39m=[32m"listbox-button__control btn btn--form"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"btn__cell"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__label"[39m
+        [36m>[39m
+          [0mSelected:  [0m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__text"[39m
+        [36m>[39m
+          [0m-[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--dropdown"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-dropdown"[39m
+              [33mviewBox[39m=[32m"1.35 5.7 21.6 12.58"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M12.186 18.285c-.451-.009-.809-.167-1.075-.441l-9.337-9.6a1.527 1.527 0 01-.424-.999v-.108c.015-.386.166-.741.424-1.008.56-.573 1.529-.57 2.082 0l8.294 8.53 8.292-8.532c.558-.57 1.526-.57 2.08 0 .265.27.416.629.428 1.01v.087c-.012.391-.165.75-.427 1.02l-9.333 9.6a1.443 1.443 0 01-1.004.441"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-dropdown"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</button>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"listbox__options listbox-button__listbox"[39m
+      [33mrole[39m=[32m"listbox"[39m
+      [33mtabindex[39m=[32m"-1"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 1[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-small"[39m
+              [33mviewBox[39m=[32m"0 0 12 9"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.714.29a1 1 0 00-1.41 0l-6.3 6.3-2.29-2.3a1.004 1.004 0 00-1.42 1.42l3 3a1 1 0 001.41 0l7-7a1 1 0 00.01-1.42z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<select[39m
+      [33mclass[39m=[32m"listbox__native"[39m
+      [33mhidden[39m=[32m""[39m
+    [36m>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+    [36m</select>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-listbox-button/test/__snapshots__/renders-with-second-item-selected.expected.html
+++ b/src/components/ebay-listbox-button/test/__snapshots__/renders-with-second-item-selected.expected.html
@@ -1,0 +1,134 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"listbox-button"[39m
+    [33mselected[39m=[32m"1"[39m
+  [36m>[39m
+    [36m<button[39m
+      [33maria-haspopup[39m=[32m"listbox"[39m
+      [33mclass[39m=[32m"listbox-button__control btn btn--form"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<span[39m
+        [33mclass[39m=[32m"btn__cell"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__label"[39m
+        [36m>[39m
+          [0mSelected: [0m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"btn__text"[39m
+        [36m>[39m
+          [0m-[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--dropdown"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-dropdown"[39m
+              [33mviewBox[39m=[32m"1.35 5.7 21.6 12.58"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M12.186 18.285c-.451-.009-.809-.167-1.075-.441l-9.337-9.6a1.527 1.527 0 01-.424-.999v-.108c.015-.386.166-.741.424-1.008.56-.573 1.529-.57 2.082 0l8.294 8.53 8.292-8.532c.558-.57 1.526-.57 2.08 0 .265.27.416.629.428 1.01v.087c-.012.391-.165.75-.427 1.02l-9.333 9.6a1.443 1.443 0 01-1.004.441"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-dropdown"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</span>[39m
+    [36m</button>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"listbox__options listbox-button__listbox"[39m
+      [33mrole[39m=[32m"listbox"[39m
+      [33mtabindex[39m=[32m"-1"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 1[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-small"[39m
+              [33mviewBox[39m=[32m"0 0 12 9"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33md[39m=[32m"M11.714.29a1 1 0 00-1.41 0l-6.3 6.3-2.29-2.3a1.004 1.004 0 00-1.42 1.42l3 3a1 1 0 001.41 0l7-7a1 1 0 00.01-1.42z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"listbox__option"[39m
+        [33mrole[39m=[32m"option"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"listbox__value"[39m
+        [36m>[39m
+          [0mOption 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--tick-small"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mxlink:href[39m=[32m"#icon-tick-small"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<select[39m
+      [33mclass[39m=[32m"listbox__native"[39m
+      [33mhidden[39m=[32m""[39m
+    [36m>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"1"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"2"[39m
+      [36m/>[39m
+      [36m<option[39m
+        [33mvalue[39m=[32m"3"[39m
+      [36m/>[39m
+    [36m</select>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-listbox-button/test/test.server.js
+++ b/src/components/ebay-listbox-button/test/test.server.js
@@ -1,112 +1,37 @@
-import { expect, use } from 'chai';
-import chaiDom from 'chai-dom';
-import { render } from '@marko/testing-library';
-import template from '..';
-import * as mock from './mock';
-const { testPassThroughAttributes } = require('../../../common/test-utils/server');
+import { composeStories } from '@storybook/marko/dist/testing';
+import { snapshotHTML } from '../../../common/test-utils/snapshots';
+import * as stories from '../listbox-button.stories';
 
-use(chaiDom);
+const { Standard } = composeStories(stories);
+
+const htmlSnap = snapshotHTML(__dirname);
 
 describe('listbox', () => {
     it('renders basic version', async () => {
-        const input = mock.basic3Options;
-        const { getByRole, getAllByRole } = await render(template, input);
-
-        const btnEl = getByRole('button');
-        const listboxEl = getAllByRole('listbox').find(isVisible);
-        const visibleOptionEls = getAllByRole('option').filter(isVisible);
-
-        expect(btnEl).has.attr('aria-haspopup', 'listbox');
-        expect(btnEl).has.attr('name', input.buttonName);
-        expect(btnEl).has.text('-');
-        expect(btnEl).has.class('listbox-button__control');
-
-        expect(listboxEl).has.class('listbox-button__listbox');
-
-        expect(visibleOptionEls).has.length(3);
-        visibleOptionEls.forEach((optionEl) => {
-            expect(optionEl).does.not.have.attr('aria-selected');
-        });
-    });
-
-    it('renders empty', async () => {
-        const input = mock.basic0Options;
-        const { getAllByRole } = await render(template, input);
-        expect(getAllByRole('button')).has.length(1);
-        expect(getAllByRole('listbox').filter(isVisible)[0].childNodes).has.length(0);
+        await htmlSnap(Standard);
     });
 
     it('renders fluid layout', async () => {
-        const input = mock.basic3Optionsfluid;
-        const { getAllByRole } = await render(template, input);
-        expect(getAllByRole('button')).has.length(1);
-        expect(getAllByRole('listbox')[0].parentNode).has.class('listbox-button--fluid');
+        await htmlSnap(Standard, { fluid: true });
     });
 
     it('renders truncated layout', async () => {
-        const input = mock.basic3Optionstruncated;
-        const { getAllByRole, getByRole } = await render(template, input);
-        expect(getAllByRole('button')).has.length(1);
-        expect(getByRole('button')).has.class('btn--truncated');
-        expect(getAllByRole('listbox')[0].parentNode).has.tagName('DIV');
+        await htmlSnap(Standard, { truncate: true });
     });
 
     it('renders with second item selected', async () => {
-        const input = mock.basic3Options1Selected;
-        const { getAllByRole } = await render(template, input);
-        expect(getAllByRole('option').filter(isVisible).findIndex(isAriaSelected)).is.equal(1);
+        await htmlSnap(Standard, { selected: 1 });
     });
 
     it('renders with prefix label', async () => {
-        const input = mock.basic3Options1Selected;
-        const { getAllByText } = await render(
-            template,
-            Object.assign({}, input, { prefixLabel: 'prefix:' })
-        );
-        expect(getAllByText('prefix: option 1')).has.length(1);
+        await htmlSnap(Standard, { prefixLabel: 'Selected: ' });
     });
 
     it('renders with prefix id', async () => {
-        const input = mock.basic3Options1Selected;
-        const { getByRole, getAllByText } = await render(
-            template,
-            Object.assign({}, input, { prefixId: 'prefixId' })
-        );
-        const btnEl = getByRole('button');
-        const label = getAllByText('option 1')[0];
-        expect(btnEl).has.attribute('aria-labelledby');
-        expect(btnEl.getAttribute('aria-labelledby')).to.equal(
-            `prefixId ${label.getAttribute('id')}`
-        );
+        await htmlSnap(Standard, { prefixId: 'prefixId' });
     });
 
     it('renders with floating label', async () => {
-        const input = mock.basic3Options1Selected;
-        const { getAllByText, getByRole } = await render(
-            template,
-            Object.assign({}, input, { floatingLabel: 'floating label' })
-        );
-
-        const label = getAllByText('floating label');
-        expect(label).has.length(1);
-        expect(label[0]).has.class('btn__floating-label');
-        const btnEl = getByRole('button');
-        expect(btnEl).has.class('btn--floating-label');
-    });
-
-    testPassThroughAttributes(template);
-    testPassThroughAttributes(template, {
-        child: {
-            name: 'options',
-            multiple: true,
-        },
+        await htmlSnap(Standard, { floatingLabel: 'floating label' });
     });
 });
-
-function isAriaSelected(el) {
-    return el.getAttribute('aria-selected') === 'true';
-}
-
-function isVisible(el) {
-    return !el.hasAttribute('hidden') && !el.closest('[hidden]');
-}


### PR DESCRIPTION
## Description
Changes to reflect the new DOM structure/styling in Skin.

I also switched the server testing to use snapshots. The browser tests didn't appear to be testing anything related to the change.

## References
#1786 

## Screenshots
Before:
<img width="206" alt="image" src="https://user-images.githubusercontent.com/1675667/195428667-3457ebae-859c-4a74-af9c-71af8383d389.png">

After:
<img width="206" alt="image" src="https://user-images.githubusercontent.com/1675667/195428389-e4326ef3-6fac-47d3-9c5a-2b4bc6f6f549.png">

