### PR TITLE
feat(confirm-dialog): added destructive CTA button variant

### DIFF
--- a/src/components/ebay-confirm-dialog/confirm-dialog.stories.js
+++ b/src/components/ebay-confirm-dialog/confirm-dialog.stories.js
@@ -40,7 +40,7 @@ export default {
             control: { type: "text" },
             description: "Text for reject button",
         },
-        variant: {
+        "confirm-cta-variant": {
             options: ["none", "destructive"],
             description: "The alternative main CTA button variant to use.",
             table: {

--- a/src/components/ebay-confirm-dialog/confirm-dialog.stories.js
+++ b/src/components/ebay-confirm-dialog/confirm-dialog.stories.js
@@ -40,6 +40,16 @@ export default {
             control: { type: "text" },
             description: "Text for reject button",
         },
+        variant: {
+            options: ["none", "destructive"],
+            description: "The alternative main CTA button variant to use.",
+            table: {
+                defaultValue: {
+                    summary: "none",
+                },
+            },
+            type: { category: "Options" },
+        },
         onOpen: {
             action: "on-open",
             description: "Triggered on dialog open",

--- a/src/components/ebay-confirm-dialog/index.marko
+++ b/src/components/ebay-confirm-dialog/index.marko
@@ -4,7 +4,7 @@ $ var mainId = component.getElId("confirm-dialog-main");
 <ebay-dialog-base
     ...input
     open=input.open
-    variant=input.variant
+    confirm-cta-variant=input['confirm-cta-variant']
     on-open("emit", "open")
     on-close("emit", "reject")
     main-id=mainId
@@ -27,7 +27,7 @@ $ var mainId = component.getElId("confirm-dialog-main");
             aria-describedby=mainId
             class=[
                 "confirm-dialog__confirm",
-                input.variant && input.variant !== 'none' && `btn--${input.variant}`
+                input['confirm-cta-variant'] && input['confirm-cta-variant'] !== 'none' && `btn--${input['confirm-cta-variant']}`
             ]>
             ${input.confirmText}
         </ebay-button>

--- a/src/components/ebay-confirm-dialog/index.marko
+++ b/src/components/ebay-confirm-dialog/index.marko
@@ -4,6 +4,7 @@ $ var mainId = component.getElId("confirm-dialog-main");
 <ebay-dialog-base
     ...input
     open=input.open
+    variant=input.variant
     on-open("emit", "open")
     on-close("emit", "reject")
     main-id=mainId
@@ -24,7 +25,10 @@ $ var mainId = component.getElId("confirm-dialog-main");
             on-click("emit", "confirm")
             id=confirmId
             aria-describedby=mainId
-            class="confirm-dialog__confirm">
+            class=[
+                "confirm-dialog__confirm",
+                input.variant && input.variant !== 'none' && `btn--${input.variant}`
+            ]>
             ${input.confirmText}
         </ebay-button>
     </@footer>

--- a/src/components/ebay-confirm-dialog/marko-tag.json
+++ b/src/components/ebay-confirm-dialog/marko-tag.json
@@ -7,6 +7,7 @@
     "@html-attributes": "expression",
     "@open": "boolean",
     "@close-focus": "string",
+    "@confirm-cta-variant": "string",
     "@confirm-text": "string",
     "@reject-text": "string",
     "@role": "never",


### PR DESCRIPTION
Fixes #1919 

## Description

Added variant option to the confirm dialog main CTA button with the first supported variant of `destructive`.

## Context

I allowed flexibility to add other potential variants for better scalability.

## Screenshots

<img width="921" alt="image" src="https://github.com/eBay/ebayui-core/assets/1675667/bf1d9dc0-2dc1-4b51-8b8f-aaf4e7e672fd">
