### PR TITLE
feat(date-textbox): add value input

### DIFF
--- a/src/components/ebay-date-textbox/component.js
+++ b/src/components/ebay-date-textbox/component.js
@@ -1,13 +1,15 @@
 // @ts-check
 
 import Expander from "makeup-expander";
-import { toISO } from "../ebay-calendar/component";
+import { dateArgToISO, toISO } from "../ebay-calendar/component";
 
 const MIN_WIDTH_FOR_DOUBLE_PANE = 600;
 
 /**
  * @typedef {import('../ebay-calendar/component').DayISO} DayISO
  * @typedef {{
+ *   value?: Date | number | string,
+ *   rangeEnd?: Date | number | string,
  *   locale?: string,
  *   range?: boolean,
  *   disableBefore?: Date | number | string,
@@ -60,6 +62,12 @@ export default class extends Marko.Component {
      * @param {Input} input
      */
     onInput(input) {
+        if (input.value) {
+            this.state.firstSelected = dateArgToISO(input.value);
+        }
+        if (input.rangeEnd) {
+            this.state.secondSelected = dateArgToISO(input.rangeEnd);
+        }
         if (!input.range) {
             this.state.secondSelected = null;
         }

--- a/src/components/ebay-date-textbox/date-textbox.stories.js
+++ b/src/components/ebay-date-textbox/date-textbox.stories.js
@@ -24,6 +24,16 @@ export default {
     },
 
     argTypes: {
+        value: {
+            type: "date",
+            control: { type: "date" },
+            description: "Selected date",
+            table: {
+                defaultValue: {
+                    summary: "undefined",
+                },
+            },
+        },
         range: {
             type: "boolean",
             control: { type: "boolean" },
@@ -31,6 +41,16 @@ export default {
             table: {
                 defaultValue: {
                     summary: "false",
+                },
+            },
+        },
+        rangeEnd: {
+            type: "date",
+            control: { type: "date" },
+            description: "If range is true, the end of the selected range",
+            table: {
+                defaultValue: {
+                    summary: "undefined",
                 },
             },
         },

--- a/src/components/ebay-date-textbox/marko-tag.json
+++ b/src/components/ebay-date-textbox/marko-tag.json
@@ -1,6 +1,8 @@
 {
     "attributes": {
         "locale": "string",
+        "value": "expression",
+        "rangeEnd": "expression",
         "range": "boolean",
         "disableBefore": "expression",
         "disableAfter": "expression",


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->
- resolves #1940 

## Description
- Add `value` and `rangeEnd` to the date textbox component, so developers can change state externally.