### PR TITLE
feat(calendar): maintain parity with skin's a11y updates

### DIFF
--- a/src/components/ebay-calendar/calendar.stories.js
+++ b/src/components/ebay-calendar/calendar.stories.js
@@ -133,36 +133,16 @@ export default {
                 },
             },
         },
-        a11ySelectedText: {
-            type: 'text',
-            control: { type: 'text' },
-            description: 'Text to indicate a selected date',
-            table: { defaultValue: { summary: 'selected' } },
-        },
-        a11yRangeStartText: {
-            type: 'text',
-            control: { type: 'text' },
-            description: 'Text to indicate the start of a selected range',
-            table: { defaultValue: { summary: 'start of range' } },
-        },
-        a11yInRangeText: {
-            type: 'text',
-            control: { type: 'text' },
-            description: 'Text to indicate a value that is inside the selected range',
-            table: { defaultValue: { summary: 'in range' } },
-        },
-        a11yRangeEndText: {
-            type: 'text',
-            control: { type: 'text' },
-            description: 'Text to indicate the end of a selected range',
-            table: { defaultValue: { summary: 'end of range' } },
-        },
-        a11yTodayText: {
-            type: 'text',
-            control: { type: 'text' },
+        buildA11yCellText: {
+            type: 'callback',
+            control: { type: 'callback' },
             description:
-                'Text to indicate the current date. Only shown in static calendars, where "aria-current" is not supported',
-            table: { defaultValue: { summary: 'today' } },
+                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `selected`, `rangeStart`, `inRange`, `rangeEnd`, `today`, and `disabled`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range - today"`',
+            table: {
+                defaultValue: {
+                    summary: '(info) => [generates hyphen-separated list of strings]',
+                },
+            },
         },
         onSelect: {
             action: 'on-select',

--- a/src/components/ebay-calendar/calendar.stories.js
+++ b/src/components/ebay-calendar/calendar.stories.js
@@ -133,14 +133,73 @@ export default {
                 },
             },
         },
-        buildA11yCellText: {
-            type: 'callback',
-            control: { type: 'callback' },
-            description:
-                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `isSelected`, `isRangeStart`, `isInRange`, `isRangeEnd`, `isToday`, `isDisabled`, and `locale`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range - today"`',
+        a11ySelectedText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is selected',
             table: {
                 defaultValue: {
-                    summary: '(info) => [generates hyphen-separated list of strings]',
+                    summary: 'selected',
+                },
+            },
+        },
+        a11yRangeStartText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is the start of a range',
+            table: {
+                defaultValue: {
+                    summary: 'start of range',
+                },
+            },
+        },
+        a11yInRangeText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is in a range',
+            table: {
+                defaultValue: {
+                    summary: 'in range',
+                },
+            },
+        },
+        a11yRangeEndText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is the end of a range',
+            table: {
+                defaultValue: {
+                    summary: 'end of range',
+                },
+            },
+        },
+        a11yTodayText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is the current date',
+            table: {
+                defaultValue: {
+                    summary: 'today',
+                },
+            },
+        },
+        a11yDisabledText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is disabled',
+            table: {
+                defaultValue: {
+                    summary: 'inactive',
+                },
+            },
+        },
+        a11ySeparator: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers to separate properties',
+            table: {
+                defaultValue: {
+                    summary: ' - ',
                 },
             },
         },

--- a/src/components/ebay-calendar/calendar.stories.js
+++ b/src/components/ebay-calendar/calendar.stories.js
@@ -60,6 +60,17 @@ export default {
                 },
             },
         },
+        selected: {
+            type: 'text|array',
+            control: { type: 'object' },
+            description:
+                'Date or list of dates that are selected, represented as an ISO string or an array of ISO strings',
+            table: {
+                defaultValue: {
+                    summary: 'undefined',
+                },
+            },
+        },
         locale: {
             type: 'text',
             control: { type: 'text' },
@@ -122,6 +133,12 @@ export default {
                 },
             },
         },
