### PR TITLE
fix(filter-menu): footer text passthrough

### DIFF
--- a/src/components/ebay-filter-menu/index.marko
+++ b/src/components/ebay-filter-menu/index.marko
@@ -86,7 +86,12 @@ $ var isForm = input.variant === "form";
                 aria-label=`${input.a11yFooterText || input.footer.a11yFooterText}`
                 class=`${baseClass}__footer`
                 onClick(!isForm && "handleFooterButtonClick")>
-                <${input.footerText || input.footer.renderBody}/>
+                <if(input.footerText)>
+                    ${input.footerText}
+                </if>
+                <else>
+                    <${input.footer.renderBody}/>
+                </else>
             </button>
         </if>
     </>

--- a/src/components/ebay-filter-menu/test/__snapshots__/renders-with-footer-render-body.expected.html
+++ b/src/components/ebay-filter-menu/test/__snapshots__/renders-with-footer-render-body.expected.html
@@ -1,0 +1,101 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"filter-menu"[39m
+    [33mtext[39m=[32m"Button"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"filter-menu__items"[39m
+      [33mrole[39m=[32m"menu"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--checkbox-unchecked"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-checkbox-unchecked"[39m
+                [33mviewBox[39m=[32m"0 0 18 18"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M6.4 17H11.6C12.7366 17 13.5289 16.9992 14.1458 16.9488C14.7509 16.8994 15.0986 16.8072 15.362 16.673C15.9265 16.3854 16.3854 15.9265 16.673 15.362C16.8072 15.0986 16.8994 14.7509 16.9488 14.1458C16.9992 13.5289 17 12.7366 17 11.6V6.4C17 5.26339 16.9992 4.47108 16.9488 3.85424C16.8994 3.24907 16.8072 2.90138 16.673 2.63803C16.3854 2.07354 15.9265 1.6146 15.362 1.32698C15.0986 1.19279 14.7509 1.10062 14.1458 1.05118C13.5289 1.00078 12.7366 1 11.6 1H6.4C5.26339 1 4.47108 1.00078 3.85424 1.05118C3.24907 1.10062 2.90138 1.19279 2.63803 1.32698C2.07354 1.6146 1.6146 2.07354 1.32698 2.63803C1.19279 2.90138 1.10062 3.24907 1.05118 3.85424C1.00078 4.47108 1 5.26339 1 6.4V11.6C1 12.7366 1.00078 13.5289 1.05118 14.1458C1.10062 14.7509 1.19279 15.0986 1.32698 15.362C1.6146 15.9265 2.07354 16.3854 2.63803 16.673C2.90138 16.8072 3.24907 16.8994 3.85424 16.9488C4.47108 16.9992 5.26339 17 6.4 17ZM0.435974 15.816C0 14.9603 0 13.8402 0 11.6V6.4C0 4.15979 0 3.03969 0.435974 2.18404C0.819467 1.43139 1.43139 0.819467 2.18404 0.435974C3.03969 0 4.15979 0 6.4 0H11.6C13.8402 0 14.9603 0 15.816 0.435974C16.5686 0.819467 17.1805 1.43139 17.564 2.18404C18 3.03969 18 4.15979 18 6.4V11.6C18 13.8402 18 14.9603 17.564 15.816C17.1805 16.5686 16.5686 17.1805 15.816 17.564C14.9603 18 13.8402 18 11.6 18H6.4C4.15979 18 3.03969 18 2.18404 17.564C1.43139 17.1805 0.819467 16.5686 0.435974 15.816Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-checkbox-unchecked"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 1[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--checkbox-unchecked"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-checkbox-unchecked"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 2[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--checkbox-unchecked"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-checkbox-unchecked"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 3[0m
+        [36m</span>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<button[39m
+      [33maria-label[39m=[32m"a11y text"[39m
+      [33mclass[39m=[32m"filter-menu__footer"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [0mtest text[0m
+    [36m</button>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-filter-menu/test/__snapshots__/renders-with-footer-text.expected.html
+++ b/src/components/ebay-filter-menu/test/__snapshots__/renders-with-footer-text.expected.html
@@ -1,0 +1,101 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"filter-menu"[39m
+    [33mtext[39m=[32m"Button"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"filter-menu__items"[39m
+      [33mrole[39m=[32m"menu"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--checkbox-unchecked"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-checkbox-unchecked"[39m
+                [33mviewBox[39m=[32m"0 0 18 18"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M6.4 17H11.6C12.7366 17 13.5289 16.9992 14.1458 16.9488C14.7509 16.8994 15.0986 16.8072 15.362 16.673C15.9265 16.3854 16.3854 15.9265 16.673 15.362C16.8072 15.0986 16.8994 14.7509 16.9488 14.1458C16.9992 13.5289 17 12.7366 17 11.6V6.4C17 5.26339 16.9992 4.47108 16.9488 3.85424C16.8994 3.24907 16.8072 2.90138 16.673 2.63803C16.3854 2.07354 15.9265 1.6146 15.362 1.32698C15.0986 1.19279 14.7509 1.10062 14.1458 1.05118C13.5289 1.00078 12.7366 1 11.6 1H6.4C5.26339 1 4.47108 1.00078 3.85424 1.05118C3.24907 1.10062 2.90138 1.19279 2.63803 1.32698C2.07354 1.6146 1.6146 2.07354 1.32698 2.63803C1.19279 2.90138 1.10062 3.24907 1.05118 3.85424C1.00078 4.47108 1 5.26339 1 6.4V11.6C1 12.7366 1.00078 13.5289 1.05118 14.1458C1.10062 14.7509 1.19279 15.0986 1.32698 15.362C1.6146 15.9265 2.07354 16.3854 2.63803 16.673C2.90138 16.8072 3.24907 16.8994 3.85424 16.9488C4.47108 16.9992 5.26339 17 6.4 17ZM0.435974 15.816C0 14.9603 0 13.8402 0 11.6V6.4C0 4.15979 0 3.03969 0.435974 2.18404C0.819467 1.43139 1.43139 0.819467 2.18404 0.435974C3.03969 0 4.15979 0 6.4 0H11.6C13.8402 0 14.9603 0 15.816 0.435974C16.5686 0.819467 17.1805 1.43139 17.564 2.18404C18 3.03969 18 4.15979 18 6.4V11.6C18 13.8402 18 14.9603 17.564 15.816C17.1805 16.5686 16.5686 17.1805 15.816 17.564C14.9603 18 13.8402 18 11.6 18H6.4C4.15979 18 3.03969 18 2.18404 17.564C1.43139 17.1805 0.819467 16.5686 0.435974 15.816Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-checkbox-unchecked"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 1[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--checkbox-unchecked"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-checkbox-unchecked"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 2[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--checkbox-unchecked"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-checkbox-unchecked"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 3[0m
+        [36m</span>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<button[39m
+      [33maria-label[39m=[32m"a11y text for footer button"[39m
+      [33mclass[39m=[32m"filter-menu__footer"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [0mtest text[0m
+    [36m</button>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-filter-menu/test/test.server.js
+++ b/src/components/ebay-filter-menu/test/test.server.js
@@ -2,6 +2,7 @@ import { composeStories } from '@storybook/marko/dist/testing';
 import { snapshotHTML } from '../../../common/test-utils/snapshots';
 import * as stories from '../filter-menu.stories';
 import { testPassThroughAttributes } from '../../../common/test-utils/server';
+import { createRenderBody } from '../../../common/test-utils/shared';
 
 const { Standard } = composeStories(stories);
 
@@ -21,6 +22,19 @@ describe('filter-menu', () => {
     it(`renders disabled item`, async () => {
         items[1] = Object.assign({ disabled: true }, items[1]);
         await htmlSnap(Standard);
+    });
+
+    it(`renders with footer text`, async () => {
+        await htmlSnap(Standard, { footerText: 'test text' });
+    });
+
+    it(`renders with footer render body`, async () => {
+        await htmlSnap(Standard, {
+            footer: {
+                renderBody: createRenderBody('test text'),
+                a11yFooterText: 'a11y text',
+            },
+        });
     });
 
     testPassThroughAttributes(Standard);


### PR DESCRIPTION
## Description
* We were passing footer text as a render body element, but it has no render body. We want to pass it directly. Changed it to pass it as a string
* Added tests to catch this case.

## References
https://github.com/eBay/ebayui-core/issues/1824