### PR TITLE
fix: storybook a11y bug fixes

### DIFF
--- a/src/components/ebay-combobox/combobox.stories.js
+++ b/src/components/ebay-combobox/combobox.stories.js
@@ -48,7 +48,7 @@ export default {
             description:
                 "default is `none`; available values are `none` or `list`. For list, will automatically filter results while typing.",
         },
-        "list-selection": {
+        listSelection: {
             control: { type: "text" },
             description:
                 "default is `automatic`; available values are `automatic`, `manual`. If set to automatic will automatically fill in the input with the currently highlighted item when using the up/down keys.",

--- a/src/components/ebay-drawer-dialog/examples/default.marko
+++ b/src/components/ebay-drawer-dialog/examples/default.marko
@@ -1,6 +1,5 @@
 <ebay-drawer-dialog
     a11y-close-text="Close drawer"
-    aria-labelledby="drawer-title"
     open=state.open
     on-close("closeDrawer")
     on-expanded("emit", "expanded")

--- a/src/components/ebay-drawer-dialog/examples/lots-of-text.marko
+++ b/src/components/ebay-drawer-dialog/examples/lots-of-text.marko
@@ -1,6 +1,5 @@
 <ebay-drawer-dialog
     a11y-close-text="Close Dialog"
-    aria-labelledby="drawer-title"
     open=state.open
     on-close("closeDrawer")>
     <@header id="drawer-title">Heading</@header>

--- a/src/components/ebay-drawer-dialog/examples/no-handle.marko
+++ b/src/components/ebay-drawer-dialog/examples/no-handle.marko
@@ -1,6 +1,5 @@
 <ebay-drawer-dialog
     a11y-close-text="Close Dialog"
-    aria-labelledby="drawer-title"
     open=state.open
     noHandle
     on-close("closeDrawer")>

--- a/src/components/ebay-drawer-dialog/examples/withFooter.marko
+++ b/src/components/ebay-drawer-dialog/examples/withFooter.marko
@@ -1,6 +1,5 @@
 <ebay-drawer-dialog
     a11y-close-text="Close drawer"
-    aria-labelledby="drawer-title"
     open=state.open
     on-close("closeDrawer")
     on-expanded("emit", "expanded")

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-basic-version.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-basic-version.expected.html
@@ -1,6 +1,6 @@
 [36m<DocumentFragment>[39m
   [36m<div[39m
-    [33maria-labelledby[39m=[32m"drawer-title"[39m
+    [33maria-labelledby[39m=[32m"s0-0-@dialog-dialog-title"[39m
     [33maria-modal[39m=[32m"true"[39m
     [33mclass[39m=[32m"drawer-dialog drawer-dialog--mask-fade-slow"[39m
     [33mhidden[39m=[32m""[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-in-expanded-state.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-in-expanded-state.expected.html
@@ -1,6 +1,6 @@
 [36m<DocumentFragment>[39m
   [36m<div[39m
-    [33maria-labelledby[39m=[32m"drawer-title"[39m
+    [33maria-labelledby[39m=[32m"s0-0-@dialog-dialog-title"[39m
     [33maria-modal[39m=[32m"true"[39m
     [33mclass[39m=[32m"drawer-dialog drawer-dialog--mask-fade-slow"[39m
     [33mexpanded[39m=[32m""[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-in-open-state.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-in-open-state.expected.html
@@ -1,6 +1,6 @@
 [36m<DocumentFragment>[39m
   [36m<div[39m
-    [33maria-labelledby[39m=[32m"drawer-title"[39m
+    [33maria-labelledby[39m=[32m"s0-0-@dialog-dialog-title"[39m
     [33maria-modal[39m=[32m"true"[39m
     [33mclass[39m=[32m"drawer-dialog drawer-dialog--mask-fade-slow"[39m
     [33mrole[39m=[32m"dialog"[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-with-footer-version.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-with-footer-version.expected.html
@@ -1,6 +1,6 @@
 [36m<DocumentFragment>[39m
   [36m<div[39m
-    [33maria-labelledby[39m=[32m"drawer-title"[39m
+    [33maria-labelledby[39m=[32m"s0-0-@dialog-dialog-title"[39m
     [33maria-modal[39m=[32m"true"[39m
     [33mclass[39m=[32m"drawer-dialog drawer-dialog--mask-fade-slow"[39m
     [33mhidden[39m=[32m""[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-with-text-close.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-with-text-close.expected.html
@@ -1,6 +1,6 @@
 [36m<DocumentFragment>[39m
   [36m<div[39m
-    [33maria-labelledby[39m=[32m"drawer-title"[39m
+    [33maria-labelledby[39m=[32m"s0-0-@dialog-dialog-title"[39m
     [33maria-modal[39m=[32m"true"[39m
     [33mclass[39m=[32m"drawer-dialog drawer-dialog--mask-fade-slow"[39m
     [33mhidden[39m=[32m""[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-without-handle.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-without-handle.expected.html
@@ -1,6 +1,6 @@
 [36m<DocumentFragment>[39m
   [36m<div[39m
-    [33maria-labelledby[39m=[32m"drawer-title"[39m
+    [33maria-labelledby[39m=[32m"s0-0-@dialog-dialog-title"[39m
     [33maria-modal[39m=[32m"true"[39m
     [33mclass[39m=[32m"drawer-dialog drawer-dialog--mask-fade-slow"[39m
     [33mhidden[39m=[32m""[39m


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Fixed an issue in storybook for combobox where list-selection manual is not working as expected.
- Fixed an issue in storybook for drawer dialog where aria-labelledby is not mapped to drawer dialog title.

## References

#1912, #1917

## Screenshots

**Combobox**
<img width="1203" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/161f2eb2-753b-4e40-833c-426618e8933f">

**Drawer dialog**
<img width="1022" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/fb04a46b-52ad-4786-a68a-13e54cde078e">