+        a11ySelectedText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to indicate a selected date',
+            table: { defaultValue: { summary: 'selected' } },
+        },
         a11yRangeStartText: {
             type: 'text',
             control: { type: 'text' },
@@ -139,6 +156,13 @@ export default {
             control: { type: 'text' },
             description: 'Text to indicate the end of a selected range',
             table: { defaultValue: { summary: 'end of range' } },
+        },
+        a11yTodayText: {
+            type: 'text',
+            control: { type: 'text' },
+            description:
+                'Text to indicate the current date. Only shown in static calendars, where "aria-current" is not supported',
+            table: { defaultValue: { summary: 'today' } },
         },
         onSelect: {
             action: 'on-select',

--- a/src/components/ebay-calendar/calendar.stories.js
+++ b/src/components/ebay-calendar/calendar.stories.js
@@ -137,7 +137,7 @@ export default {
             type: 'callback',
             control: { type: 'callback' },
             description:
-                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `selected`, `rangeStart`, `inRange`, `rangeEnd`, `today`, and `disabled`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range - today"`',
+                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `isSelected`, `isRangeStart`, `isInRange`, `isRangeEnd`, `isToday`, `isDisabled`, and `locale`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range - today"`',
             table: {
                 defaultValue: {
                     summary: '(info) => [generates hyphen-separated list of strings]',

--- a/src/components/ebay-calendar/component.js
+++ b/src/components/ebay-calendar/component.js
@@ -25,7 +25,7 @@ const DAY_UPDATE_KEYMAP = {
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   getA11yShowMonthText?: (monthName: string) => string,
- *   buildA11yCellText?: (info: {selected?: boolean, rangeStart?: boolean, inRange?: boolean, rangeEnd?: boolean, today?: boolean, disabled?: boolean}) => string,
+ *   buildA11yCellText?: (info: {isSelected: boolean, isRangeStart: boolean, isInRange: boolean, isRangeEnd: boolean, isToday: boolean, isDisabled: boolean, locale: string}) => string,
  * }} Input
  * @typedef {{
  *   todayISO: DayISO,

--- a/src/components/ebay-calendar/component.js
+++ b/src/components/ebay-calendar/component.js
@@ -25,9 +25,11 @@ const DAY_UPDATE_KEYMAP = {
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   getA11yShowMonthText?: (monthName: string) => string,
+ *   a11ySelectedText?: string,
  *   a11yRangeStartText?: string,
  *   a11yInRangeText?: string,
  *   a11yRangeEndText?: string,
+ *   a11yTodayText?: string,
  * }} Input
  * @typedef {{
  *   todayISO: DayISO,

--- a/src/components/ebay-calendar/component.js
+++ b/src/components/ebay-calendar/component.js
@@ -25,11 +25,7 @@ const DAY_UPDATE_KEYMAP = {
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   getA11yShowMonthText?: (monthName: string) => string,
- *   a11ySelectedText?: string,
- *   a11yRangeStartText?: string,
- *   a11yInRangeText?: string,
- *   a11yRangeEndText?: string,
- *   a11yTodayText?: string,
+ *   buildA11yCellText?: (info: {selected?: boolean, rangeStart?: boolean, inRange?: boolean, rangeEnd?: boolean, today?: boolean, disabled?: boolean}) => string,
  * }} Input
  * @typedef {{
  *   todayISO: DayISO,

--- a/src/components/ebay-calendar/component.js
+++ b/src/components/ebay-calendar/component.js
@@ -25,7 +25,13 @@ const DAY_UPDATE_KEYMAP = {
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   getA11yShowMonthText?: (monthName: string) => string,
- *   buildA11yCellText?: (info: {isSelected: boolean, isRangeStart: boolean, isInRange: boolean, isRangeEnd: boolean, isToday: boolean, isDisabled: boolean, locale: string}) => string,
+ *   a11ySelectedText?: string,
+ *   a11yRangeStartText?: string,
+ *   a11yInRangeText?: string,
+ *   a11yRangeEndText?: string,
+ *   a11yTodayText?: string,
+ *   a11yDisabledText?: string,
+ *   a11ySeparator?: string,
  * }} Input
  * @typedef {{
  *   todayISO: DayISO,

--- a/src/components/ebay-calendar/index.marko
+++ b/src/components/ebay-calendar/index.marko
@@ -1,20 +1,20 @@
 // @ts-check
-import {toISO} from "./component"
+import {localeOverride, toISO} from "./component"
 
 $ const numMonths = input.numMonths || 1;
 $ const monthDates = [...Array(numMonths)].map((_, i) => component.getMonthDate(state.offset + i));
 $ const getShowMonthText = input.getA11yShowMonthText ?? ((month) => `Show ${month}`);
 /**
-* @param {{selected: boolean, rangeStart: boolean, inRange: boolean, rangeEnd: boolean, today: boolean, disabled: boolean}} info
+* @param {{isSelected: boolean, isRangeStart: boolean, isInRange: boolean, isRangeEnd: boolean, isToday: boolean, isDisabled: boolean}} info
 */
 static function defaultBuildA11yCellText(info) {
     const parts = [""];
-    if (info.selected) parts.push("selected");
-    if (info.rangeStart) parts.push("start of range");
-    if (info.rangeEnd) parts.push("end of range");
-    if (!info.rangeStart && !info.rangeEnd && info.inRange) parts.push("in range");
-    if (info.today) parts.push("today");
-    if (info.disabled) parts.push("inactive");
+    if (info.isSelected) parts.push("selected");
+    if (info.isRangeStart) parts.push("start of range");
+    if (info.isRangeEnd) parts.push("end of range");
+    if (!info.isRangeStart && !info.isRangeEnd && info.isInRange) parts.push("in range");
+    if (info.isToday) parts.push("today");
+    if (info.isDisabled) parts.push("inactive");
     return parts.join(" - ");
 }
 $ const buildA11yCellText = input.buildA11yCellText ?? defaultBuildA11yCellText;
@@ -84,12 +84,13 @@ $ const buildA11yCellText = input.buildA11yCellText ?? defaultBuildA11yCellText;
                                     $ const isRangeEnd = dayISO === state.rangeEnd;
                                     $ const isDisabled = component.isDisabled(dayISO);
                                     $ const a11yText = buildA11yCellText({
-                                        selected: isSelected,
-                                        rangeStart: isRangeStart,
-                                        inRange: isInRange,
-                                        rangeEnd: isRangeEnd,
-                                        today: !input.interactive && isToday,
-                                        disabled: !input.interactive && isDisabled,
+                                        isSelected,
+                                        isRangeStart,
+                                        isInRange,
+                                        isRangeEnd,
+                                        isToday: !input.interactive && isToday,
+                                        isDisabled: !input.interactive && isDisabled,
+                                        locale: localeOverride(input.locale)
                                     });
                                     <td class={
                                             "calendar__cell--selected": isSelected,

--- a/src/components/ebay-calendar/index.marko
+++ b/src/components/ebay-calendar/index.marko
@@ -5,8 +5,8 @@ $ const numMonths = input.numMonths || 1;
 $ const monthDates = [...Array(numMonths)].map((_, i) => component.getMonthDate(state.offset + i));
 $ const getShowMonthText = input.getA11yShowMonthText ?? ((month) => `Show ${month}`);
 /**
- * @param {{selected: boolean, rangeStart: boolean, inRange: boolean, rangeEnd: boolean, today: boolean, disabled: boolean}} info
- */
+* @param {{selected: boolean, rangeStart: boolean, inRange: boolean, rangeEnd: boolean, today: boolean, disabled: boolean}} info
+*/
 static function defaultBuildA11yCellText(info) {
     const parts = [""];
     if (info.selected) parts.push("selected");

--- a/src/components/ebay-calendar/index.marko
+++ b/src/components/ebay-calendar/index.marko
@@ -4,11 +4,20 @@ import {toISO} from "./component"
 $ const numMonths = input.numMonths || 1;
 $ const monthDates = [...Array(numMonths)].map((_, i) => component.getMonthDate(state.offset + i));
 $ const getShowMonthText = input.getA11yShowMonthText ?? ((month) => `Show ${month}`);
-$ const selectedText = input.a11ySelectedText ?? "selected";
-$ const rangeStartText = input.a11yRangeStartText ?? "start of range";
-$ const inRangeText = input.a11yInRangeText ?? "in range";
-$ const rangeEndText = input.a11yRangeEndText ?? "end of range";
-$ const todayText = input.a11yTodayText ?? "today";
+/**
+ * @param {{selected: boolean, rangeStart: boolean, inRange: boolean, rangeEnd: boolean, today: boolean, disabled: boolean}} info
+ */
+static function defaultBuildA11yCellText(info) {
+    const parts = [""];
+    if (info.selected) parts.push("selected");
+    if (info.rangeStart) parts.push("start of range");
+    if (info.rangeEnd) parts.push("end of range");
+    if (!info.rangeStart && !info.rangeEnd && info.inRange) parts.push("in range");
+    if (info.today) parts.push("today");
+    if (info.disabled) parts.push("inactive");
+    return parts.join(" - ");
+}
+$ const buildA11yCellText = input.buildA11yCellText ?? defaultBuildA11yCellText;
 
 <div.calendar>
     <if(input.navigable)>
@@ -74,13 +83,14 @@ $ const todayText = input.a11yTodayText ?? "today";
                                     $ const isInRange = component.isInRange(dayISO);
                                     $ const isRangeEnd = dayISO === state.rangeEnd;
                                     $ const isDisabled = component.isDisabled(dayISO);
-                                    $ let a11yText = "";
-                                    $ {
-                                        if (isSelected) a11yText += ` - ${selectedText}`;
-                                        if (isRangeStart) a11yText += ` - ${rangeStartText}`;
-                                        else if (isRangeEnd) a11yText += ` - ${rangeEndText}`;
-                                        else if (isInRange) a11yText += ` - ${inRangeText}`;
-                                    }
+                                    $ const a11yText = buildA11yCellText({
+                                        selected: isSelected,
+                                        rangeStart: isRangeStart,
+                                        inRange: isInRange,
+                                        rangeEnd: isRangeEnd,
+                                        today: !input.interactive && isToday,
+                                        disabled: !input.interactive && isDisabled,
+                                    });
                                     <td class={
                                             "calendar__cell--selected": isSelected,
                                             "calendar__range--start": isRangeStart,
@@ -103,7 +113,6 @@ $ const todayText = input.a11yTodayText ?? "today";
                                             </button>
                                         </if>
                                         <else>
-                                            $ if (isToday) a11yText += ` - ${todayText}`;
                                             <span class={
                                                     "calendar__cell--disabled": isDisabled,
                                                     "calendar__cell--current": isToday,

--- a/src/components/ebay-calendar/index.marko
+++ b/src/components/ebay-calendar/index.marko
@@ -3,21 +3,15 @@ import {localeOverride, toISO} from "./component"
 
 $ const numMonths = input.numMonths || 1;
 $ const monthDates = [...Array(numMonths)].map((_, i) => component.getMonthDate(state.offset + i));
+
 $ const getShowMonthText = input.getA11yShowMonthText ?? ((month) => `Show ${month}`);
-/**
-* @param {{isSelected: boolean, isRangeStart: boolean, isInRange: boolean, isRangeEnd: boolean, isToday: boolean, isDisabled: boolean}} info
-*/
-static function defaultBuildA11yCellText(info) {
-    const parts = [""];
-    if (info.isSelected) parts.push("selected");
-    if (info.isRangeStart) parts.push("start of range");
-    if (info.isRangeEnd) parts.push("end of range");
-    if (!info.isRangeStart && !info.isRangeEnd && info.isInRange) parts.push("in range");
-    if (info.isToday) parts.push("today");
-    if (info.isDisabled) parts.push("inactive");
-    return parts.join(" - ");
-}
-$ const buildA11yCellText = input.buildA11yCellText ?? defaultBuildA11yCellText;
+$ const a11ySelectedText = input.a11ySelectedText ?? "selected";
+$ const a11yRangeStartText = input.a11yRangeStartText ?? "start of range";
+$ const a11yInRangeText = input.a11yInRangeText ?? "in range";
+$ const a11yRangeEndText = input.a11yRangeEndText ?? "end of range";
+$ const a11yTodayText = input.a11yTodayText ?? "today";
+$ const a11yDisabledText = input.a11yDisabledText ?? "inactive";
+$ const a11ySeparator = input.a11ySeparator ?? " - ";
 
 <div.calendar>
     <if(input.navigable)>
@@ -83,15 +77,12 @@ $ const buildA11yCellText = input.buildA11yCellText ?? defaultBuildA11yCellText;
                                     $ const isInRange = component.isInRange(dayISO);
                                     $ const isRangeEnd = dayISO === state.rangeEnd;
                                     $ const isDisabled = component.isDisabled(dayISO);
-                                    $ const a11yText = buildA11yCellText({
-                                        isSelected,
-                                        isRangeStart,
-                                        isInRange,
-                                        isRangeEnd,
-                                        isToday: !input.interactive && isToday,
-                                        isDisabled: !input.interactive && isDisabled,
-                                        locale: localeOverride(input.locale)
-                                    });
+                                    $ let a11yTexts = [""];
+                                    $ if (isSelected) a11yTexts.push(a11ySelectedText);
+                                    $ if (isRangeStart) a11yTexts.push(a11yRangeStartText);
+                                    $ if (!isRangeStart && !isRangeEnd && isInRange) a11yTexts.push(a11yInRangeText);
+                                    $ if (isRangeEnd) a11yTexts.push(a11yRangeEndText);
+
                                     <td class={
                                             "calendar__cell--selected": isSelected,
                                             "calendar__range--start": isRangeStart,
@@ -102,7 +93,7 @@ $ const buildA11yCellText = input.buildA11yCellText ?? defaultBuildA11yCellText;
                                             <button
                                                 key=dayISO
                                                 disabled=isDisabled
-                                                aria-label=a11yText && `${day}${a11yText}`
+                                                aria-label=(a11yTexts.length > 1) && `${day}${a11yTexts.join(a11ySeparator)}`
                                                 tabindex=state.tabindexISO !== dayISO && -1
                                                 aria-current=isToday && "date"
                                                 onClick('onDaySelect', dayISO)
@@ -114,11 +105,13 @@ $ const buildA11yCellText = input.buildA11yCellText ?? defaultBuildA11yCellText;
                                             </button>
                                         </if>
                                         <else>
+                                            $ if (isToday) a11yTexts.push(a11yTodayText);
+                                            $ if (isDisabled) a11yTexts.push(a11yDisabledText);
                                             <span class={
                                                     "calendar__cell--disabled": isDisabled,
                                                     "calendar__cell--current": isToday,
                                                 }>
-                                                ${day}<if(a11yText)><span.clipped>${a11yText}</span></if>
+                                                ${day}<if(a11yTexts.length > 1)><span.clipped>${a11yTexts.join(a11ySeparator)}</span></if>
                                             </span>
                                         </else>
                                     </td>

--- a/src/components/ebay-calendar/index.marko
+++ b/src/components/ebay-calendar/index.marko
@@ -2,11 +2,13 @@
 import {toISO} from "./component"
 
 $ const numMonths = input.numMonths || 1;
-$ const monthDates = [...Array(numMonths)].map((_, i) => component.getMonthDate(state.offset + i))
-$ const getShowMonthText = input.getA11yShowMonthText ?? ((month) => `Show ${month}`)
-$ const rangeStartText = input.a11yRangeStartText ?? "start of range"
-$ const inRangeText = input.a11yInRangeText ?? "in range"
-$ const rangeEndText = input.a11yRangeEndText ?? "end of range"
+$ const monthDates = [...Array(numMonths)].map((_, i) => component.getMonthDate(state.offset + i));
+$ const getShowMonthText = input.getA11yShowMonthText ?? ((month) => `Show ${month}`);
+$ const selectedText = input.a11ySelectedText ?? "selected";
+$ const rangeStartText = input.a11yRangeStartText ?? "start of range";
+$ const inRangeText = input.a11yInRangeText ?? "in range";
+$ const rangeEndText = input.a11yRangeEndText ?? "end of range";
+$ const todayText = input.a11yTodayText ?? "today";
 
 <div.calendar>
     <if(input.navigable)>
@@ -64,37 +66,34 @@ $ const rangeEndText = input.a11yRangeEndText ?? "end of range"
                                 </else-if>
                                 <for|day| from=startDate to=endDate>
                                     $ const dayISO = toISO(new Date(year, month, day));
+                                    $ const isToday = dayISO === state.todayISO;
+                                    $ const isSelected = (Array.isArray(input.selected)
+                                            ? input.selected.some((iso) => iso === dayISO)
+                                            : input.selected && input.selected === dayISO);
                                     $ const isRangeStart = dayISO === state.rangeStart;
                                     $ const isInRange = component.isInRange(dayISO);
                                     $ const isRangeEnd = dayISO === state.rangeEnd;
-                                    $ const disabled = component.isDisabled(dayISO);
-                                    $ const rangeAriaLabel = (input.range && Array.isArray(input.selected) && (
-                                            isRangeStart
-                                            ? `${day} - ${rangeStartText}`
-                                            : isRangeEnd
-                                            ? `${day} - ${rangeEndText}`
-                                            : isInRange
-                                            ? `${day} - ${inRangeText}`
-                                            : undefined
-                                        ))
-                                    <td
-                                        class={
+                                    $ const isDisabled = component.isDisabled(dayISO);
+                                    $ let a11yText = "";
+                                    $ {
+                                        if (isSelected) a11yText += ` - ${selectedText}`;
+                                        if (isRangeStart) a11yText += ` - ${rangeStartText}`;
+                                        else if (isRangeEnd) a11yText += ` - ${rangeEndText}`;
+                                        else if (isInRange) a11yText += ` - ${inRangeText}`;
+                                    }
+                                    <td class={
+                                            "calendar__cell--selected": isSelected,
                                             "calendar__range--start": isRangeStart,
                                             "calendar__range": isInRange,
                                             "calendar__range--end": isRangeEnd,
-                                        }
-                                        aria-current=dayISO === state.todayISO && "date"
-                                        aria-selected=(
-                                            Array.isArray(input.selected)
-                                                ? input.selected.some((iso) => iso === dayISO)
-                                                : input.selected && input.selected === dayISO
-                                        ) && "true">
+                                        }>
                                         <if(input.interactive)>
                                             <button
                                                 key=dayISO
-                                                disabled=disabled
-                                                aria-label=rangeAriaLabel
+                                                disabled=isDisabled
+                                                aria-label=a11yText && `${day}${a11yText}`
                                                 tabindex=state.tabindexISO !== dayISO && -1
+                                                aria-current=isToday && "date"
                                                 onClick('onDaySelect', dayISO)
                                                 onFocus('onDayFocus', dayISO)
                                                 onMouseover('onDayFocus', dayISO)
@@ -104,10 +103,12 @@ $ const rangeEndText = input.a11yRangeEndText ?? "end of range"
                                             </button>
                                         </if>
                                         <else>
-                                            <span
-                                                class=disabled && "calendar__cell--disabled"
-                                                aria-label=rangeAriaLabel>
-                                                ${day}
+                                            $ if (isToday) a11yText += ` - ${todayText}`;
+                                            <span class={
+                                                    "calendar__cell--disabled": isDisabled,
+                                                    "calendar__cell--current": isToday,
+                                                }>
+                                                ${day}<if(a11yText)><span.clipped>${a11yText}</span></if>
                                             </span>
                                         </else>
                                     </td>

--- a/src/components/ebay-calendar/marko-tag.json
+++ b/src/components/ebay-calendar/marko-tag.json
@@ -11,10 +11,6 @@
     "disableWeekdays": "array",
     "disableList": "array",
     "getA11yShowMonthText": "function",
-    "a11ySelectedText": "string",
-    "a11yRangeStartText": "string",
-    "a11yInRangeText": "string",
-    "a11yRangeEndText": "string",
-    "a11yTodayText": "string"
+    "buildA11yCellText": "function"
   }
 }

--- a/src/components/ebay-calendar/marko-tag.json
+++ b/src/components/ebay-calendar/marko-tag.json
@@ -11,8 +11,10 @@
     "disableWeekdays": "array",
     "disableList": "array",
     "getA11yShowMonthText": "function",
+    "a11ySelectedText": "string",
     "a11yRangeStartText": "string",
     "a11yInRangeText": "string",
-    "a11yRangeEndText": "string"
+    "a11yRangeEndText": "string",
+    "a11yTodayText": "string"
   }
 }

--- a/src/components/ebay-calendar/marko-tag.json
+++ b/src/components/ebay-calendar/marko-tag.json
@@ -11,6 +11,12 @@
     "disableWeekdays": "array",
     "disableList": "array",
     "getA11yShowMonthText": "function",
-    "buildA11yCellText": "function"
+    "a11ySelectedText": "string",
+    "a11yRangeStartText": "string",
+    "a11yInRangeText": "string",
+    "a11yRangeEndText": "string",
+    "a11yTodayText": "string",
+    "a11yDisabledText": "string",
+    "a11ySeparator": "string"
   }
 }

--- a/src/components/ebay-date-textbox/component.js
+++ b/src/components/ebay-date-textbox/component.js
@@ -15,7 +15,7 @@ const MIN_WIDTH_FOR_DOUBLE_PANE = 600;
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   getA11yShowMonthText?: (monthName: string) => string,
- *   buildA11yCellText?: (info: {selected?: boolean, rangeStart?: boolean, inRange?: boolean, rangeEnd?: boolean}) => string,
+ *   buildA11yCellText?: (info: {isSelected: boolean, isRangeStart: boolean, isInRange: boolean, isRangeEnd: boolean, locale: string}) => string,
  *   a11yOpenPopoverText?: string,
  *   inputPlaceholderText?: string | [string, string],
  * }} Input

--- a/src/components/ebay-date-textbox/component.js
+++ b/src/components/ebay-date-textbox/component.js
@@ -15,7 +15,7 @@ const MIN_WIDTH_FOR_DOUBLE_PANE = 600;
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   getA11yShowMonthText?: (monthName: string) => string,
- *   buildA11yCellText?: (info: {selected?: boolean, rangeStart?: boolean, inRange?: boolean, rangeEnd?: boolean, today?: boolean, disabled?: boolean}) => string,
+ *   buildA11yCellText?: (info: {selected?: boolean, rangeStart?: boolean, inRange?: boolean, rangeEnd?: boolean}) => string,
  *   a11yOpenPopoverText?: string,
  *   inputPlaceholderText?: string | [string, string],
  * }} Input

--- a/src/components/ebay-date-textbox/component.js
+++ b/src/components/ebay-date-textbox/component.js
@@ -14,10 +14,14 @@ const MIN_WIDTH_FOR_DOUBLE_PANE = 600;
  *   disableAfter?: Date | number | string,
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
- *   getA11yShowMonthText?: (monthName: string) => string,
- *   buildA11yCellText?: (info: {isSelected: boolean, isRangeStart: boolean, isInRange: boolean, isRangeEnd: boolean, locale: string}) => string,
- *   a11yOpenPopoverText?: string,
  *   inputPlaceholderText?: string | [string, string],
+ *   getA11yShowMonthText?: (monthName: string) => string,
+ *   a11yOpenPopoverText?: string,
+ *   a11ySelectedText?: string,
+ *   a11yRangeStartText?: string,
+ *   a11yInRangeText?: string,
+ *   a11yRangeEndText?: string,
+ *   a11ySeparator?: string,
  * }} Input
  * @typedef {{
  *   numMonths: number,

--- a/src/components/ebay-date-textbox/component.js
+++ b/src/components/ebay-date-textbox/component.js
@@ -15,10 +15,7 @@ const MIN_WIDTH_FOR_DOUBLE_PANE = 600;
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   getA11yShowMonthText?: (monthName: string) => string,
- *   a11ySelectedText?: string,
- *   a11yRangeStartText?: string,
- *   a11yInRangeText?: string,
- *   a11yRangeEndText?: string,
+ *   buildA11yCellText?: (info: {selected?: boolean, rangeStart?: boolean, inRange?: boolean, rangeEnd?: boolean, today?: boolean, disabled?: boolean}) => string,
  *   a11yOpenPopoverText?: string,
  *   inputPlaceholderText?: string | [string, string],
  * }} Input

--- a/src/components/ebay-date-textbox/component.js
+++ b/src/components/ebay-date-textbox/component.js
@@ -15,6 +15,7 @@ const MIN_WIDTH_FOR_DOUBLE_PANE = 600;
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   getA11yShowMonthText?: (monthName: string) => string,
+ *   a11ySelectedText?: string,
  *   a11yRangeStartText?: string,
  *   a11yInRangeText?: string,
  *   a11yRangeEndText?: string,

--- a/src/components/ebay-date-textbox/date-textbox.stories.js
+++ b/src/components/ebay-date-textbox/date-textbox.stories.js
@@ -91,29 +91,16 @@ export default {
                 },
             },
         },
