### PR TITLE
fix: fixes typo on tooltip

### DIFF
--- a/src/components/ebay-line-chart/tooltip.marko
+++ b/src/components/ebay-line-chart/tooltip.marko
@@ -5,7 +5,7 @@
     <if(point.tooltip)>${point.tooltip}</if>
     <else-if(input.seriesLength)>
         <div style='display: flex; justify-content: space-between; width: 100%; align-items: flex-start;'>
-            ${pnt.series.name}
+            ${point.series.name}
             <span style='margin-left: 16px'>${point.label}</span>
         </div>
     </else-if>


### PR DESCRIPTION
## Description
Fixes typo in variable that would prevent the component from rendering

## Context
There was a typo in tooltip.marko when having more than one series that would give several errors on log and prevent the tooltip to show up

## References
https://github.com/eBay/ebayui-core/issues/1866

## Screenshots
Can be found in the issue
