### PR TITLE
fix: ebay-line-chart - Fix to onInput crashing because this.input is undefined

### DIFF
--- a/src/components/ebay-line-chart/component.js
+++ b/src/components/ebay-line-chart/component.js
@@ -53,7 +53,8 @@ export default class {
             .mount();
     }
 
-    onInput() {
+    onInput(input) {
+        this.input = this.input || input;
         // if chartRef does not exist do not try to run setupCharts as it may be server side and highcharts only works on the client side
         if (this.chartRef && this.chartRef.destroy) {
             this.chartRef.destroy();


### PR DESCRIPTION
## Description
Adds a fix to onInput to so it will have this.input whenever this._setupChart() gets called

## Context
Whenever ebay-line-chart gets rerendered, onInput gets called and throws an error because this.input is undefined

## Screenshots
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/17763219/228373522-832f0f26-51fb-4649-af50-44a7cb20800c.png">