-        a11ySelectedText: {
-            type: 'text',
-            control: { type: 'text' },
-            description: 'Text to indicate a selected date',
-            table: { defaultValue: { summary: 'selected' } },
-        },
-        a11yRangeStartText: {
-            type: 'text',
-            control: { type: 'text' },
-            description: 'Text to indicate the start of a selected range',
-            table: { defaultValue: { summary: 'start of range' } },
-        },
-        a11yInRangeText: {
-            type: 'text',
-            control: { type: 'text' },
-            description: 'Text to indicate a value that is inside the selected range',
-            table: { defaultValue: { summary: 'in range' } },
-        },
-        a11yRangeEndText: {
-            type: 'text',
-            control: { type: 'text' },
-            description: 'Text to indicate the end of a selected range',
-            table: { defaultValue: { summary: 'end of range' } },
+        buildA11yCellText: {
+            type: 'callback',
+            control: { type: 'callback' },
+            description:
+                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `selected`, `rangeStart`, `inRange`, `rangeEnd`, `today`, and `disabled`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range - today"`',
+            table: {
+                defaultValue: {
+                    summary: '(info) => [generates hyphen-separated list of strings]',
+                },
+            },
         },
         a11yOpenPopoverText: {
             type: 'text',

--- a/src/components/ebay-date-textbox/date-textbox.stories.js
+++ b/src/components/ebay-date-textbox/date-textbox.stories.js
@@ -93,14 +93,53 @@ export default {
                 },
             },
         },
