### PR TITLE
fix: updated filter menu icon to dropdown

### DIFF
--- a/src/components/ebay-filter-menu-button/index.marko
+++ b/src/components/ebay-filter-menu-button/index.marko
@@ -30,7 +30,7 @@ static var ignoredAttributes = [
         aria-pressed=(component.getCheckedValues().some(Boolean) && "true")>
         <span class="filter-menu-button__button-cell">
             <span class="filter-menu-button__button-text">${input.text}</span>
-            <ebay-chevron-down-icon/>
+            <ebay-dropdown-icon/>
         </span>
     </button>
     <ebay-filter-menu

--- a/src/components/ebay-filter-menu-button/test/test.server.js
+++ b/src/components/ebay-filter-menu-button/test/test.server.js
@@ -17,7 +17,7 @@ describe('filter-menu-button', () => {
         expect(btnEl).has.attr('aria-haspopup', 'true');
         expect(btnEl).has.attr('aria-expanded', 'false');
         expect(btnEl).has.property('parentElement').with.class('filter-menu-button');
-        expect(btnEl.querySelector('.icon--chevron-down')).has.property('tagName', 'svg');
+        expect(btnEl.querySelector('.icon--dropdown')).has.property('tagName', 'svg');
         expect(getByRole('menu'))
             .has.property('parentElement')
             .with.class('filter-menu-button__menu');


### PR DESCRIPTION
Updated filter menu icon to be a dropdown-icon instead of chevron icon