### PR TITLE
fix(combobox): a11y errors when disabled 

### DIFF
--- a/src/components/ebay-combobox/index.marko
+++ b/src/components/ebay-combobox/index.marko
@@ -69,6 +69,7 @@ $ var id = input.id || component.getElId('input');
             aria-roledescription=roledescription
             aria-haspopup='listbox'
             autocomplete='off'
+            aria-expanded='false'
             onBlur('handleComboboxBlur')
             onClick('handleComboboxClick')
             onFocus('handleFocus')

--- a/src/components/ebay-combobox/test/__snapshots__/renders-basic-version.expected.html
+++ b/src/components/ebay-combobox/test/__snapshots__/renders-basic-version.expected.html
@@ -7,6 +7,7 @@
     [36m>[39m
       [36m<input[39m
         [33maria-autocomplete[39m=[32m"list"[39m
+        [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"listbox"[39m
         [33maria-roledescription[39m=[32m"Use up and down arrow keys to navigate options. Options change based on text input"[39m
         [33mautocomplete[39m=[32m"off"[39m

--- a/src/components/ebay-combobox/test/__snapshots__/renders-empty.expected.html
+++ b/src/components/ebay-combobox/test/__snapshots__/renders-empty.expected.html
@@ -7,6 +7,7 @@
     [36m>[39m
       [36m<input[39m
         [33maria-autocomplete[39m=[32m"list"[39m
+        [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"listbox"[39m
         [33maria-roledescription[39m=[32m"Use up and down arrow keys to navigate options. Options change based on text input"[39m
         [33mautocomplete[39m=[32m"off"[39m

--- a/src/components/ebay-combobox/test/__snapshots__/renders-with-actionable-button.expected.html
+++ b/src/components/ebay-combobox/test/__snapshots__/renders-with-actionable-button.expected.html
@@ -7,6 +7,7 @@
     [36m>[39m
       [36m<input[39m
         [33maria-autocomplete[39m=[32m"list"[39m
+        [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"listbox"[39m
         [33maria-roledescription[39m=[32m"Use up and down arrow keys to navigate options. Options change based on text input"[39m
         [33mautocomplete[39m=[32m"off"[39m

--- a/src/components/ebay-combobox/test/__snapshots__/renders-with-borderless-enabled.expected.html
+++ b/src/components/ebay-combobox/test/__snapshots__/renders-with-borderless-enabled.expected.html
@@ -7,6 +7,7 @@
     [36m>[39m
       [36m<input[39m
         [33maria-autocomplete[39m=[32m"list"[39m
+        [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"listbox"[39m
         [33maria-roledescription[39m=[32m"Use up and down arrow keys to navigate options. Options change based on text input"[39m
         [33mautocomplete[39m=[32m"off"[39m

--- a/src/components/ebay-combobox/test/__snapshots__/renders-with-default-actionable-button.expected.html
+++ b/src/components/ebay-combobox/test/__snapshots__/renders-with-default-actionable-button.expected.html
@@ -7,6 +7,7 @@
     [36m>[39m
       [36m<input[39m
         [33maria-autocomplete[39m=[32m"list"[39m
+        [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"listbox"[39m
         [33maria-roledescription[39m=[32m"Use up and down arrow keys to navigate options. Options change based on text input"[39m
         [33mautocomplete[39m=[32m"off"[39m

--- a/src/components/ebay-combobox/test/__snapshots__/renders-with-floating-label.expected.html
+++ b/src/components/ebay-combobox/test/__snapshots__/renders-with-floating-label.expected.html
@@ -13,6 +13,7 @@
     [36m>[39m
       [36m<input[39m
         [33maria-autocomplete[39m=[32m"list"[39m
+        [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"listbox"[39m
         [33maria-roledescription[39m=[32m"Use up and down arrow keys to navigate options. Options change based on text input"[39m
         [33mautocomplete[39m=[32m"off"[39m

--- a/src/components/ebay-combobox/test/__snapshots__/renders-with-second-item-selected.expected.html
+++ b/src/components/ebay-combobox/test/__snapshots__/renders-with-second-item-selected.expected.html
@@ -7,6 +7,7 @@
     [36m>[39m
       [36m<input[39m
         [33maria-autocomplete[39m=[32m"list"[39m
+        [33maria-expanded[39m=[32m"false"[39m
         [33maria-haspopup[39m=[32m"listbox"[39m
         [33maria-roledescription[39m=[32m"Use up and down arrow keys to navigate options. Options change based on text input"[39m
         [33mautocomplete[39m=[32m"off"[39m

--- a/src/components/ebay-combobox/test/test.browser.js
+++ b/src/components/ebay-combobox/test/test.browser.js
@@ -378,7 +378,7 @@ describe('given the combobox starts with zero options', () => {
         });
 
         it('then it should not be expanded', () => {
-            expect(component.getByRole('combobox')).not.has.attr('aria-expanded');
+            expect(component.getByRole('combobox')).has.attr('aria-expanded', 'false');
         });
     });
 


### PR DESCRIPTION
## Description
When the component is mounted in disabled state, makeup-expander is not associated leading to a11y error `Required ARIA attributes not present: aria-expanded, aria-controls`.

To fix this, added `aria-expanded` attribute set to false on mount. This attribute along with `aria-controls` updates to current state once expander attaches.

## Context
#1863

## References

Combobox pattern  tested using [mind pattern checklist](https://ebay.gitbook.io/mindpatterns/appendix/checklist#combobox)

## Screenshots

Before:
<img width="1576" alt="image" src="https://user-images.githubusercontent.com/6342519/224448531-4bff7fb1-349e-456c-9713-534da3650eb8.png">

After:
<img width="1576" alt="image" src="https://user-images.githubusercontent.com/6342519/224448805-0c5ae325-297a-408c-b507-e1ec28ae454c.png">

