### PR TITLE
feat(button/segmented-button): added new sizes

### DIFF
--- a/src/components/ebay-button/button.stories.js
+++ b/src/components/ebay-button/button.stories.js
@@ -29,8 +29,7 @@ export default {
             description: "url for link behaviour (switches to anchor tag)",
         },
         size: {
-            options: ["large", "regular"],
-
+            options: ["large", "regular", "small"],
             description: "",
             table: {
                 defaultValue: {

--- a/src/components/ebay-button/index.marko
+++ b/src/components/ebay-button/index.marko
@@ -29,9 +29,15 @@ static var validPriorities = [
     'delete'
 ];
 
+static var validSizes = [
+    'large',
+    'small'
+];
+
 $ {
     input.toJSON = toJSON;
-    var size = input.size === "large" ? "large" : null;
+    var size = validSizes.includes(input.size) ? input.size : null;
+
     var priority = input.priority || "secondary";
     if (input.borderless || input.variant === 'form') {
         priority = 'none';

--- a/src/components/ebay-button/marko-tag.json
+++ b/src/components/ebay-button/marko-tag.json
@@ -7,7 +7,9 @@
     "@html-attributes": "expression",
     "@partially-disabled": "boolean",
     "@priority": "string",
-    "@size": "size",
+    "@size": {
+        "enum": ["small", "regular", "large"]
+    },
     "@fluid": "boolean",
     "@fixed-height": "boolean",
     "@truncate": "boolean",

--- a/src/components/ebay-button/test/__snapshots__/renders-small-button.expected.html
+++ b/src/components/ebay-button/test/__snapshots__/renders-small-button.expected.html
@@ -1,0 +1,11 @@
+[36m<DocumentFragment>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--small btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mdata-marko[39m=[32m"{\"onclick\":\"handleClick s0 false\",\"onkeydown\":\"handleKeydown s0 false\",\"onfocus\":\"handleFocus s0 false\",\"onblur\":\"handleBlur s0 false\"}"[39m
+    [33mhref[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mButton[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-button/test/test.server.js
+++ b/src/components/ebay-button/test/test.server.js
@@ -67,6 +67,12 @@ it("renders truncated button", async () => {
     });
 });
 
+it("renders small button", async () => {
+    await htmlSnap(Standard, {
+        size: "small",
+    });
+});
+
 it("renders large truncated button", async () => {
     await htmlSnap(Standard, {
         truncate: true,

--- a/src/components/ebay-fake-menu-button/test/__snapshots__/renders-with-size-small.expected.html
+++ b/src/components/ebay-fake-menu-button/test/__snapshots__/renders-with-size-small.expected.html
@@ -5,7 +5,7 @@
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-label[39m=[32m"Menu A11y Text"[39m
-      [33mclass[39m=[32m"fake-menu-button__button btn btn--secondary"[39m
+      [33mclass[39m=[32m"fake-menu-button__button btn btn--small btn--secondary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m

--- a/src/components/ebay-menu-button/test/__snapshots__/renders-with-size-small.expected.html
+++ b/src/components/ebay-menu-button/test/__snapshots__/renders-with-size-small.expected.html
@@ -5,7 +5,7 @@
     [36m<button[39m
       [33maria-expanded[39m=[32m"false"[39m
       [33maria-haspopup[39m=[32m"true"[39m
-      [33mclass[39m=[32m"menu-button__button btn btn--secondary"[39m
+      [33mclass[39m=[32m"menu-button__button btn btn--small btn--secondary"[39m
       [33mdata-ebayui[39m=[32m""[39m
       [33mtype[39m=[32m"button"[39m
     [36m>[39m

--- a/src/components/ebay-segmented-buttons/index.marko
+++ b/src/components/ebay-segmented-buttons/index.marko
@@ -1,35 +1,35 @@
-import { processHtmlAttributes } from '../../common/html-attributes';
+import { processHtmlAttributes } from "../../common/html-attributes";
 static {
-    var ignoredAttributes = [
-        "class",
-        "buttons",
-    ];
-    var ignoredButtonAttributes = [
-        "class",
-        "icon"
-    ];
+    var ignoredAttributes = ["class", "buttons", "size"];
+    var ignoredButtonAttributes = ["class", "icon"];
 }
+static var validSizes = ["large"];
+$ var size = validSizes.includes(input.size) ? input.size : null;
 
-<div class=["segmented-buttons", input.class]
-    ...processHtmlAttributes(input, ignoredAttributes)>
+<div
+    class=[
+        "segmented-buttons",
+        size && `segmented-buttons--${size}`,
+        input.class,
+    ]
+    ...processHtmlAttributes(input, ignoredAttributes)
+>
     <ul>
-        <for|button,index| of=(input.buttons || [])>
+        <for|button, index| of=input.buttons || []>
             <li>
-                <button class=[
-                    "segmented-buttons__button",
-                    button.class
-                ]
-                aria-current=(state.selectedIndex === index && 'true')
-                on-click('onButtonClick', index)
-                ...processHtmlAttributes(button, ignoredButtonAttributes)>
+                <button
+                    class=["segmented-buttons__button", button.class]
+                    aria-current=state.selectedIndex === index && "true"
+                    on-click("onButtonClick", index)
+                    ...processHtmlAttributes(button, ignoredButtonAttributes)
+                >
                     <if(button.icon)>
-                        <span.segmented-buttons__button-cell>
+                        <span class="segmented-buttons__button-cell">
                             <${button.icon}/>
                             <span>
                                 <${button}/>
                             </span>
                         </span>
-
                     </if>
                     <else>
                         <${button.renderBody}/>

--- a/src/components/ebay-segmented-buttons/marko-tag.json
+++ b/src/components/ebay-segmented-buttons/marko-tag.json
@@ -5,6 +5,9 @@
         "targetProperty": null
     },
     "@html-attributes": "expression",
+    "@size": {
+        "enum": ["regular", "large"]
+    },
     "@buttons <button>[]": {
         "@*": {
             "targetProperty": null,

--- a/src/components/ebay-segmented-buttons/segmented-buttons.stories.js
+++ b/src/components/ebay-segmented-buttons/segmented-buttons.stories.js
@@ -36,6 +36,16 @@ export default {
                 category: "@button attribute",
             },
         },
+        size: {
+            options: ["large", "regular"],
+            description: "",
+            table: {
+                defaultValue: {
+                    summary: "none",
+                },
+            },
+            type: { category: "Options" },
+        },
         icon: {
             description: "The icon to show before the text",
             name: "@icon",

--- a/src/components/ebay-segmented-buttons/test/__snapshots__/renders-large.expected.html
+++ b/src/components/ebay-segmented-buttons/test/__snapshots__/renders-large.expected.html
@@ -1,0 +1,41 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"segmented-buttons segmented-buttons--large"[39m
+  [36m>[39m
+    [36m<ul>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33maria-current[39m=[32m"true"[39m
+          [33mclass[39m=[32m"segmented-buttons__button"[39m
+          [33mvalue[39m=[32m"quarter1"[39m
+        [36m>[39m
+          [0mQ1[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"segmented-buttons__button"[39m
+          [33mvalue[39m=[32m"quarter2"[39m
+        [36m>[39m
+          [0mQ2[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"segmented-buttons__button"[39m
+          [33mvalue[39m=[32m"quarter3"[39m
+        [36m>[39m
+          [0mQ3[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"segmented-buttons__button"[39m
+          [33mvalue[39m=[32m"quarter4"[39m
+        [36m>[39m
+          [0mQ4[0m
+        [36m</button>[39m
+      [36m</li>[39m
+    [36m</ul>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-segmented-buttons/test/test.server.js
+++ b/src/components/ebay-segmented-buttons/test/test.server.js
@@ -13,6 +13,10 @@ describe("ebay-segmented-buttons", () => {
         await htmlSnap(Default);
     });
 
+    it("renders large", async () => {
+        await htmlSnap(Default, { size: "large" });
+    });
+
     it("renders with menu items", async () => {
         await htmlSnap(WithIcons);
     });


### PR DESCRIPTION

## Description
* Added small size for button
* Added large size (and size attribute) for segmented-buttons

## Context
* There were some tests testing small button size for menu button. Updated the snapshots for that. 

## References
[#1907](https://github.com/eBay/ebayui-core/issues/1907)
https://github.com/eBay/skin/issues/2066
https://github.com/eBay/skin/issues/2064

## Screenshots
<img width="523" alt="Screen Shot 2023-05-26 at 9 17 49 AM" src="https://github.com/eBay/ebayui-core/assets/1755269/dcef5c82-3221-44bc-8672-1add1dad4771">
<img width="516" alt="Screen Shot 2023-05-26 at 9 17 55 AM" src="https://github.com/eBay/ebayui-core/assets/1755269/7c53f4b4-cd86-4d7f-9e39-59c6772c7872">
<img width="505" alt="Screen Shot 2023-05-26 at 9 18 06 AM" src="https://github.com/eBay/ebayui-core/assets/1755269/928c015f-dcf2-41e7-8a93-5d614bfdad53">

