### PR TITLE
fix(fake-menu-button): use vertically aligned icon

### DIFF
--- a/src/components/ebay-fake-menu-button/index.marko
+++ b/src/components/ebay-fake-menu-button/index.marko
@@ -74,7 +74,7 @@ $ {
         on-escape("handleButtonEscape")
         key="button">
         <if(isOverflowVariant)>
-            <ebay-overflow-horizontal-24-icon/>
+            <ebay-overflow-vertical-24-icon/>
         </if>
         <else>
             <span class=[

--- a/src/components/ebay-fake-menu-button/test/__snapshots__/renders-with-overflow-variant.expected.html
+++ b/src/components/ebay-fake-menu-button/test/__snapshots__/renders-with-overflow-variant.expected.html
@@ -11,21 +11,21 @@
     [36m>[39m
       [36m<svg[39m
         [33maria-hidden[39m=[32m"true"[39m
-        [33mclass[39m=[32m"icon icon--overflow-horizontal-24"[39m
+        [33mclass[39m=[32m"icon icon--overflow-vertical-24"[39m
         [33mfocusable[39m=[32m"false"[39m
       [36m>[39m
         [36m<defs>[39m
           [36m<symbol[39m
-            [33mid[39m=[32m"icon-overflow-horizontal-24"[39m
+            [33mid[39m=[32m"icon-overflow-vertical-24"[39m
             [33mviewBox[39m=[32m"0 0 24 24"[39m
           [36m>[39m
             [36m<path[39m
-              [33md[39m=[32m"M17 12a2 2 0 1 0 3.999.001A2 2 0 0 0 17 12Zm-7 0a2 2 0 1 0 3.999.001A2 2 0 0 0 10 12Zm-5 2a2 2 0 1 1-.001-3.999A2 2 0 0 1 5 14Z"[39m
+              [33md[39m=[32m"M12 7a2 2 0 1 0 .001-3.999A2 2 0 0 0 12 7Zm0 7a2 2 0 1 0 .001-3.999A2 2 0 0 0 12 14Zm2 5a2 2 0 1 1-3.999.001A2 2 0 0 1 14 19Z"[39m
             [36m/>[39m
           [36m</symbol>[39m
         [36m</defs>[39m
         [36m<use[39m
-          [33mxlink:href[39m=[32m"#icon-overflow-horizontal-24"[39m
+          [33mxlink:href[39m=[32m"#icon-overflow-vertical-24"[39m
         [36m/>[39m
       [36m</svg>[39m
     [36m</button>[39m


### PR DESCRIPTION
## Context
<!--- Why did you make these changes, and why in this particular way? -->
As per icon mapping [sheet](https://docs.google.com/spreadsheets/d/19DVpv0Kxw3UCbEUqpIpf3Ip6FydSCpadrBc5nnmblNc/edit#gid=1853666549) `overflow` should translate to `vertical` aligned icon.

<img width="1277" alt="Screen Shot 2023-04-24 at 9 47 29 PM" src="https://user-images.githubusercontent.com/5200733/234176862-86a06a4e-ca66-4ac0-a76b-785a58c841d8.png">


## References
<!-- Include links to JIRA, Github, etc. if appropriate. -->
Fixes #1893 

## Screenshots

<!-- Upload screenshots if appropriate. -->
<img width="119" alt="Screen Shot 2023-04-24 at 9 48 52 PM" src="https://user-images.githubusercontent.com/5200733/234177022-fc0d6f94-d13a-44d7-9e4e-002bbde91596.png">