### PR TITLE
feat(filter): added support to use aria-pressed

### DIFF
--- a/src/components/ebay-filter/filter.stories.js
+++ b/src/components/ebay-filter/filter.stories.js
@@ -29,6 +29,10 @@ export default {
         selected: {
             control: { type: 'boolean' },
         },
+        useAriaPressed: {
+            control: { type: 'boolean' },
+            description: 'defaults to `true`',
+        },
         a11ySelectedText: {
             control: { type: 'text' },
             description: 'defaults to `"Selected"`, but should be changed based on L10N or I18N',
@@ -52,6 +56,7 @@ export default {
 export const Standard = Template.bind({});
 Standard.args = {
     renderBody: `text`,
+    useAriaPressed: true,
 };
 Standard.parameters = {
     docs: {

--- a/src/components/ebay-filter/index.marko
+++ b/src/components/ebay-filter/index.marko
@@ -2,7 +2,8 @@ import { processHtmlAttributes } from "../../common/html-attributes"
 
 static var ignoredAttributes = [
     "selected",
-    "a11ySelectedText"
+    "a11ySelectedText",
+    "useAriaPressed"
 ];
 
 $ var baseClass = input.href ? "filter-link" : "filter-button";
@@ -15,7 +16,7 @@ $ var baseClass = input.href ? "filter-link" : "filter-button";
         input.class
     ]
     type=(!input.href && "button")
-    aria-pressed=(!input.href && state.selected && "true")
+    aria-pressed=(input.useAriaPressed !== false && !input.href && state.selected && "true")
     onClick("handleButtonClick")>
     <span class=`${baseClass}__cell`>
         <span>

--- a/src/components/ebay-filter/marko-tag.json
+++ b/src/components/ebay-filter/marko-tag.json
@@ -18,5 +18,6 @@
   "@referrerpolicy": "#html-referrerpolicy",
   "@rel": "#html-rel",
   "@target": "#html-target",
-  "@aria-pressed": "never"
+  "@aria-pressed": "never",
+  "@useAriaPressed": "boolean"
 }

--- a/src/components/ebay-filter/test/mock/index.js
+++ b/src/components/ebay-filter/test/mock/index.js
@@ -2,10 +2,15 @@ import { createRenderBody } from '../../../../common/test-utils/shared';
 
 export const Basic = {
     renderBody: createRenderBody('text'),
+    useAriaPressed: true,
 };
 
 export const Selected = Object.assign({}, Basic, {
     selected: true,
+});
+
+export const withOutPressed = Object.assign({}, Selected, {
+    useAriaPressed: false,
 });
 
 export const Disabled = Object.assign({}, Basic, {

--- a/src/components/ebay-filter/test/test.server.js
+++ b/src/components/ebay-filter/test/test.server.js
@@ -22,6 +22,12 @@ describe('filter', () => {
         expect(getByRole('button')).has.attr('aria-pressed', 'true');
     });
 
+    it('renders without pressed attribute', async () => {
+        const input = mock.withOutPressed;
+        const { getByRole } = await render(template, input);
+        expect(getByRole('button')).does.not.have.attr('aria-pressed');
+    });
+
     it('renders with disabled attribute', async () => {
         const input = mock.Disabled;
         const { getByRole } = await render(template, input);


### PR DESCRIPTION
## Description
Added a configuration `useAriaPressed` which defaults to `true`. This config can be set to `false` where using `aria-pressed` is inappropriate. 

## References
#1772 

## Screenshots

When `selected` and `useAriaPressed` set to `true`

<img width="1565" alt="image" src="https://user-images.githubusercontent.com/6342519/195905655-1911e6b3-1729-4fe0-8a9f-259377498211.png">

When `selected` and `useAriaPressed` set to `false`

<img width="1565" alt="image" src="https://user-images.githubusercontent.com/6342519/195905796-f7319ff8-0826-4de2-973e-a20b0b80acc2.png">


