### PR TITLE
fix(ebay-infotip): removed double events from infotip

### DIFF
--- a/src/components/ebay-infotip/component.js
+++ b/src/components/ebay-infotip/component.js
@@ -11,6 +11,10 @@ export default {
         }
     },
 
+    handleOpenModal() {
+        this.setOpen(true);
+    },
+
     handleExpand() {
         this.setOpen(true);
         this.emit('expand');

--- a/src/components/ebay-infotip/index.marko
+++ b/src/components/ebay-infotip/index.marko
@@ -41,7 +41,7 @@ $ var pointer = input.pointer || "bottom";
                 key="host"
                 class=[`${classPrefix}__host`, "icon-btn", "icon-btn--transparent"]
                 type="button"
-                on-click(isModal && "handleExpand")
+                on-click(isModal && "handleOpenModal")
                 disabled=input.disabled
                 aria-label=input.ariaLabel>
                 <if(input.icon)>


### PR DESCRIPTION
## Description
There was a problem with infotip calling expand twice. This is because the `on-click` method of the button was calling onExpand, but also the `drawer-dialog` `on-open` event was triggering the same `onExpand` method. I changed it so the `on-click` calls an open dialog method which just opens the dialog. The other event stays the same. This will make it so if it's programmatically called, it will still trigger properly. 

## References
https://github.com/eBay/ebayui-core/issues/1845
