### PR TITLE
feat: synced filter and menu with new makeup changes for disabled state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "license": "MIT",
       "dependencies": {
         "@marko-tags/subscribe": "^0.4.2",
-        "makeup-active-descendant": "0.5.1",
-        "makeup-expander": "~0.10.0",
-        "makeup-floating-label": "~0.3.1",
-        "makeup-focusables": "~0.3.0",
-        "makeup-key-emitter": "~0.3.0",
+        "makeup-active-descendant": "0.6.1",
+        "makeup-expander": "~0.10.1",
+        "makeup-floating-label": "~0.3.2",
+        "makeup-focusables": "~0.3.1",
+        "makeup-key-emitter": "~0.3.1",
         "makeup-keyboard-trap": "~0.4.1",
-        "makeup-prevent-scroll-keys": "~0.2.0",
-        "makeup-roving-tabindex": "~0.5.1",
+        "makeup-prevent-scroll-keys": "~0.2.1",
+        "makeup-roving-tabindex": "~0.6.0",
         "makeup-screenreader-trap": "~0.4.1",
-        "makeup-typeahead": "^0.2.0"
+        "makeup-typeahead": "^0.2.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.19.3",
@@ -26295,11 +26295,11 @@
       }
     },
     "node_modules/makeup-active-descendant": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/makeup-active-descendant/-/makeup-active-descendant-0.5.1.tgz",
-      "integrity": "sha512-d9KL7rWBnGxTU05rYO3LYHOjh3fsBNITp670LyUQWy7Jxav9mOGiTWHT4utnSzvqDUmoyADx9I9wlDbSU7it4Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/makeup-active-descendant/-/makeup-active-descendant-0.6.1.tgz",
+      "integrity": "sha512-WL8q0vbDJFORXPuw5xtYTALWlizRd1k4F5HX/roCA66d9zBrOZdsBZXu0HTqzOVdIZmBQcTqKqZe8JMkM+txnA==",
       "dependencies": {
-        "makeup-navigation-emitter": "~0.5.1",
+        "makeup-navigation-emitter": "~0.6.0",
         "makeup-next-id": "~0.4.0"
       }
     },
@@ -26312,9 +26312,9 @@
       }
     },
     "node_modules/makeup-expander": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.10.0.tgz",
-      "integrity": "sha512-j4f+2DU4xwqd6ClgAzkOzis66sQ/wtn0gaq8NeRPT0qK8Ht2/8C9sZS61kbJYk+P11/D9St2sq5Za2qUzpbt0w==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.10.1.tgz",
+      "integrity": "sha512-auGubmGHsxRTOSvraLBwSYvSouzOlMNR6aXpE5GHi29p0z/IoMCH+Pb8IAXUPSv3ABXSh0bdSjaCrNIH0VNAVw==",
       "dependencies": {
         "makeup-exit-emitter": "~0.4.0",
         "makeup-focusables": "~0.3.0",
@@ -26322,19 +26322,19 @@
       }
     },
     "node_modules/makeup-floating-label": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.3.1.tgz",
-      "integrity": "sha512-3It3ASpKIRbzC8d0fJohoIJ9BmMpw9mIEcrysPoZkvsSWDYhg+i+exBmkDhst0skotpNfL0iwMnkKOWD0k1IZw=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.3.2.tgz",
+      "integrity": "sha512-7wesLkcea9TKDz11LaZMHsCwDIt5GZV9Pli15zKHf/WXASLEr2bSMNhg2JpdMdaZZ7qokj04iak/Qv3uKo/iRg=="
     },
     "node_modules/makeup-focusables": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.3.0.tgz",
-      "integrity": "sha512-WNgwxCmMWs/J/SyoFYrN4FNLq85XuplzkectPipthsiIySBu2Gc+15sgRufEbPShdeSCfyebMhENPXNmN3v6/Q=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.3.1.tgz",
+      "integrity": "sha512-SHL/VBBA6aqTGGay6/6rQvZjlAKmp/VASL46bHdEUfDxWhALzV3xquctr3C3WxdlnFwd4qxbIS3nv1Um9MSJhw=="
     },
     "node_modules/makeup-key-emitter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/makeup-key-emitter/-/makeup-key-emitter-0.3.0.tgz",
