### PR TITLE
feat: added common cdn loader, and set highcharts to load from cdn

### DIFF
--- a/scripts/generate-cdn.js
+++ b/scripts/generate-cdn.js
@@ -10,24 +10,36 @@ import rimraf from 'rimraf';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.join(__dirname, '..');
+const versionPath = 'src/common/cdn/versions.json';
 
-function update3dPlayerJSONFile(version) {
-    const versionFile = path.join(rootDir, 'src/components/ebay-3d-viewer/versions.json');
-    const threedVersions = {
-        '//': 'This is a generated file. Run script file to update',
-        modelViewer: version,
-    };
-    const newVersion = JSON.stringify(threedVersions);
-    fs.writeFileSync(versionFile, newVersion);
-}
+const cdnConfig = {
+    shaka: {
+        versionCommand:
+            "npm list shaka-player --depth 1 | grep shaka-player | awk -F @ '{ print  $2 }'",
+        generator: shakaGenerator,
+    },
+    highcharts: {
+        versionCommand:
+            "npm list highcharts --depth 1 | grep highcharts | awk -F @ '{ print  $2 }'",
+        generator: highchartsGenerator,
+    },
+    modelViewer: {
+        versionCommand:
+            "npm list @google/model-viewer --depth 1 | grep google/model-viewer | awk -F @ '{ print  $3 }'",
+        generator: threeDPlayerGenerator,
+    },
+};
 
-function updateVideoJSONFile(version) {
-    const versionFile = path.join(rootDir, 'src/components/ebay-video/versions.json');
-    const videoVersions = {
-        '//': 'This is a generated file. Run script file to update',
-        shaka: version,
-    };
-    const newVersion = JSON.stringify(videoVersions);
+function updateVersionFile(version) {
+    const versionFile = path.join(rootDir, versionPath);
+    const versionObject = Object.assign(
+        {},
+        {
+            '//': 'This is a generated file. Run generateCDN script file to update',
+        },
+        version
+    );
+    const newVersion = JSON.stringify(versionObject);
     fs.writeFileSync(versionFile, newVersion);
 }
 
@@ -53,36 +65,58 @@ function download(url, dir, fileName) {
     });
 }
 
