### PR TITLE
fix(ebay-carousel): scroll fails while setting index

### DIFF
--- a/src/components/ebay-carousel/component.js
+++ b/src/components/ebay-carousel/component.js
@@ -580,6 +580,7 @@ export default {
             };
         });
 
+        this.skipScrolling = false;
         this.state = state;
     },
 


### PR DESCRIPTION
## Description

The problem seems to be occurring during `handleScroll`. If user selected index is not matching with closest index we compute, we set the `skipScrolling` flag to `true` and is not being reset unless component is remounted or a explicit call to `move` function is made. 

So updated code to reset `skipScrolling` flag to `false` on onInput lifecycle method. 

## Context
#1805 

