### PR TITLE
feat(icon-button): add size attribute

### DIFF
--- a/src/components/ebay-icon-button/icon-button.stories.js
+++ b/src/components/ebay-icon-button/icon-button.stories.js
@@ -32,6 +32,16 @@ export default {
             },
             control: { type: 'boolean' },
         },
+        size: {
+            description: 'alternative size for the icon button',
+            options: ['small', 'large'],
+            control: { type: 'select' },
+            table: {
+                defaultValue: {
+                    summary: '',
+                },
+            },
+        },
         partiallyDisabled: {
             description: 'programmatically disabled, but remains keyboard focusable',
             table: {

--- a/src/components/ebay-icon-button/icon-button.stories.js
+++ b/src/components/ebay-icon-button/icon-button.stories.js
@@ -34,11 +34,11 @@ export default {
         },
         size: {
             description: 'alternative size for the icon button',
-            options: ['small', 'large'],
+            options: ['small', 'regular', 'large'],
             control: { type: 'select' },
             table: {
                 defaultValue: {
-                    summary: '',
+                    summary: 'regular',
                 },
             },
         },

--- a/src/components/ebay-icon-button/index.marko
+++ b/src/components/ebay-icon-button/index.marko
@@ -1,5 +1,7 @@
 import { processHtmlAttributes } from "../../common/html-attributes"
 
+static const VALID_SIZES = ['small', 'large']
+
 static function toJSON() {
     return {
         disabled: this.disabled
@@ -11,7 +13,8 @@ static var ignoredAttributes = [
     "badgeNumber",
     "badgeAriaLabel",
     "toJSON",
-    "transparent"
+    "transparent",
+    "size"
 ];
 
 $ {
@@ -31,8 +34,7 @@ $ {
         'icon-btn',
         isBadged && `icon-btn--badged`,
         input.transparent && 'icon-btn--transparent',
-        input.size === 'small' && 'icon-btn--small',
-        input.size === 'large' && 'icon-btn--large'
+        VALID_SIZES.includes(input.size) && `icon-btn--${input.size}`
     ]
     data-ebayui=true
     type=(tag === "button" && (input.type || "button"))

--- a/src/components/ebay-icon-button/index.marko
+++ b/src/components/ebay-icon-button/index.marko
@@ -30,7 +30,9 @@ $ {
         input.class,
         'icon-btn',
         isBadged && `icon-btn--badged`,
-        input.transparent && 'icon-btn--transparent'
+        input.transparent && 'icon-btn--transparent',
+        input.size === 'small' && 'icon-btn--small',
+        input.size === 'large' && 'icon-btn--large'
     ]
     data-ebayui=true
     type=(tag === "button" && (input.type || "button"))

--- a/src/components/ebay-icon-button/marko-tag.json
+++ b/src/components/ebay-icon-button/marko-tag.json
@@ -9,6 +9,9 @@
   "@transparent": "boolean",
   "@badge-number": "expression",
   "@badge-aria-label": "string",
+  "@size": {
+    "enum": ["small", "regular", "large"]
+  },
   "@autofocus": "#html-autofocus",
   "@disabled": "#html-disabled",
   "@form": "#html-form",


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
<!--- What are the changes? -->
Added the `size` attribute to `ebay-icon-button`.

## Context
<!--- Why did you make these changes, and why in this particular way? -->
- Styles do not change unless this is tested in tandem with ebay/skin#1930
- Right now `size` officially only supports "small" and "large", where `undefined` or any other string represents "default/normal". 
