### PR TITLE
feat(filter-menu-button): added support for footer attribute

### DIFF
--- a/src/components/ebay-filter-menu-button/filter-menu-button.stories.js
+++ b/src/components/ebay-filter-menu-button/filter-menu-button.stories.js
@@ -32,10 +32,6 @@ export default {
             control: { type: 'text' },
             description: 'a11y text for the button',
         },
-        footerText: {
-            control: { type: 'text' },
-            description: 'footer text for the button',
-        },
         pressed: {
             control: { type: 'boolean' },
             description: 'whether button is pressed (default is `false`)',
@@ -62,13 +58,6 @@ export default {
         item: {
             table: {
                 category: '@attribute tags',
-            },
-        },
-        a11yFooterText: {
-            control: { type: 'text' },
-            description: 'a11y text for the footer button',
-            table: {
-                category: 'when footer-text is set',
             },
         },
         formName: {
@@ -150,6 +139,12 @@ export default {
                 },
             },
         },
+        footer: {
+            name: '@footer',
+            table: {
+                category: '@attribute tags',
+            },
+        },
     },
 };
 
@@ -170,8 +165,11 @@ Standard.args = {
             renderBody: `item 3`,
         },
     ],
-    footerText: 'Apply',
-    a11yText: 'Filter Menu Button A11y Text',
+    a11yText: 'filter menu button a11y text',
+    footer: {
+        renderBody: 'Apply',
+        a11yFooterText: 'footer button a11y text',
+    },
 };
 Standard.parameters = {
     docs: {

--- a/src/components/ebay-filter-menu-button/index.marko
+++ b/src/components/ebay-filter-menu-button/index.marko
@@ -3,6 +3,7 @@ import { processHtmlAttributes } from "../../common/html-attributes"
 static var ignoredAttributes = [
     "variant",
     "text",
+    "footer",
     "footerText",
     "disabled",
     "selected",
@@ -12,6 +13,7 @@ static var ignoredAttributes = [
     "items",
     "type"
 ];
+$ var footer = input.footer || {};
 
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
@@ -49,5 +51,10 @@ static var ignoredAttributes = [
         <for|item, i| of=(input.items || [])>
             <@item ...item checked=component.isChecked(i)/>
         </for>
+        <if(input.footerText || input.footer)>
+            <@footer ...footer a11y-footer-text=(input.a11yFooterText || input.footer.a11yFooterText)>
+                <${input.footerText || input.footer.renderBody}/>
+            </@footer>
+        </if>
     </ebay-filter-menu>
 </span>

--- a/src/components/ebay-filter-menu-button/marko-tag.json
+++ b/src/components/ebay-filter-menu-button/marko-tag.json
@@ -28,5 +28,13 @@
     "@role": "never",
     "@aria-checked": "never",
     "@for": "never"
+  },
+  "@footer <footer>": {
+    "attribute-groups": ["html-attributes"],
+    "@*": {
+      "targetProperty": null,
+      "type": "expression"
+    },
+    "@html-attributes": "expression"
   }
 }

--- a/src/components/ebay-filter-menu-button/test/__snapshots__/renders-basic-version.expected.html
+++ b/src/components/ebay-filter-menu-button/test/__snapshots__/renders-basic-version.expected.html
@@ -5,7 +5,7 @@
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-label[39m=[32m"Filter Menu Button A11y Text"[39m
+      [33maria-label[39m=[32m"filter menu button a11y text"[39m
       [33mclass[39m=[32m"filter-menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m
@@ -129,6 +129,7 @@
         [36m</div>[39m
       [36m</div>[39m
       [36m<button[39m
+        [33maria-label[39m=[32m"footer button a11y text"[39m
         [33mclass[39m=[32m"filter-menu-button__footer"[39m
         [33mtype[39m=[32m"button"[39m
       [36m>[39m

--- a/src/components/ebay-filter-menu-button/test/__snapshots__/renders-checked-item.expected.html
+++ b/src/components/ebay-filter-menu-button/test/__snapshots__/renders-checked-item.expected.html
@@ -5,7 +5,7 @@
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-label[39m=[32m"Filter Menu Button A11y Text"[39m
+      [33maria-label[39m=[32m"filter menu button a11y text"[39m
       [33mclass[39m=[32m"filter-menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m
@@ -129,6 +129,7 @@
         [36m</div>[39m
       [36m</div>[39m
       [36m<button[39m
+        [33maria-label[39m=[32m"footer button a11y text"[39m
         [33mclass[39m=[32m"filter-menu-button__footer"[39m
         [33mtype[39m=[32m"button"[39m
       [36m>[39m

--- a/src/components/ebay-filter-menu-button/test/__snapshots__/renders-disabled-item.expected.html
+++ b/src/components/ebay-filter-menu-button/test/__snapshots__/renders-disabled-item.expected.html
@@ -5,7 +5,7 @@
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33maria-label[39m=[32m"Filter Menu Button A11y Text"[39m
+      [33maria-label[39m=[32m"filter menu button a11y text"[39m
       [33mclass[39m=[32m"filter-menu-button__button"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m
@@ -129,6 +129,7 @@
         [36m</div>[39m
       [36m</div>[39m
       [36m<button[39m
+        [33maria-label[39m=[32m"footer button a11y text"[39m
         [33mclass[39m=[32m"filter-menu-button__footer"[39m
         [33mtype[39m=[32m"button"[39m
       [36m>[39m

--- a/src/components/ebay-filter-menu/filter-menu.stories.js
+++ b/src/components/ebay-filter-menu/filter-menu.stories.js
@@ -28,17 +28,6 @@ export default {
             control: { type: 'text' },
             description: '"" (default) / "form"',
         },
-        footerText: {
-            control: { type: 'text' },
-            description: 'a11y text for the button',
-        },
-        a11yFooterText: {
-            control: { type: 'text' },
-            description: 'a11y text for the footer button',
-            table: {
-                category: 'when footer-text is set',
-            },
-        },
         classPrefix: {
             control: { type: 'text' },
             description:
@@ -113,6 +102,12 @@ export default {
                 },
             },
         },
+        footer: {
+            name: '@footer',
+            table: {
+                category: '@attribute tags',
+            },
+        },
     },
 };
 
@@ -133,8 +128,10 @@ Standard.args = {
         },
     ],
     text: 'Button',
-    footerText: 'Apply',
-    a11yText: 'Filter Menu Button A11y Text',
+    footer: {
+        renderBody: 'Apply',
+        a11yFooterText: 'a11y text for footer button',
+    },
 };
 Standard.parameters = {
     docs: {

--- a/src/components/ebay-filter-menu/index.marko
+++ b/src/components/ebay-filter-menu/index.marko
@@ -2,6 +2,7 @@ import { processHtmlAttributes } from "../../common/html-attributes"
 
 static var ignoredAttributes = [
     "variant",
+    "footer",
     "footerText",
     "a11yFooterText",
     "class",
@@ -78,13 +79,14 @@ $ var isForm = input.variant === "form";
                 </>
             </for>
         </div>
-        <if(input.footerText)>
+        <if(input.footerText || input.footer)>
             <button
+                ...processHtmlAttributes(input.footer, ignoredAttributes)
                 type=(isForm ? "submit" : "button")
-                aria-label=input.a11yFooterText
+                aria-label=`${input.a11yFooterText || input.footer.a11yFooterText}`
                 class=`${baseClass}__footer`
                 onClick(!isForm && "handleFooterButtonClick")>
-                ${input.footerText}
+                <${input.footerText || input.footer.renderBody}/>
             </button>
         </if>
     </>

--- a/src/components/ebay-filter-menu/test/__snapshots__/renders-basic-version.expected.html
+++ b/src/components/ebay-filter-menu/test/__snapshots__/renders-basic-version.expected.html
@@ -91,6 +91,7 @@
       [36m</div>[39m
     [36m</div>[39m
     [36m<button[39m
+      [33maria-label[39m=[32m"a11y text for footer button"[39m
       [33mclass[39m=[32m"filter-menu__footer"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m

--- a/src/components/ebay-filter-menu/test/__snapshots__/renders-checked-item.expected.html
+++ b/src/components/ebay-filter-menu/test/__snapshots__/renders-checked-item.expected.html
@@ -91,6 +91,7 @@
       [36m</div>[39m
     [36m</div>[39m
     [36m<button[39m
+      [33maria-label[39m=[32m"a11y text for footer button"[39m
       [33mclass[39m=[32m"filter-menu__footer"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m

--- a/src/components/ebay-filter-menu/test/__snapshots__/renders-disabled-item.expected.html
+++ b/src/components/ebay-filter-menu/test/__snapshots__/renders-disabled-item.expected.html
@@ -91,6 +91,7 @@
       [36m</div>[39m
     [36m</div>[39m
     [36m<button[39m
+      [33maria-label[39m=[32m"a11y text for footer button"[39m
       [33mclass[39m=[32m"filter-menu__footer"[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -118,6 +118,21 @@ describe('given the menu is in the default state', () => {
         });
     });
 
+    describe('when footer attributes are passed', () => {
+        const footer = {
+            renderBody: 'Apply',
+            disabled: true,
+        };
+
+        beforeEach(async () => {
+            component = await render(Standard, { footer });
+            footerButton = component.getAllByRole('button')[0];
+        });
+        it('then footer has attribute disabled', () => {
+            expect(footerButton).has.attribute('disabled');
+        });
+    });
+
     describe('when an item is added via input from its parent and the new item is clicked', () => {
         const newItems = addRenderBodies([
             ...items,


### PR DESCRIPTION
## Description
Added support for filter-menu & filter-menu-button footer attribute to support passing html attributes to the footer button

## References
#1770 

## Screenshots

### filter-menu-button
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/6342519/200982432-589db62f-62e0-47a9-9753-7defc398b0a6.png">

### filter-menu
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/6342519/200982687-c6dcac55-fa4f-435e-871f-6f36f1602e7f.png">