-      "integrity": "sha512-LJMbf+V/35fBP54KY3wZLoFlRHkNN+ks/7/tcYDkprfH1s/1iRsbJI52P23sas1Pry5dAL18vSNBCK/7iGobKg=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/makeup-key-emitter/-/makeup-key-emitter-0.3.1.tgz",
+      "integrity": "sha512-J9dn2fb3SIpCzomt70OLa5W6qicoOJPoP1/4u8Vau6Y4RcEPIFMyHiTZbBTXLaOUR12Lm7xiFafao0pTHkFVIQ=="
     },
     "node_modules/makeup-keyboard-trap": {
       "version": "0.4.1",
@@ -26345,9 +26345,9 @@
       }
     },
     "node_modules/makeup-navigation-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/makeup-navigation-emitter/-/makeup-navigation-emitter-0.5.1.tgz",
-      "integrity": "sha512-hqwaHzZugXE7SwIV+tUC28TMMxt9It2LD5wxnlfAOj/S49H3iPl/5z0CmA4sELxp2XwAFnD1Dg75AG396bjVMQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/makeup-navigation-emitter/-/makeup-navigation-emitter-0.6.0.tgz",
+      "integrity": "sha512-lk4OSg7cytThSvo0oUvHH+7SyHPeZ75srXNSvDoBYAb+2t8uh9lTIu335OtvL6m3Ab7oVYj0CpJK2fjzsPzXEQ==",
       "dependencies": {
         "makeup-exit-emitter": "~0.4.0",
         "makeup-key-emitter": "~0.3.0"
@@ -26359,16 +26359,16 @@
       "integrity": "sha512-7HSHKcHcTsONxRWiADCPnpXTofIDyq4i/JDq4IKBUMcmDUb/jK4wgz3DyQD3AK/GSFUeC3y7M9baBSk2qJvr2Q=="
     },
     "node_modules/makeup-prevent-scroll-keys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/makeup-prevent-scroll-keys/-/makeup-prevent-scroll-keys-0.2.0.tgz",
-      "integrity": "sha512-JomR/CgtC+OBF9t4v3tbGDDBvi/5Q6qQQ4ZyjU776alg5XBQ2l2rVuOUXXUmv9DEpP3GryO2/mCdk1d4q078Og=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/makeup-prevent-scroll-keys/-/makeup-prevent-scroll-keys-0.2.1.tgz",
+      "integrity": "sha512-UhNKuzXxbMeqkhb6YBQCJhDiStNzIrxFM5lqOyW61X3QUx4FJ2XHVBYGpZk9tZ1DMLvr9sLmOBp0B0rtZpwtRA=="
     },
     "node_modules/makeup-roving-tabindex": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/makeup-roving-tabindex/-/makeup-roving-tabindex-0.5.1.tgz",
-      "integrity": "sha512-M6X/rl/1HfcM27WIwQre0FyvTVu5G/y7vc+3lYaBt8HHydIjEOC9+flRxkI2wrbbrJ/wodnuu3093O6Ic95ugw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/makeup-roving-tabindex/-/makeup-roving-tabindex-0.6.0.tgz",
+      "integrity": "sha512-dzkGCV0NvZMkqvcuhyHlXLouJBnJQ9aFCnEGIGwBIpgLJ0G1BRgmHnlriNDBJOrJE4NDGBh34aTsacYUGFPnnQ==",
       "dependencies": {
-        "makeup-navigation-emitter": "~0.5.1"
+        "makeup-navigation-emitter": "~0.6.0"
       }
     },
     "node_modules/makeup-screenreader-trap": {
@@ -26377,9 +26377,9 @@
       "integrity": "sha512-64x5elJZlImluq2DFmHZnW4YEt6jvRZGnI4mD37RFVDpE7I2S3DvLrCp1WvaX7j0DNpzZHP7pv4ZM5ru7CJ0Bw=="
     },
     "node_modules/makeup-typeahead": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/makeup-typeahead/-/makeup-typeahead-0.2.0.tgz",