-        buildA11yCellText: {
-            type: 'callback',
-            control: { type: 'callback' },
-            description:
-                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `isSelected`, `isRangeStart`, `isInRange`, `isRangeEnd`, and `locale`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range"`',
+        a11ySelectedText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is selected',
             table: {
                 defaultValue: {
-                    summary: '(info) => [generates hyphen-separated list of strings]',
+                    summary: 'selected',
+                },
+            },
+        },
+        a11yRangeStartText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is the start of a range',
+            table: {
+                defaultValue: {
+                    summary: 'start of range',
+                },
+            },
+        },
+        a11yInRangeText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is in a range',
+            table: {
+                defaultValue: {
+                    summary: 'in range',
+                },
+            },
+        },
+        a11yRangeEndText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers when a date is the end of a range',
+            table: {
+                defaultValue: {
+                    summary: 'end of range',
+                },
+            },
+        },
+        a11ySeparator: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to be read by screen readers to separate properties',
+            table: {
+                defaultValue: {
+                    summary: ' - ',
                 },
             },
         },

--- a/src/components/ebay-date-textbox/date-textbox.stories.js
+++ b/src/components/ebay-date-textbox/date-textbox.stories.js
@@ -95,7 +95,7 @@ export default {
             type: 'callback',
             control: { type: 'callback' },
             description:
-                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `selected`, `rangeStart`, `inRange`, `rangeEnd`, `today`, and `disabled`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range - today"`',
+                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `selected`, `rangeStart`, `inRange`, and `rangeEnd`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range"`',
             table: {
                 defaultValue: {
                     summary: '(info) => [generates hyphen-separated list of strings]',

--- a/src/components/ebay-date-textbox/date-textbox.stories.js
+++ b/src/components/ebay-date-textbox/date-textbox.stories.js
@@ -91,6 +91,12 @@ export default {
                 },
             },
         },
+        a11ySelectedText: {
+            type: 'text',
+            control: { type: 'text' },
+            description: 'Text to indicate a selected date',
+            table: { defaultValue: { summary: 'selected' } },
+        },
         a11yRangeStartText: {
             type: 'text',
             control: { type: 'text' },

--- a/src/components/ebay-date-textbox/date-textbox.stories.js
+++ b/src/components/ebay-date-textbox/date-textbox.stories.js
@@ -1,7 +1,9 @@
-import { addRenderBodies } from '../../../.storybook/utils';
+import { addRenderBodies, buildExtensionTemplate } from '../../../.storybook/utils';
+import { tagToString } from '../../../.storybook/storybook-code-source';
 import Readme from './README.md';
-import DefaultTemplate from './examples/default.marko';
-import DefaultTemplateCode from './examples/default.marko?raw';
+import Component from './index.marko';
+import LocalizedTemplate from './examples/localized.marko';
+import LocalizedTemplateCode from './examples/localized.marko?raw';
 
 const Template = (args) => ({
     input: addRenderBodies(args),
@@ -9,7 +11,7 @@ const Template = (args) => ({
 
 export default {
     title: 'form input/ebay-date-textbox',
-    component: DefaultTemplate,
+    component: Component,
     parameters: {
         docs: {
             description: {
@@ -95,7 +97,7 @@ export default {
             type: 'callback',
             control: { type: 'callback' },
             description:
-                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `selected`, `rangeStart`, `inRange`, and `rangeEnd`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range"`',
+                'Function used to get the text for each cell in the calendar. Should return a string that describes the cell. The function is passed an object with the following properties: `isSelected`, `isRangeStart`, `isInRange`, `isRangeEnd`, and `locale`. By default, the function returns hyphen-separated english words describing each property, such as `" - selected - start of range"`',
             table: {
                 defaultValue: {
                     summary: '(info) => [generates hyphen-separated list of strings]',
@@ -132,7 +134,9 @@ export const Default = Template.bind({});
 Default.parameters = {
     docs: {
         source: {
-            DefaultTemplateCode,
+            code: tagToString('ebay-date-textbox', {}),
         },
     },
 };
+
+export const Localized = buildExtensionTemplate(LocalizedTemplate, LocalizedTemplateCode);

--- a/src/components/ebay-date-textbox/examples/localized.marko
+++ b/src/components/ebay-date-textbox/examples/localized.marko
@@ -1,0 +1,15 @@
+<ebay-date-textbox
+    disableBefore="2023-01-12"
+    disableAfter="2023-02-19"
+    range
+    locale="af"
+    getA11yShowMonthText=(monthName) => `Gaan na ${monthName}`
+    buildA11yCellText=({isSelected, isRangeStart, isInRange, isRangeEnd}) => {
+        let string = ""
+        if (isSelected) string += " (geselekteerde)";
+        if (isRangeStart) string += " (reeks begin)";
+        if (isInRange) string += " (binne bereik)";
+        if (isRangeEnd) string += " (reeks einde)";
+        return string;
+    }
+    on-change("emit", "change")/>

--- a/src/components/ebay-date-textbox/examples/localized.marko
+++ b/src/components/ebay-date-textbox/examples/localized.marko
@@ -1,15 +1,10 @@
 <ebay-date-textbox
-    disableBefore="2023-01-12"
-    disableAfter="2023-02-19"
+    disableBefore=new Date()
     range
     locale="af"
     getA11yShowMonthText=(monthName) => `Gaan na ${monthName}`
-    buildA11yCellText=({isSelected, isRangeStart, isInRange, isRangeEnd}) => {
-        let string = "";
-        if (isSelected) string += " (geselekteerde)";
-        if (isRangeStart) string += " (reeks begin)";
-        if (isInRange) string += " (binne bereik)";
-        if (isRangeEnd) string += " (reeks einde)";
-        return string;
-    }
+    a11ySelectedText="Geselekteerde"
+    a11yRangeStartText="Reeks begin"
+    a11yInRangeText="Binne bereik"
+    a11yRangeEndText="Reeks einde"
     on-change("emit", "change")/>

--- a/src/components/ebay-date-textbox/examples/localized.marko
+++ b/src/components/ebay-date-textbox/examples/localized.marko
@@ -5,7 +5,7 @@
     locale="af"
     getA11yShowMonthText=(monthName) => `Gaan na ${monthName}`
     buildA11yCellText=({isSelected, isRangeStart, isInRange, isRangeEnd}) => {
-        let string = ""
+        let string = "";
         if (isSelected) string += " (geselekteerde)";
         if (isRangeStart) string += " (reeks begin)";
         if (isInRange) string += " (binne bereik)";

--- a/src/components/ebay-date-textbox/index.marko
+++ b/src/components/ebay-date-textbox/index.marko
@@ -46,10 +46,7 @@ $ {
             disableList=input.disableList
             disableWeekdays=input.disableWeekdays
             getA11yShowMonthText=input.getA11yShowMonthText
-            a11ySelectedText=input.a11ySelectedText
-            a11yRangeStartText=input.a11yRangeStartText
-            a11yInRangeText=input.a11yInRangeText
-            a11yRangeEndText=input.a11yRangeEndText
+            buildA11yCellText=input.buildA11yCellText
             on-select("onPopoverSelect")/>
     </div>
 </span>

--- a/src/components/ebay-date-textbox/index.marko
+++ b/src/components/ebay-date-textbox/index.marko
@@ -46,6 +46,7 @@ $ {
             disableList=input.disableList
             disableWeekdays=input.disableWeekdays
             getA11yShowMonthText=input.getA11yShowMonthText
+            a11ySelectedText=input.a11ySelectedText
             a11yRangeStartText=input.a11yRangeStartText
             a11yInRangeText=input.a11yInRangeText
             a11yRangeEndText=input.a11yRangeEndText

--- a/src/components/ebay-date-textbox/index.marko
+++ b/src/components/ebay-date-textbox/index.marko
@@ -46,7 +46,11 @@ $ {
             disableList=input.disableList
             disableWeekdays=input.disableWeekdays
             getA11yShowMonthText=input.getA11yShowMonthText
-            buildA11yCellText=input.buildA11yCellText
+            a11ySelectedText=input.a11ySelectedText
+            a11yRangeStartText=input.a11yRangeStartText
+            a11yInRangeText=input.a11yInRangeText
+            a11yRangeEndText=input.a11yRangeEndText
+            a11ySeparator=input.a11ySeparator
             on-select("onPopoverSelect")/>
     </div>
 </span>

--- a/src/components/ebay-date-textbox/marko-tag.json
+++ b/src/components/ebay-date-textbox/marko-tag.json
@@ -7,6 +7,7 @@
     "disableWeekdays": "array",
     "disableList": "array",
     "getA11yShowMonthText": "function",
+    "a11ySelectedText": "string",
     "a11yRangeStartText": "string",
     "a11yInRangeText": "string",
     "a11yRangeEndText": "string",

--- a/src/components/ebay-date-textbox/marko-tag.json
+++ b/src/components/ebay-date-textbox/marko-tag.json
@@ -7,10 +7,7 @@
     "disableWeekdays": "array",
     "disableList": "array",
     "getA11yShowMonthText": "function",
-    "a11ySelectedText": "string",
-    "a11yRangeStartText": "string",
-    "a11yInRangeText": "string",
-    "a11yRangeEndText": "string",
+    "buildA11yCellText": "function",
     "a11yOpenPopoverText": "string",
     "inputPlaceholderText": "expression"
   }

--- a/src/components/ebay-date-textbox/marko-tag.json
+++ b/src/components/ebay-date-textbox/marko-tag.json
@@ -6,9 +6,13 @@
     "disableAfter": "expression",
     "disableWeekdays": "array",
     "disableList": "array",
+    "inputPlaceholderText": "expression",
     "getA11yShowMonthText": "function",
-    "buildA11yCellText": "function",
     "a11yOpenPopoverText": "string",
-    "inputPlaceholderText": "expression"
+    "a11ySelectedText": "string",
+    "a11yRangeStartText": "string",
+    "a11yInRangeText": "string",
+    "a11yRangeEndText": "string",
+    "a11ySeparator": "string"
   }
 }


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

- more details on ebay/skin#2019
    - until merged, these changes won't work unless ebayui-core is locally linked with that skin on that branch

## Description
- Add configurable a11y text for "today" and "selected"
- Move a11y info to clipped span in static calendars
- Add classes and move attributes to satisfy new skin selectors