### PR TITLE
fix(fake-menu-button) separator takes up a position

### DIFF
--- a/src/components/ebay-fake-menu/component.js
+++ b/src/components/ebay-fake-menu/component.js
@@ -20,4 +20,8 @@ export default {
 
         this.emit(`${eventType}`, eventObj);
     },
+
+    onInput(input) {
+        this.items = (input.items || []).filter((item) => !item.separator);
+    },
 };

--- a/src/components/ebay-fake-menu/index.marko
+++ b/src/components/ebay-fake-menu/index.marko
@@ -24,6 +24,14 @@ static {
 }
 
 $ var baseClass = input.classPrefix || "fake-menu";
+$ var separatorCount = 0;
+$ var seperatorMap = (input.items || []).reduce((map, item, index) => {
+    if(item.separator) {
+        map[index - separatorCount] = true;
+        separatorCount++;
+    }
+    return map;
+}, {});
 <span
     ...processHtmlAttributes(input, ignoredAttributes)
     class=[
@@ -40,40 +48,38 @@ $ var baseClass = input.classPrefix || "fake-menu";
         key="menu"
         tabindex="-1"
         id:scoped="menu">
-        <for|item, index| of=(input.items || [])>
+        <for|item, index| of=(component.items)>
             $ var isDisabled = !item.href || item.disabled;
             $ var defaultAriaCurrent = item.itemMatchesUrl === false ? 'true' : 'page';
-            <if (item.separator)>
+            <if (seperatorMap[index])>
                 <li>
                     <hr class=`${baseClass}__separator` role="separator" />
                 </li>
             </if>
-            <else>
-                <li>
-                    $ var isButton = item.type === "button" || item.type ==="submit";
-                    <${isButton ? "button" : "a"}
-                        ...processHtmlAttributes(item, itemIgnoredAttributes)
-                        class=[`${baseClass}__item`, item.class]
-                        style=item.style
-                        disabled=(isButton && item.disabled)
-                        aria-disabled=(!isButton && item.disabled && 'true')
-                        aria-current=(item.current ? defaultAriaCurrent : false)
-                        href=(item.disabled ? null : item.href)
-                        type=(isButton && item.type)
-                        onKeydown(!item.disabled && "handleItemKeydown", index)
-                        onClick(!item.disabled && "handleItemClick", index)
-                        key="item[]">
-                        <span>
-                            <${item.renderBody}/>
-                        </span>
-                        <if(item.badgeNumber)>
-                            <ebay-badge type="menu" number=item.badgeNumber/>
-                        </if>
+            <li>
+                $ var isButton = item.type === "button" || item.type ==="submit";
+                <${isButton ? "button" : "a"}
+                    ...processHtmlAttributes(item, itemIgnoredAttributes)
+                    class=[`${baseClass}__item`, item.class]
+                    style=item.style
+                    disabled=(isButton && item.disabled)
+                    aria-disabled=(!isButton && item.disabled && 'true')
+                    aria-current=(item.current ? defaultAriaCurrent : false)
+                    href=(item.disabled ? null : item.href)
+                    type=(isButton && item.type)
+                    onKeydown(!item.disabled && "handleItemKeydown", index)
+                    onClick(!item.disabled && "handleItemClick", index)
+                    key="item[]">
+                    <span>
+                        <${item.renderBody}/>
+                    </span>
+                    <if(item.badgeNumber)>
+                        <ebay-badge type="menu" number=item.badgeNumber/>
+                    </if>
 
-                        <ebay-tick-small-icon />
-                    </>
-                </li>
-            </else>
+                    <ebay-tick-small-icon />
+                </>
+            </li>
         </for>
     </ul>
 </span>

--- a/src/components/ebay-fake-menu/test/test.browser.js
+++ b/src/components/ebay-fake-menu/test/test.browser.js
@@ -46,3 +46,33 @@ describe('given the menu is in the default state', () => {
         });
     });
 });
+
+describe('given the menu has checkbox items with separator', () => {
+    const input = Object.assign({ type: 'checkbox' }, mock.separator4Items);
+
+    const firstItemText = input.items[0].renderBody.text;
+    const secondItemText = input.items[1].renderBody.text;
+    const thirdItemText = input.items[3].renderBody.text;
+
+    beforeEach(async () => {
+        component = await render(template, input);
+    });
+
+    describe('when all items are clicked', () => {
+        beforeEach(async () => {
+            await fireEvent.click(component.getByText(firstItemText));
+            await fireEvent.click(component.getByText(secondItemText));
+            await fireEvent.click(component.getByText(thirdItemText));
+        });
+
+        it('then it emits three select events with correct data', () => {
+            const selectEvents = component.emitted('select');
+            expect(selectEvents).to.have.length(3);
+
+            const [[eventArg0], [eventArg1], [eventArg2]] = selectEvents;
+            expect(eventArg0.index).to.deep.equal(0);
+            expect(eventArg1.index).to.deep.equal(1);
+            expect(eventArg2.index).to.deep.equal(2);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
To match indexes, passed filtered menu items excluding separators. Inserted separators at respective locations.

## References
#1829 

## Screenshots
Menu items were selected from first item to last and we can see events fired with the right indexes.

<img width="963" alt="image" src="https://user-images.githubusercontent.com/6342519/206062984-7b4db057-c0ad-4777-bacd-711270884c7a.png">
