### PR TITLE
fix(line-chart): typo in onInput

### DIFF
--- a/src/components/ebay-line-chart/component.js
+++ b/src/components/ebay-line-chart/component.js
@@ -57,7 +57,7 @@ export default class {
         // if chartRef does not exist do not try to run setupCharts as it may be server side and highcharts only works on the client side
         if (this.chartRef && this.chartRef.destroy) {
             this.chartRef.destroy();
-            this._setupCharts();
+            this._setupChart();
         }
     }
     getContainerId() {


### PR DESCRIPTION

## Description
Typo in `onInput`, changed it to be the correct method name

## References
https://github.com/eBay/ebayui-core/issues/1860