-      "integrity": "sha512-McE2ylsbzCU+LLyQO2hlEcOdQjVrlzJqWZtqDbpuxhU4j/ysrSMhi5UeA0B0CRX4HuaiB/xl7G0axGMTTRDpew=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/makeup-typeahead/-/makeup-typeahead-0.2.1.tgz",
+      "integrity": "sha512-ZCpx3u4vBTxYNWbHC0pD5xzud4dEiNFZGThdOk1ayvAKF6qLjtTLKjEPcgBgvjK+AQXDJT83QK+9V+9BX7OuGg=="
     },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
@@ -58559,11 +58559,11 @@
       }
     },
     "makeup-active-descendant": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/makeup-active-descendant/-/makeup-active-descendant-0.5.1.tgz",
-      "integrity": "sha512-d9KL7rWBnGxTU05rYO3LYHOjh3fsBNITp670LyUQWy7Jxav9mOGiTWHT4utnSzvqDUmoyADx9I9wlDbSU7it4Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/makeup-active-descendant/-/makeup-active-descendant-0.6.1.tgz",
+      "integrity": "sha512-WL8q0vbDJFORXPuw5xtYTALWlizRd1k4F5HX/roCA66d9zBrOZdsBZXu0HTqzOVdIZmBQcTqKqZe8JMkM+txnA==",
       "requires": {
-        "makeup-navigation-emitter": "~0.5.1",
+        "makeup-navigation-emitter": "~0.6.0",
         "makeup-next-id": "~0.4.0"
       }
     },
@@ -58576,9 +58576,9 @@
       }
     },
     "makeup-expander": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.10.0.tgz",
-      "integrity": "sha512-j4f+2DU4xwqd6ClgAzkOzis66sQ/wtn0gaq8NeRPT0qK8Ht2/8C9sZS61kbJYk+P11/D9St2sq5Za2qUzpbt0w==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/makeup-expander/-/makeup-expander-0.10.1.tgz",
+      "integrity": "sha512-auGubmGHsxRTOSvraLBwSYvSouzOlMNR6aXpE5GHi29p0z/IoMCH+Pb8IAXUPSv3ABXSh0bdSjaCrNIH0VNAVw==",
       "requires": {
         "makeup-exit-emitter": "~0.4.0",
         "makeup-focusables": "~0.3.0",
@@ -58586,19 +58586,19 @@
       }
     },
     "makeup-floating-label": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.3.1.tgz",
-      "integrity": "sha512-3It3ASpKIRbzC8d0fJohoIJ9BmMpw9mIEcrysPoZkvsSWDYhg+i+exBmkDhst0skotpNfL0iwMnkKOWD0k1IZw=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/makeup-floating-label/-/makeup-floating-label-0.3.2.tgz",
+      "integrity": "sha512-7wesLkcea9TKDz11LaZMHsCwDIt5GZV9Pli15zKHf/WXASLEr2bSMNhg2JpdMdaZZ7qokj04iak/Qv3uKo/iRg=="
     },
     "makeup-focusables": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.3.0.tgz",
-      "integrity": "sha512-WNgwxCmMWs/J/SyoFYrN4FNLq85XuplzkectPipthsiIySBu2Gc+15sgRufEbPShdeSCfyebMhENPXNmN3v6/Q=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/makeup-focusables/-/makeup-focusables-0.3.1.tgz",
+      "integrity": "sha512-SHL/VBBA6aqTGGay6/6rQvZjlAKmp/VASL46bHdEUfDxWhALzV3xquctr3C3WxdlnFwd4qxbIS3nv1Um9MSJhw=="
     },
     "makeup-key-emitter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/makeup-key-emitter/-/makeup-key-emitter-0.3.0.tgz",
