### PR TITLE
fix(filter-menu-button): pass input a11yFooterText value to filter-menu

### DIFF
--- a/src/components/ebay-filter-menu-button/index.marko
+++ b/src/components/ebay-filter-menu-button/index.marko
@@ -41,6 +41,7 @@ static var ignoredAttributes = [
         form-action=input.formAction
         form-method=input.formMethod
         footer-text=input.footerText
+        a11y-footer-text=input.a11yFooterText
         on-keydown("handleMenuKeydown")
         on-change("handleMenuChange")
         on-form-submit("handleFormSubmit")

--- a/src/components/ebay-filter-menu/index.marko
+++ b/src/components/ebay-filter-menu/index.marko
@@ -3,6 +3,7 @@ import { processHtmlAttributes } from "../../common/html-attributes"
 static var ignoredAttributes = [
     "variant",
     "footerText",
+    "a11yFooterText",
     "class",
     "style",
     "classPrefix",


### PR DESCRIPTION
## Description
Passed a11y footer text input from filter-menu-button to filter-menu to reflect aria-label for footer button.

## References
#1769 

## Screenshots
<img width="1457" alt="image" src="https://user-images.githubusercontent.com/6342519/195672244-4a15070d-d41c-47e8-8528-157a19c2851f.png">