+async function shakaGenerator({ version, cdnVersionPath }) {
+    await download(getShakaUrl(version), cdnVersionPath, 'shaka-player.ui.js');
+    await download(getShakaCSSUrl(version), cdnVersionPath, 'controls.css');
+    // Remove define
+    execSync(
+        `sed -i '' -e 's/typeof define=="function"/typeof define=="w"/' ${cdnVersionPath}/shaka-player.ui.js`
+    );
+}
+
+async function threeDPlayerGenerator({ cdnVersionPath }) {
+    await fs.promises.cp(
+        `${rootDir}/node_modules/@google/model-viewer/dist/model-viewer.min.js`,
+        `${cdnVersionPath}/model-viewer.min.js`
+    );
+}
+
+async function highchartsGenerator({ cdnVersionPath }) {
+    await fs.promises.cp(
+        `${rootDir}/node_modules/highcharts/highcharts.js`,
+        `${cdnVersionPath}/highcharts.js`
+    );
+    await fs.promises.cp(
+        `${rootDir}/node_modules/highcharts/modules/accessibility.js`,
+        `${cdnVersionPath}/accessibility.js`
+    );
+    await fs.promises.cp(
+        `${rootDir}/node_modules/highcharts/modules/pattern-fill.js`,
+        `${cdnVersionPath}/pattern-fill.js`
+    );
+}
+
 async function run() {
-    const version = execSync(
-        "npm list shaka-player --depth 1 | grep shaka-player | awk -F @ '{ print  $2 }'",
-        { encoding: 'utf8' }
-    ).trim();
-    const threeDVersion = execSync(
-        "npm list @google/model-viewer --depth 1 | grep google/model-viewer | awk -F @ '{ print  $3 }'",
-        { encoding: 'utf8' }
-    ).trim();
+    const versionObject = {};
 
     const cdnDir = path.join(rootDir, '_cdn', 'ebayui');
-    const playerPath = path.join(cdnDir, 'shaka', `v${version}`);
-    const threeDPlayerPath = path.join(cdnDir, 'google-model-viewer', `v${threeDVersion}`);
 
     try {
         rimraf.sync(cdnDir);
-        updateVideoJSONFile(version);
-        await fs.promises.mkdir(playerPath, { recursive: true });
-        await download(getShakaUrl(version), playerPath, 'shaka-player.ui.js');
-        await download(getShakaCSSUrl(version), playerPath, 'controls.css');
-        // Remove define
-        execSync(
-            `sed -i '' -e 's/typeof define=="function"/typeof define=="w"/' ${playerPath}/shaka-player.ui.js`
-        );
-        update3dPlayerJSONFile(threeDVersion);
-        await fs.promises.mkdir(threeDPlayerPath, { recursive: true });
-        await fs.promises.cp(
-            `${rootDir}/node_modules/@google/model-viewer/dist/model-viewer.min.js`,
-            `${threeDPlayerPath}/model-viewer.min.js`
-        );
+        for (const key of Object.keys(cdnConfig)) {
+            const { versionCommand, generator } = cdnConfig[key];
+
+            const version = execSync(versionCommand, { encoding: 'utf8' }).trim();
+
+            versionObject[key] = version;
+
+            const cdnVersionPath = path.join(cdnDir, key, `v${version}`);
+
+            await fs.promises.mkdir(cdnVersionPath, { recursive: true });
+
+            await generator({ cdnVersionPath, version });
+        }
+        updateVersionFile(versionObject);
     } catch (e) {
         console.error(e);
     }

--- a/src/common/cdn/index.js
+++ b/src/common/cdn/index.js
@@ -10,7 +10,7 @@ const MAX_RETRIES = 3;
  * function setLoaded(boolean) : sets the is loaded state
  * function handleSuccess() : when cdn is succsssfully loaded
  * function handleError(err) : when the cdn loading fails
- * boolean stagger :  (optional) if all promoses should be staggered or executed in any order
+ * boolean stagger :  (optional) if all promises should be staggered or executed in any order
  */
 export class CDNLoader {
     constructor(self, { key, files, types, setLoading, handleSuccess, handleError, stagger }) {
@@ -56,7 +56,7 @@ export class CDNLoader {
         }
     }
 
-    loadCDN(immediate) {
+    loadCDN() {
         const _timeout =
             window.requestIdleCallback ||
             function (handler, arg) {
@@ -75,13 +75,8 @@ export class CDNLoader {
         this.setLoading(false);
 
         _cancel(this.loadDelay);
-        if (!immediate) {
-            this.setLoading(false);
-            this.loadDelay = _timeout(() => this._loadCDN(), { timeout: 100 });
-        } else {
-            this.setLoading(true);
-            this._loadCDN();
-        }
+        this.setLoading(true);
+        this.loadDelay = _timeout(() => this._loadCDN(), { timeout: 100 });
     }
 
     _catchError(err) {

--- a/src/common/cdn/index.js
+++ b/src/common/cdn/index.js
@@ -1,0 +1,108 @@
+import { loader } from '../loader';
+import versions from './versions.json';
+const MAX_RETRIES = 3;
+
+/**
+ * @config object with the following (all are required)
+ * string key : the key to lookup both in versions and CDN url
+ * [] files : The files to lookup in the CDN
+ * [] types :  The Types of files for CDN loader (see common/loader)
+ * function setLoaded(boolean) : sets the is loaded state
+ * function handleSuccess() : when cdn is succsssfully loaded
+ * function handleError(err) : when the cdn loading fails
+ * boolean stagger :  (optional) if all promoses should be staggered or executed in any order
+ */
+export class CDNLoader {
+    constructor(self, { key, files, types, setLoading, handleSuccess, handleError, stagger }) {
+        this.self = self;
+        this.retryTimes = 0;
+        this.setLoading = setLoading;
+        this.handleError = handleError;
+        this.handleSuccess = handleSuccess;
+        this.files = files;
+        this.types = types;
+        this.key = key;
+        this.stagger = stagger;
+        this._setFiles();
+    }
+
+    setOverrides(overrides, version) {
+        this._setFiles(overrides, version);
+
+        return this;
+    }
+
+    _setFiles(overrides, version) {
+        this.cdnFiles = [];
+        this.url = `https://ir.ebaystatic.com/cr/v/c1/ebayui/${this.key}/v${
+            version || versions[this.key]
+        }`;
+        for (let i = 0; i < this.files.length; i++) {
+            if (overrides && overrides[i]) {
+                this.cdnFiles[i] = overrides[i];
+            } else {
+                this.cdnFiles[i] = `${this.url}/${this.files[i]}`;
+            }
+        }
+    }
+
+    mount() {
+        this.isLoaded = false;
+
+        if (document.readyState === 'complete') {
+            this.loadCDN();
+        } else {
+            this.self.subscribeTo(window).once('load', this.loadCDN.bind(this));
+        }
+    }
+
+    loadCDN(immediate) {
+        const _timeout =
+            window.requestIdleCallback ||
+            function (handler, arg) {
+                return setTimeout(() => {
+                    handler();
+                }, arg.timeout);
+            };
+
+        const _cancel =
+            window.cancelIdleCallback ||
+            function (id) {
+                clearTimeout(id);
+            };
+
+        this.retryTimes = 0;
+        this.setLoading(false);
+
+        _cancel(this.loadDelay);
+        if (!immediate) {
+            this.setLoading(false);
+            this.loadDelay = _timeout(() => this._loadCDN(), { timeout: 100 });
+        } else {
+            this.setLoading(true);
+            this._loadCDN();
+        }
+    }
+
+    _catchError(err) {
+        clearTimeout(this.retryTimeout);
+        this.retryTimes += 1;
+        if (this.retryTimes < MAX_RETRIES) {
+            this.retryTimeout = setTimeout(() => this._loadCDN(), 2000);
+        } else {
+            this.setLoading(false);
+            this.handleError(err);
+        }
+    }
+
+    _loadCDN() {
+        loader(this.cdnFiles, this.types, this.stagger)
+            .then(() => {
+                this.setLoading(false);
+                this.handleSuccess();
+            })
+            .catch((err) => {
+                this._catchError(err);
+            });
+    }
+}

--- a/src/common/cdn/test/test.browser.js
+++ b/src/common/cdn/test/test.browser.js
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import { waitFor } from '@marko/testing-library';
+import sinon from 'sinon';
+import { CDNLoader } from '..';
+import * as load from '../../loader';
+
+describe('CDN Loader', () => {
+    it('Properly loads files from CDN', async () => {
+        sinon.stub(load, 'loader').returns(Promise.resolve());
+        const setLoading = sinon.spy();
+        const handleSuccess = sinon.spy();
+        const handleError = sinon.spy();
+
+        const cdnLoader = new CDNLoader(
+            {
+                subscribeTo: sinon.spy(),
+            },
+            {
+                key: 'key',
+                files: ['files'],
+                types: ['src'],
+                setLoading,
+                handleSuccess,
+                handleError,
+            }
+        );
+
+        cdnLoader.mount();
+
+        await waitFor(() => {
+            expect(load.loader.called).to.equal(true, 'loader called');
+            expect(handleError.called).to.equal(false, 'error called');
+            expect(handleSuccess.called).to.equal(true, 'success called');
+            expect(setLoading.calledWith(false)).to.equal(true);
+            load.loader.restore();
+        });
+    });
+
+    it('Properly fails', async () => {
+        sinon.stub(load, 'loader').returns(Promise.reject());
+        const setLoading = sinon.spy();
+        const handleSuccess = sinon.spy();
+        const handleError = sinon.spy();
+
+        const cdnLoader = new CDNLoader(
+            {
+                subscribeTo: sinon.spy(),
+            },
+            {
+                key: 'key',
+                files: ['files'],
+                types: ['src'],
+                setLoading,
+                handleSuccess,
+                handleError,
+            }
+        );
+
+        cdnLoader.mount();
+
+        await waitFor(
+            () => {
+                expect(load.loader.called).to.equal(true, 'loader called');
+                expect(handleError.called).to.equal(true, 'error called');
+                expect(handleSuccess.called).to.equal(false, 'success called');
+                expect(setLoading.calledWith(false)).to.equal(true);
+                load.loader.restore();
+            },
+            { timeout: 6000 }
+        );
+    });
+});

--- a/src/common/cdn/versions.json
+++ b/src/common/cdn/versions.json
@@ -1,0 +1,6 @@
+{
+  "//": "This is a generated file. Run generateCDN script file to update",
+  "shaka": "4.3.2",
+  "highcharts": "10.2.1",
+  "modelViewer": "2.1.1"
+}

--- a/src/components/ebay-3d-viewer/index.marko
+++ b/src/components/ebay-3d-viewer/index.marko
@@ -31,10 +31,7 @@ static {
             <else>An error has occurred</else>
         </div>
     </div>
-    <div
-        class=['three-d-player__overlay', state.isLoaded && 'three-d-player__overlay--hidden']
-        on-click('loadCDN', true)
-    >
+    <div class=['three-d-player__overlay', state.isLoaded && 'three-d-player__overlay--hidden']>
         <if(!state.showLoading)>
             <ebay-video-play-icon a11y-text=input.a11yStartText || 'Click to start'/>
         </if>

--- a/src/components/ebay-3d-viewer/versions.json
+++ b/src/components/ebay-3d-viewer/versions.json
@@ -1,1 +1,0 @@
-{ "//": "This is a generated file. Run script file to update", "modelViewer": "2.1.1" }

--- a/src/components/ebay-line-chart/line-chart.stories.js
+++ b/src/components/ebay-line-chart/line-chart.stories.js
@@ -76,6 +76,18 @@ export default {
             type: { name: 'string', require: false },
             description: 'A class name that will be added to the main chart container',
         },
+        cdnHighcharts: {
+            type: { name: 'string', require: false },
+            description: 'CDN url override for loading highcharts',
+        },
+        cdnHighchartsAccessibility: {
+            type: { name: 'string', require: false },
+            description: 'CDN url override for loading highcharts accessibility module',
+        },
+        version: {
+            type: { name: 'string', require: false },
+            description: 'Highcharts version to load from CDN',
+        },
     },
 };
 

--- a/src/components/ebay-video/index.marko
+++ b/src/components/ebay-video/index.marko
@@ -58,7 +58,7 @@ static var ignoredAttributes = [
             "video-player__overlay",
             state.isLoaded && "video-player__overlay--hidden"
         ]
-        on-click("loadCDN", true)>
+        on-click("loadVideo", true)>
         <if(!state.showLoading)>
             <ebay-video-play-icon a11y-text=(input.a11yPlayText || "Click to play")/>
         </if>

--- a/src/components/ebay-video/versions.json
+++ b/src/components/ebay-video/versions.json
@@ -1,1 +1,0 @@
-{ "//": "This is a generated file. Run script file to update", "shaka": "4.3.2" }


### PR DESCRIPTION
fixes https://github.com/eBay/ebayui-core/issues/1835

## Description
Since highcharts is the third component to use CDN loading of scripts, I decided to take some time and refactor the CDN code to be more generic. (Also good as part of tech debt)

## Context
* Updated the generate CDN script to take a simple config object to generate the cdn files, and version.json file. There is only 1 version.json in the `common/cdn` directory
* Added a `common/cdn` file, which has a class that does all the cdn loading. 
* Added some tests for this

## Note
For high charts, the accessibility and pattern-fill modules required highcharts to be loaded. There was an issue if we would load all the scripts async, then there could be a race condition to cause the accessibility module to fail loading. I added a stagger option, so that it will not load another module, until the previous one is loaded. This could be improved to only wait for the high charts module, and then all others to load at the same time... however pattern-fill is used for other modules which we are not going to officially include. So I left it as is for now, and we can revisit when needed. 