-      "integrity": "sha512-LJMbf+V/35fBP54KY3wZLoFlRHkNN+ks/7/tcYDkprfH1s/1iRsbJI52P23sas1Pry5dAL18vSNBCK/7iGobKg=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/makeup-key-emitter/-/makeup-key-emitter-0.3.1.tgz",
+      "integrity": "sha512-J9dn2fb3SIpCzomt70OLa5W6qicoOJPoP1/4u8Vau6Y4RcEPIFMyHiTZbBTXLaOUR12Lm7xiFafao0pTHkFVIQ=="
     },
     "makeup-keyboard-trap": {
       "version": "0.4.1",
@@ -58609,9 +58609,9 @@
       }
     },
     "makeup-navigation-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/makeup-navigation-emitter/-/makeup-navigation-emitter-0.5.1.tgz",
-      "integrity": "sha512-hqwaHzZugXE7SwIV+tUC28TMMxt9It2LD5wxnlfAOj/S49H3iPl/5z0CmA4sELxp2XwAFnD1Dg75AG396bjVMQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/makeup-navigation-emitter/-/makeup-navigation-emitter-0.6.0.tgz",
+      "integrity": "sha512-lk4OSg7cytThSvo0oUvHH+7SyHPeZ75srXNSvDoBYAb+2t8uh9lTIu335OtvL6m3Ab7oVYj0CpJK2fjzsPzXEQ==",
       "requires": {
         "makeup-exit-emitter": "~0.4.0",
         "makeup-key-emitter": "~0.3.0"
@@ -58623,16 +58623,16 @@
       "integrity": "sha512-7HSHKcHcTsONxRWiADCPnpXTofIDyq4i/JDq4IKBUMcmDUb/jK4wgz3DyQD3AK/GSFUeC3y7M9baBSk2qJvr2Q=="
     },
     "makeup-prevent-scroll-keys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/makeup-prevent-scroll-keys/-/makeup-prevent-scroll-keys-0.2.0.tgz",
-      "integrity": "sha512-JomR/CgtC+OBF9t4v3tbGDDBvi/5Q6qQQ4ZyjU776alg5XBQ2l2rVuOUXXUmv9DEpP3GryO2/mCdk1d4q078Og=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/makeup-prevent-scroll-keys/-/makeup-prevent-scroll-keys-0.2.1.tgz",
+      "integrity": "sha512-UhNKuzXxbMeqkhb6YBQCJhDiStNzIrxFM5lqOyW61X3QUx4FJ2XHVBYGpZk9tZ1DMLvr9sLmOBp0B0rtZpwtRA=="
     },
     "makeup-roving-tabindex": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/makeup-roving-tabindex/-/makeup-roving-tabindex-0.5.1.tgz",
-      "integrity": "sha512-M6X/rl/1HfcM27WIwQre0FyvTVu5G/y7vc+3lYaBt8HHydIjEOC9+flRxkI2wrbbrJ/wodnuu3093O6Ic95ugw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/makeup-roving-tabindex/-/makeup-roving-tabindex-0.6.0.tgz",
+      "integrity": "sha512-dzkGCV0NvZMkqvcuhyHlXLouJBnJQ9aFCnEGIGwBIpgLJ0G1BRgmHnlriNDBJOrJE4NDGBh34aTsacYUGFPnnQ==",
       "requires": {
-        "makeup-navigation-emitter": "~0.5.1"
+        "makeup-navigation-emitter": "~0.6.0"
       }
     },
     "makeup-screenreader-trap": {
@@ -58641,9 +58641,9 @@
       "integrity": "sha512-64x5elJZlImluq2DFmHZnW4YEt6jvRZGnI4mD37RFVDpE7I2S3DvLrCp1WvaX7j0DNpzZHP7pv4ZM5ru7CJ0Bw=="
     },
     "makeup-typeahead": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/makeup-typeahead/-/makeup-typeahead-0.2.0.tgz",
