### PR TITLE
tips add support for heading elements

### DIFF
--- a/src/components/components/ebay-tooltip-overlay/index.marko
+++ b/src/components/components/ebay-tooltip-overlay/index.marko
@@ -4,6 +4,7 @@ import constants from "./constants";
 static function noop() {}
 static var typeRoles = constants.typeRoles;
 static var pointerStyles = constants.pointerStyles;
+static var ignoredHeaderAttributes = ["id", "as", "class"];
 
 $ input.toJSON = noop;
 
@@ -19,6 +20,7 @@ $ var overlayStyles = hasUserStyles ? {
     right: input.styleRight,
     bottom: input.styleBottom
 } : pointerStyles[input.pointer || "bottom"];
+$ var heading = input.heading;
 
 <span
     id=input.id
@@ -26,7 +28,7 @@ $ var overlayStyles = hasUserStyles ? {
     role=typeRoles[input.type]
     aria-labelledby=(
         input.type === "tourtip" &&
-        input.heading &&
+        heading &&
         component.elId("tourtip-label")
     )
     style=overlayStyles>
@@ -34,13 +36,13 @@ $ var overlayStyles = hasUserStyles ? {
     <span class=`${input.type}__mask`>
         <span class=`${input.type}__cell`>
             <span class=`${input.type}__content`>
-                <if(input.heading)>
-                    <span
-                        ...processHtmlAttributes(input.heading)
+                <if(heading)>
+                    <${heading.as || "span"}
+                        ...processHtmlAttributes(heading, ignoredHeaderAttributes)
                         class=[`${input.type}__heading`, input.heading.class]
                         id:scoped="tourtip-label">
-                        <${input.heading.renderBody}/>
-                    </span>
+                        <${heading.renderBody}/>
+                    </>
                 </if>
                 <if(input.content)>
                     <${Object.keys(input.content).length > 1 && "span"}

--- a/src/components/ebay-tourtip/test/__snapshots__/renders-default-tourtip.expected.html
+++ b/src/components/ebay-tourtip/test/__snapshots__/renders-default-tourtip.expected.html
@@ -35,12 +35,12 @@
               [36m<span[39m
                 [33mclass[39m=[32m"tourtip__content"[39m
               [36m>[39m
-                [36m<span[39m
+                [36m<h2[39m
                   [33mclass[39m=[32m"tourtip__heading"[39m
                   [33mid[39m=[32m"s0-@base-0-4-tourtip-label"[39m
                 [36m>[39m
                   [0mImportant[0m
-                [36m</span>[39m
+                [36m</h2>[39m
                 [36m<p>[39m
                   [0mThis new feature was added.[0m
                 [36m</p>[39m

--- a/src/components/ebay-tourtip/test/__snapshots__/renders-tourtip-closed.expected.html
+++ b/src/components/ebay-tourtip/test/__snapshots__/renders-tourtip-closed.expected.html
@@ -35,12 +35,12 @@
               [36m<span[39m
                 [33mclass[39m=[32m"tourtip__content"[39m
               [36m>[39m
-                [36m<span[39m
+                [36m<h2[39m
                   [33mclass[39m=[32m"tourtip__heading"[39m
                   [33mid[39m=[32m"s0-@base-0-4-tourtip-label"[39m
                 [36m>[39m
                   [0mImportant[0m
-                [36m</span>[39m
+                [36m</h2>[39m
                 [36m<p>[39m
                   [0mThis new feature was added.[0m
                 [36m</p>[39m

--- a/src/components/ebay-tourtip/test/test.browser.js
+++ b/src/components/ebay-tourtip/test/test.browser.js
@@ -27,6 +27,7 @@ describe('given the default tourtip', () => {
 
         thenItIsOpen();
         thenItCanBeClosed();
+        thenIthasHeading();
     });
 
     function thenItIsOpen() {
@@ -48,6 +49,12 @@ describe('given the default tourtip', () => {
             it('then it is closed', () => {
                 expect(component.queryByRole('region')).to.equal(null);
             });
+        });
+    }
+
+    function thenIthasHeading() {
+        it('then it has the right heading', () => {
+            expect(component.getByText('Important').tagName).equal('H2');
         });
     }
 });

--- a/src/components/ebay-tourtip/tourtip.stories.js
+++ b/src/components/ebay-tourtip/tourtip.stories.js
@@ -114,6 +114,7 @@ Standard.args = {
     },
     heading: {
         renderBody: 'Important',
+        as: 'h2',
     },
     content: {
         renderBody: `<p>This new feature was added.</p>`,


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
Provided the ability to pass `as` attribute to heading tag to choose the right heading when needed. Default fallback is set to `span` to avoid breaking changes.

This change affects ebay-tourtip, ebay-infotip and ebay-tooltip.

## Context
#1837 

## Screenshots
<!-- Upload screenshots if appropriate. -->
<img width="858" alt="image" src="https://user-images.githubusercontent.com/6342519/210677036-178c8c20-28db-44a2-b68e-a7525dca5a96.png">

