### PR TITLE
fix: updated play icon to be play-64

### DIFF
--- a/src/components/ebay-3d-viewer/index.marko
+++ b/src/components/ebay-3d-viewer/index.marko
@@ -33,7 +33,7 @@ static {
     </div>
     <div class=['three-d-player__overlay', state.isLoaded && 'three-d-player__overlay--hidden']>
         <if(!state.showLoading)>
-            <ebay-play-24-icon a11y-text=input.a11yStartText || 'Click to start'/>
+            <ebay-play-64-colored-icon a11y-text=input.a11yStartText || 'Click to start'/>
         </if>
         <else><ebay-progress-spinner a11y-text=input.a11yLoadText || 'Loading'/></else>
     </div>

--- a/src/components/ebay-video/elements.js
+++ b/src/components/ebay-video/elements.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef,new-cap */
 const flagIconTemplate = require("../ebay-icon/icons/ebay-flag-24-icon/index.marko");
-const playIconTemplate = require("../ebay-icon/icons/ebay-play-24-icon/index.marko");
+const playIconTemplate = require("../ebay-icon/icons/ebay-play-64-colored-icon/index.marko");
 
 // Marko 4 workaround
 const flagIcon = flagIconTemplate.default || flagIconTemplate;

--- a/src/components/ebay-video/index.marko
+++ b/src/components/ebay-video/index.marko
@@ -60,7 +60,7 @@ static var ignoredAttributes = [
         ]
         on-click("loadVideo", true)>
         <if(!state.showLoading)>
-            <ebay-play-24-icon a11y-text=(input.a11yPlayText || "Click to play")/>
+            <ebay-play-64-colored-icon a11y-text=(input.a11yPlayText || "Click to play")/>
         </if>
         <else>
             <ebay-progress-spinner a11y-text=(input.a11yLoadText || "Loading")/>


### PR DESCRIPTION
## Description
Updated play icon on video and 3d-player to be `play-64-colored-icon`

## References
https://github.com/eBay/ebayui-core/issues/1881