-      "integrity": "sha512-McE2ylsbzCU+LLyQO2hlEcOdQjVrlzJqWZtqDbpuxhU4j/ysrSMhi5UeA0B0CRX4HuaiB/xl7G0axGMTTRDpew=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/makeup-typeahead/-/makeup-typeahead-0.2.1.tgz",
+      "integrity": "sha512-ZCpx3u4vBTxYNWbHC0pD5xzud4dEiNFZGThdOk1ayvAKF6qLjtTLKjEPcgBgvjK+AQXDJT83QK+9V+9BX7OuGg=="
     },
     "map-age-cleaner": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -136,16 +136,16 @@
   },
   "dependencies": {
     "@marko-tags/subscribe": "^0.4.2",
-    "makeup-active-descendant": "0.5.1",
-    "makeup-expander": "~0.10.0",
-    "makeup-floating-label": "~0.3.1",
-    "makeup-focusables": "~0.3.0",
-    "makeup-key-emitter": "~0.3.0",
+    "makeup-active-descendant": "0.6.1",
+    "makeup-expander": "~0.10.1",
+    "makeup-floating-label": "~0.3.2",
+    "makeup-focusables": "~0.3.1",
+    "makeup-key-emitter": "~0.3.1",
     "makeup-keyboard-trap": "~0.4.1",
-    "makeup-prevent-scroll-keys": "~0.2.0",
-    "makeup-roving-tabindex": "~0.5.1",
+    "makeup-prevent-scroll-keys": "~0.2.1",
+    "makeup-roving-tabindex": "~0.6.0",
     "makeup-screenreader-trap": "~0.4.1",
-    "makeup-typeahead": "^0.2.0"
+    "makeup-typeahead": "^0.2.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/src/components/ebay-filter-menu-button/component.js
+++ b/src/components/ebay-filter-menu-button/component.js
@@ -84,7 +84,7 @@ export default Object.assign({}, menuUtils, {
         this._expander = new Expander(this.getEl('container'), {
             hostSelector: '.filter-menu-button__button',
             contentSelector: '.filter-menu-button__menu',
-            focusManagement: 'focusable',
+            focusManagement: 'interactive',
             expandOnClick: true,
             autoCollapse: true,
             alwaysDoFocusManagement: true,

--- a/src/components/ebay-filter-menu/component.js
+++ b/src/components/ebay-filter-menu/component.js
@@ -91,7 +91,7 @@ export default Object.assign({}, menuUtils, {
     _setupMakeup() {
         if (this.input.variant !== 'form') {
             this._rovingTabIndex = createLinear(this.getEl('menu'), 'div', {
-                index: this.lastTabIndexPosition || 0,
+                autoInit: this.lastTabIndexPosition || 'first',
             });
 
             scrollKeyPreventer.add(this.getEl('container'));

--- a/src/components/ebay-filter-menu/component.js
+++ b/src/components/ebay-filter-menu/component.js
@@ -91,7 +91,7 @@ export default Object.assign({}, menuUtils, {
     _setupMakeup() {
         if (this.input.variant !== 'form') {
             this._rovingTabIndex = createLinear(this.getEl('menu'), 'div', {
-                autoInit: this.lastTabIndexPosition || 'first',
+                autoInit: this.lastTabIndexPosition || 'interactive',
             });
 
             scrollKeyPreventer.add(this.getEl('container'));

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -298,11 +298,16 @@ describe('given the menu is in the radio state', () => {
 
 describe('given the menu item is disabled', () => {
     const firstItemText = items[0].renderBody;
+    let firstItem;
+    let secondItem;
 
     beforeEach(async () => {
         items[0] = Object.assign({}, items[0], { disabled: true });
 
         component = await render(Standard, { items: addRenderBodies(items) });
+
+        firstItem = component.getAllByRole('menuitemcheckbox')[0];
+        secondItem = component.getAllByRole('menuitemcheckbox')[1];
     });
 
     describe('when an item is clicked', () => {
@@ -313,6 +318,38 @@ describe('given the menu item is disabled', () => {
         it('then it does not emit the change event with correct data', () => {
             const selectEvents = component.emitted('change');
             expect(selectEvents).to.length(0);
+        });
+    });
+
+    describe('when the current item is pressed with space', () => {
+        beforeEach(async () => {
+            await pressKey(firstItem, {
+                key: '(Space character)',
+                keyCode: 32,
+            });
+        });
+
+        it('then it does not emit the change event with the correct data', () => {
+            const selectEvents = component.emitted('change');
+            expect(selectEvents).has.length(0);
+        });
+    });
+    describe('when the second item is pressed with space', () => {
+        beforeEach(async () => {
+            await pressKey(secondItem, {
+                key: '(Space character)',
+                keyCode: 32,
+            });
+        });
+
+        it('then it emits the change event with the correct data', () => {
+            const selectEvents = component.emitted('change');
+            expect(selectEvents).has.length(1);
+
+            const [[eventArg]] = selectEvents;
+            expect(eventArg).has.property('checked').to.deep.equal(['item 2']);
+            expect(eventArg).has.property('currentChecked').to.equal(true);
+            expect(eventArg).has.property('index').to.equal(1);
         });
     });
 });

--- a/src/components/ebay-listbox/test/test.browser.js
+++ b/src/components/ebay-listbox/test/test.browser.js
@@ -178,9 +178,13 @@ describe('given the listbox with disabled option', () => {
             });
         });
 
-        it('then it does not emit the change event with the correct data', () => {
+        it('then it emits the change event with the correct data', () => {
             const changeEvents = component.emitted('change');
-            expect(changeEvents).has.length(0);
+            expect(changeEvents).has.length(1);
+
+            const [[changeEvent]] = changeEvents;
+            expect(changeEvent).has.property('index', 2);
+            expect(changeEvent).has.property('selected').and.is.deep.equal([options[2].value]);
         });
     });
 });

--- a/src/components/ebay-menu-button/component.js
+++ b/src/components/ebay-menu-button/component.js
@@ -32,7 +32,7 @@ export default Object.assign({}, menuUtils, {
         }
 
         if (this.rovingTabindex) {
-            this.tabindexPosition = this.rovingTabindex.filteredItems.findIndex(
+            this.tabindexPosition = this.rovingTabindex.navigableItems.findIndex(
                 (el) => el.tabIndex === 0
             );
         }

--- a/src/components/ebay-menu-button/component.js
+++ b/src/components/ebay-menu-button/component.js
@@ -32,9 +32,7 @@ export default Object.assign({}, menuUtils, {
         }
 
         if (this.rovingTabindex) {
-            this.tabindexPosition = this.rovingTabindex.navigableItems.findIndex(
-                (el) => el.tabIndex === 0
-            );
+            this.tabindexPosition = this.rovingTabindex.items.findIndex((el) => el.tabIndex === 0);
         }
     },
 

--- a/src/components/ebay-menu/component.js
+++ b/src/components/ebay-menu/component.js
@@ -30,9 +30,7 @@ export default Object.assign({}, menuUtils, {
         }
 
         if (this.rovingTabindex) {
-            this.tabindexPosition = this.rovingTabindex.navigableItems.findIndex(
-                (el) => el.tabIndex === 0
-            );
+            this.tabindexPosition = this.rovingTabindex.items.findIndex((el) => el.tabIndex === 0);
         }
     },
 

--- a/src/components/ebay-menu/component.js
+++ b/src/components/ebay-menu/component.js
@@ -30,7 +30,7 @@ export default Object.assign({}, menuUtils, {
         }
 
         if (this.rovingTabindex) {
-            this.tabindexPosition = this.rovingTabindex.filteredItems.findIndex(
+            this.tabindexPosition = this.rovingTabindex.navigableItems.findIndex(
                 (el) => el.tabIndex === 0
             );
         }


### PR DESCRIPTION
## Description
* Fixes the changes done in this PR https://github.com/makeup/makeup-js/pull/99
* The main changes needed were to switch to `autoIndex` default of `first`, and doing `focusManagement: 'interactive'` on filter-menu/filter-menu-button.
* Also I had some breaking changes in menu/menu-button which was using `filteredItems`. So switched to `navigableItems`

## Context
* Added tests to check for keyoard interactions.
* This PR tests will fail until we publish makeup with the changes in the PR