### PR TITLE
feat(toggle-button-group): add toggle button group

### DIFF
--- a/ds-versions.json
+++ b/ds-versions.json
@@ -47,6 +47,7 @@
     "toast": "2.1.0",
     "toast-dialog": "2.1.0",
     "toggle-button": "1.0.0",
+    "toggle-button-group": "1.0.0",
     "tooltip": "1.0.0",
     "tourtip": "1.0.0",
     "typography": "1.1.0"

--- a/src/components/ebay-toggle-button-group/README.md
+++ b/src/components/ebay-toggle-button-group/README.md
@@ -1,0 +1,16 @@
+<h1 style="display: flex; justify-content: space-between; align-items: center;">
+    <span>
+        ebay-toggle-button-group
+    </span>
+    <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
+        DS v1.0.0
+    </span>
+</h1>
+
+Group of toggle buttons.
+
+## Examples and Documentation
+
+-   [Storybook](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-toggle-button-group)
+-   [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/buttons-ebay-toggle-button-group)
+-   [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-toggle-button-group/examples)

--- a/src/components/ebay-toggle-button-group/browser.json
+++ b/src/components/ebay-toggle-button-group/browser.json
@@ -1,0 +1,9 @@
+{
+    "requireRemap": [
+        {
+            "from": "./style",
+            "to": "../../common/empty",
+            "if-flag": "ebayui-no-skin"
+        }
+    ]
+}

--- a/src/components/ebay-toggle-button-group/component.js
+++ b/src/components/ebay-toggle-button-group/component.js
@@ -10,9 +10,13 @@ export default class {
     }
 
     handleToggle(index, { originalEvent, pressed }) {
-        if (this.input.radio) {
+        if (this.input.variant === "radio") {
+            // radio buttons may not be deselected, so `pressed` is not necessary
+            this.state.pressed = { [index]: true };
+        } else if (this.input.variant === "single") {
             this.state.pressed = { [index]: pressed };
         } else {
+            // act as a normal checkbox
             this.state.pressed = { ...this.state.pressed, [index]: pressed };
         }
         this.emit("change", {

--- a/src/components/ebay-toggle-button-group/component.js
+++ b/src/components/ebay-toggle-button-group/component.js
@@ -13,7 +13,7 @@ export default class {
         if (this.input.variant === "radio") {
             // radio buttons may not be deselected, so `pressed` is not necessary
             this.state.pressed = { [index]: true };
-        } else if (this.input.variant === "single") {
+        } else if (this.input.variant === "radio-toggle") {
             this.state.pressed = { [index]: pressed };
         } else {
             // act as a normal checkbox

--- a/src/components/ebay-toggle-button-group/component.js
+++ b/src/components/ebay-toggle-button-group/component.js
@@ -4,15 +4,9 @@ export default class {
     }
 
     onInput(input) {
-        if (input.pressed) {
-            if (Array.isArray(input.pressed)) {
-                this.state.pressed = Object.fromEntries(
-                    input.pressed.map((i) => [i, true])
-                );
-            } else {
-                this.state.pressed = { [input.pressed]: true };
-            }
-        }
+        this.state.pressed = Object.fromEntries(
+            input.buttons.map(({ pressed }, i) => [i, !!pressed])
+        );
     }
 
     handleToggle(index, { originalEvent, pressed }) {

--- a/src/components/ebay-toggle-button-group/component.js
+++ b/src/components/ebay-toggle-button-group/component.js
@@ -1,0 +1,31 @@
+export default class {
+    onCreate() {
+        this.state = { pressed: {} };
+    }
+
+    onInput(input) {
+        if (input.pressed) {
+            if (Array.isArray(input.pressed)) {
+                this.state.pressed = Object.fromEntries(
+                    input.pressed.map((i) => [i, true])
+                );
+            } else {
+                this.state.pressed = { [input.pressed]: true };
+            }
+        }
+    }
+
+    handleToggle(index, { originalEvent, pressed }) {
+        if (this.input.radio) {
+            this.state.pressed = { [index]: pressed };
+        } else {
+            this.state.pressed = { ...this.state.pressed, [index]: pressed };
+        }
+        this.emit("change", {
+            originalEvent,
+            pressed: Object.keys(this.state.pressed)
+                .filter((i) => this.state.pressed[i])
+                .map((i) => +i),
+        });
+    }
+}

--- a/src/components/ebay-toggle-button-group/examples/controlled.marko
+++ b/src/components/ebay-toggle-button-group/examples/controlled.marko
@@ -1,0 +1,26 @@
+$ const titles = ["Option 1", "Option 2", "Option 3"];
+
+<div style={ width: "100%" }>
+    <ebay-button onClick("clearSelection")>
+        Clear Selection
+    </ebay-button>
+    <ebay-toggle-button-group columns=3 on-change("handleChange") ...input>
+        <for|title, i| of=titles>
+            <@button title=title pressed=state.pressed.includes(i)/>
+        </for>
+    </ebay-toggle-button-group>
+</div>
+
+class {
+    onCreate() {
+        this.state = {
+            pressed: [],
+        };
+    }
+    handleChange({ pressed }) {
+        this.state.pressed = pressed;
+    }
+    clearSelection() {
+        this.state.pressed = [];
+    }
+}

--- a/src/components/ebay-toggle-button-group/examples/controlled.marko
+++ b/src/components/ebay-toggle-button-group/examples/controlled.marko
@@ -6,7 +6,9 @@ $ const titles = ["Option 1", "Option 2", "Option 3"];
     </ebay-button>
     <ebay-toggle-button-group columns=3 on-change("handleChange") ...input>
         <for|title, i| of=titles>
-            <@button title=title pressed=state.pressed.includes(i)/>
+            <@button pressed=state.pressed.includes(i)>
+                ${title}
+            </@button>
         </for>
     </ebay-toggle-button-group>
 </div>

--- a/src/components/ebay-toggle-button-group/examples/icons.marko
+++ b/src/components/ebay-toggle-button-group/examples/icons.marko
@@ -1,30 +1,42 @@
 <ebay-toggle-button-group columns=3 layoutType="list" ...input>
-    <@button title="Icon 1" subtitle="Car">
+    <@button>
+        Icon 1
+        <@subtitle>Car</@subtitle>
         <@icon>
             <ebay-car-24-icon/>
         </@icon>
     </@button>
-    <@button title="Icon 2" subtitle="ATV">
+    <@button>
+        Icon 2
+        <@subtitle>ATV</@subtitle>
         <@icon>
             <ebay-atv-24-icon/>
         </@icon>
     </@button>
-    <@button title="Icon 3" subtitle="Cart">
+    <@button>
+        Icon 3
+        <@subtitle>Cart</@subtitle>
         <@icon>
             <ebay-cart-24-icon/>
         </@icon>
     </@button>
-    <@button title="Icon 4" subtitle="Jet Ski">
+    <@button>
+        Icon 4
+        <@subtitle>Jet Ski</@subtitle>
         <@icon>
             <ebay-jet-ski-24-icon/>
         </@icon>
     </@button>
-    <@button title="Icon 5" subtitle="Motorcycle">
+    <@button>
+        Icon 5
+        <@subtitle>Motorcycle</@subtitle>
         <@icon>
             <ebay-motorcycle-24-icon/>
         </@icon>
     </@button>
-    <@button title="Icon 6" subtitle="Snowmobile">
+    <@button>
+        Icon 6
+        <@subtitle>Snowmobile</@subtitle>
         <@icon>
             <ebay-snowmobile-24-icon/>
         </@icon>

--- a/src/components/ebay-toggle-button-group/examples/icons.marko
+++ b/src/components/ebay-toggle-button-group/examples/icons.marko
@@ -1,0 +1,32 @@
+<ebay-toggle-button-group columns=3 layoutType="list" ...input>
+    <@toggle-button title="Icon 1" subtitle="Car">
+        <@icon>
+            <ebay-car-24-icon/>
+        </@icon>
+    </@toggle-button>
+    <@toggle-button title="Icon 2" subtitle="ATV">
+        <@icon>
+            <ebay-atv-24-icon/>
+        </@icon>
+    </@toggle-button>
+    <@toggle-button title="Icon 3" subtitle="Cart">
+        <@icon>
+            <ebay-cart-24-icon/>
+        </@icon>
+    </@toggle-button>
+    <@toggle-button title="Icon 4" subtitle="Jet Ski">
+        <@icon>
+            <ebay-jet-ski-24-icon/>
+        </@icon>
+    </@toggle-button>
+    <@toggle-button title="Icon 5" subtitle="Motorcycle">
+        <@icon>
+            <ebay-motorcycle-24-icon/>
+        </@icon>
+    </@toggle-button>
+    <@toggle-button title="Icon 6" subtitle="Snowmobile">
+        <@icon>
+            <ebay-snowmobile-24-icon/>
+        </@icon>
+    </@toggle-button>
+</ebay-toggle-button-group>

--- a/src/components/ebay-toggle-button-group/examples/icons.marko
+++ b/src/components/ebay-toggle-button-group/examples/icons.marko
@@ -1,32 +1,32 @@
 <ebay-toggle-button-group columns=3 layoutType="list" ...input>
-    <@toggle-button title="Icon 1" subtitle="Car">
+    <@button title="Icon 1" subtitle="Car">
         <@icon>
             <ebay-car-24-icon/>
         </@icon>
-    </@toggle-button>
-    <@toggle-button title="Icon 2" subtitle="ATV">
+    </@button>
+    <@button title="Icon 2" subtitle="ATV">
         <@icon>
             <ebay-atv-24-icon/>
         </@icon>
-    </@toggle-button>
-    <@toggle-button title="Icon 3" subtitle="Cart">
+    </@button>
+    <@button title="Icon 3" subtitle="Cart">
         <@icon>
             <ebay-cart-24-icon/>
         </@icon>
-    </@toggle-button>
-    <@toggle-button title="Icon 4" subtitle="Jet Ski">
+    </@button>
+    <@button title="Icon 4" subtitle="Jet Ski">
         <@icon>
             <ebay-jet-ski-24-icon/>
         </@icon>
-    </@toggle-button>
-    <@toggle-button title="Icon 5" subtitle="Motorcycle">
+    </@button>
+    <@button title="Icon 5" subtitle="Motorcycle">
         <@icon>
             <ebay-motorcycle-24-icon/>
         </@icon>
-    </@toggle-button>
-    <@toggle-button title="Icon 6" subtitle="Snowmobile">
+    </@button>
+    <@button title="Icon 6" subtitle="Snowmobile">
         <@icon>
             <ebay-snowmobile-24-icon/>
         </@icon>
-    </@toggle-button>
+    </@button>
 </ebay-toggle-button-group>

--- a/src/components/ebay-toggle-button-group/examples/withDefault.marko
+++ b/src/components/ebay-toggle-button-group/examples/withDefault.marko
@@ -1,8 +1,26 @@
 <ebay-toggle-button-group columns=3 ...input>
-    <@button title="First Item" subtitle="Empty on load"/>
-    <@button title="Second Item" subtitle="Empty on load"/>
-    <@button title="Third Item" subtitle="Pressed on load" pressed/>
-    <@button title="Fourth Item" subtitle="Empty on load"/>
-    <@button title="Fifth Item" subtitle="Pressed on load" pressed/>
-    <@button title="Sixth Item" subtitle="Empty on load"/>
+    <@button>
+        First Item
+        <@subtitle>Empty on load</@subtitle>
+    </@button>
+    <@button>
+        Second Item
+        <@subtitle>Empty on load</@subtitle>
+    </@button>
+    <@button pressed>
+        Third Item
+        <@subtitle>Pressed on load</@subtitle>
+    </@button>
+    <@button>
+        Fourth Item
+        <@subtitle>Empty on load</@subtitle>
+    </@button>
+    <@button pressed>
+        Fifth Item
+        <@subtitle>Pressed on load</@subtitle>
+    </@button>
+    <@button>
+        Sixth Item
+        <@subtitle>Empty on load</@subtitle>
+    </@button>
 </ebay-toggle-button-group>

--- a/src/components/ebay-toggle-button-group/examples/withDefault.marko
+++ b/src/components/ebay-toggle-button-group/examples/withDefault.marko
@@ -1,0 +1,8 @@
+<ebay-toggle-button-group columns=3 ...input>
+    <@button title="First Item" subtitle="Empty on load"/>
+    <@button title="Second Item" subtitle="Empty on load"/>
+    <@button title="Third Item" subtitle="Pressed on load" pressed/>
+    <@button title="Fourth Item" subtitle="Empty on load"/>
+    <@button title="Fifth Item" subtitle="Pressed on load" pressed/>
+    <@button title="Sixth Item" subtitle="Empty on load"/>
+</ebay-toggle-button-group>

--- a/src/components/ebay-toggle-button-group/index.marko
+++ b/src/components/ebay-toggle-button-group/index.marko
@@ -1,0 +1,19 @@
+import { processHtmlAttributes } from "../../common/html-attributes";
+static var ignoredAttributes = ["class", "columns"];
+
+<ul
+    class=["toggle-button-group", input.class]
+    data-columns=input.columns
+    ...processHtmlAttributes(input, ignoredAttributes)
+>
+    <for|{ layoutType = input.layoutType, ...buttonInput }, i| of=input.buttons>
+        <li>
+            <ebay-toggle-button
+                layoutType=layoutType
+                pressed=state.pressed[i]
+                ...buttonInput
+                on-toggle("handleToggle", i)
+            />
+        </li>
+    </for>
+</ul>

--- a/src/components/ebay-toggle-button-group/index.marko
+++ b/src/components/ebay-toggle-button-group/index.marko
@@ -6,7 +6,7 @@ static var ignoredAttributes = ["class", "columns"];
     data-columns=input.columns
     ...processHtmlAttributes(input, ignoredAttributes)
 >
-    <for|{ layoutType = input.layoutType, ...buttonInput }, i| of=input.buttons>
+    <for|{ layoutType = input.layoutType, pressed, ...buttonInput }, i| of=input.buttons>
         <li>
             <ebay-toggle-button
                 layoutType=layoutType

--- a/src/components/ebay-toggle-button-group/marko-tag.json
+++ b/src/components/ebay-toggle-button-group/marko-tag.json
@@ -8,7 +8,7 @@
     "@columns": "number",
     "@radio": "boolean",
     "@layout-type": "string",
-    "@buttons <toggle-button>[]": {
+    "@buttons <button>[]": {
         "@*": {
             "targetProperty": null,
             "type": "expression"

--- a/src/components/ebay-toggle-button-group/marko-tag.json
+++ b/src/components/ebay-toggle-button-group/marko-tag.json
@@ -1,0 +1,18 @@
+{
+    "attribute-groups": ["html-attributes"],
+    "@*": {
+        "targetProperty": null,
+        "type": "expression"
+    },
+    "@html-attributes": "expression",
+    "@columns": "number",
+    "@radio": "boolean",
+    "@layout-type": "string",
+    "@buttons <toggle-button>[]": {
+        "@*": {
+            "targetProperty": null,
+            "type": "expression"
+        },
+        "@html-attributes": "expression"
+    }
+}

--- a/src/components/ebay-toggle-button-group/style.js
+++ b/src/components/ebay-toggle-button-group/style.js
@@ -1,0 +1,1 @@
+require("@ebay/skin/toggle-button-group");

--- a/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
+++ b/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
@@ -68,12 +68,12 @@ export const Default = Template.bind({});
 Default.args = {
     columns: 3,
     buttons: [
-        { title: "Button 1" },
-        { title: "Button 2" },
-        { title: "Button 3" },
-        { title: "Button 4" },
-        { title: "Button 5" },
-        { title: "Button 6" },
+        { renderBody: "Button 1" },
+        { renderBody: "Button 2" },
+        { renderBody: "Button 3" },
+        { renderBody: "Button 4" },
+        { renderBody: "Button 5" },
+        { renderBody: "Button 6" },
     ],
 };
 
@@ -98,12 +98,12 @@ WithIcons.parameters = {
     },
 };
 
-export const WithDefault = (args) => ({
+export const WithDefaultSelected = (args) => ({
     input: args,
     component: withDefaultTemplate,
 });
-WithDefault.args = {};
-WithDefault.parameters = {
+WithDefaultSelected.args = {};
+WithDefaultSelected.parameters = {
     docs: {
         source: {
             code: withDefaultCode,

--- a/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
+++ b/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
@@ -2,8 +2,12 @@ import { tagToString } from "../../../.storybook/storybook-code-source";
 import { addRenderBodies } from "../../../.storybook/utils";
 import readme from "./README.md";
 import component from "./index.marko";
-import WithIconsTemplate from "./examples/icons.marko";
-import WithIconsCode from "./examples/icons.marko?raw";
+import withIconsTemplate from "./examples/icons.marko";
+import withIconsCode from "./examples/icons.marko?raw";
+import withDefaultTemplate from "./examples/withDefault.marko";
+import withDefaultCode from "./examples/withDefault.marko?raw";
+import controlledTemplate from "./examples/controlled.marko";
+import controlledCode from "./examples/controlled.marko?raw";
 
 const Template = (args) => ({
     input: addRenderBodies(args),
@@ -38,8 +42,9 @@ export default {
                 'Enforced layout type of all buttons. May be `"minimal"` (default), `"list"`, or `"gallery"`. Gallery layout may only be used when there is also an icon or an image, and minimal layout may **not** be used when there is an icon or an image',
         },
         buttons: {
-            name: "@toggle-button",
-            description: "An `<img>` to show as the button's image",
+            name: "@button",
+            description:
+                "Represents an `<ebay-toggle-button/>` to be used as part of the group",
             table: {
                 category: "@attribute tags",
             },
@@ -80,13 +85,39 @@ Default.parameters = {
 
 export const WithIcons = (args) => ({
     input: args,
-    component: WithIconsTemplate,
+    component: withIconsTemplate,
 });
 WithIcons.args = {};
 WithIcons.parameters = {
     docs: {
         source: {
-            code: WithIconsCode,
+            code: withIconsCode,
+        },
+    },
+};
+
+export const WithDefault = (args) => ({
+    input: args,
+    component: withDefaultTemplate,
+});
+WithDefault.args = {};
+WithDefault.parameters = {
+    docs: {
+        source: {
+            code: withDefaultCode,
+        },
+    },
+};
+
+export const Controlled = (args) => ({
+    input: args,
+    component: controlledTemplate,
+});
+Controlled.args = {};
+Controlled.parameters = {
+    docs: {
+        source: {
+            code: controlledCode,
         },
     },
 };

--- a/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
+++ b/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
@@ -24,15 +24,17 @@ export default {
         },
     },
     argTypes: {
-        radio: {
-            type: "boolean",
-            control: { type: "boolean" },
-            description: "Whether the buttons act as radio buttons",
+        variant: {
+            type: "string",
+            control: { type: "select" },
+            options: ["checkbox", "radio", "single"],
+            description:
+                'Selection type for the buttons in the group. May be `"checkbox"` (default), `"radio"`, or `"single"` (same as radio but with the option to deselect)',
         },
         columns: {
             type: "number",
             control: { type: "number" },
-            description: "Suggested number of columns",
+            description: "Preferred minimum number of columns",
         },
         layoutType: {
             type: "string",

--- a/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
+++ b/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
@@ -1,0 +1,92 @@
+import { tagToString } from "../../../.storybook/storybook-code-source";
+import { addRenderBodies } from "../../../.storybook/utils";
+import readme from "./README.md";
+import component from "./index.marko";
+import WithIconsTemplate from "./examples/icons.marko";
+import WithIconsCode from "./examples/icons.marko?raw";
+
+const Template = (args) => ({
+    input: addRenderBodies(args),
+});
+
+export default {
+    title: "buttons/ebay-toggle-button-group",
+    component,
+    parameters: {
+        docs: {
+            description: {
+                component: readme,
+            },
+        },
+    },
+    argTypes: {
+        radio: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description: "Whether the buttons act as radio buttons",
+        },
+        columns: {
+            type: "number",
+            control: { type: "number" },
+            description: "Suggested number of columns",
+        },
+        layoutType: {
+            type: "string",
+            control: { type: "select" },
+            options: ["minimal", "list", "gallery"],
+            description:
+                'Enforced layout type of all buttons. May be `"minimal"` (default), `"list"`, or `"gallery"`. Gallery layout may only be used when there is also an icon or an image, and minimal layout may **not** be used when there is an icon or an image',
+        },
+        buttons: {
+            name: "@toggle-button",
+            description: "An `<img>` to show as the button's image",
+            table: {
+                category: "@attribute tags",
+            },
+        },
+        onChange: {
+            action: "on-change",
+            description: "Triggered when the pressed state changes",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "{ originalEvent, pressed }",
+                },
+            },
+        },
+    },
+};
+
+export const Default = Template.bind({});
+Default.args = {
+    columns: 3,
+    buttons: [
+        { title: "Button 1" },
+        { title: "Button 2" },
+        { title: "Button 3" },
+        { title: "Button 4" },
+        { title: "Button 5" },
+        { title: "Button 6" },
+    ],
+};
+
+Default.parameters = {
+    docs: {
+        source: {
+            code: tagToString("ebay-toggle-button", Default.args),
+        },
+    },
+};
+
+export const WithIcons = (args) => ({
+    input: args,
+    component: WithIconsTemplate,
+});
+WithIcons.args = {};
+WithIcons.parameters = {
+    docs: {
+        source: {
+            code: WithIconsCode,
+        },
+    },
+};

--- a/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
+++ b/src/components/ebay-toggle-button-group/toggle-button-group.stories.js
@@ -27,9 +27,9 @@ export default {
         variant: {
             type: "string",
             control: { type: "select" },
-            options: ["checkbox", "radio", "single"],
+            options: ["checkbox", "radio", "radio-toggle"],
             description:
-                'Selection type for the buttons in the group. May be `"checkbox"` (default), `"radio"`, or `"single"` (same as radio but with the option to deselect)',
+                'Selection type for the buttons in the group. May be `"checkbox"` (default), `"radio"`, or `"radio-toggle"` (same as radio but with the option to deselect)',
         },
         columns: {
             type: "number",

--- a/src/components/ebay-toggle-button/README.md
+++ b/src/components/ebay-toggle-button/README.md
@@ -1,8 +1,16 @@
-<h1 style='display: flex; justify-content: space-between; align-items: center;'>
+<h1 style="display: flex; justify-content: space-between; align-items: center;">
     <span>
-        undefined
+        ebay-toggle-button
     </span>
-    <span style='font-weight: normal; font-size: medium; margin-bottom: -15px;'>
+    <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
         DS v1.0.0
     </span>
 </h1>
+
+Group of toggle buttons.
+
+## Examples and Documentation
+
+-   [Storybook](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-toggle-button)
+-   [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/buttons-ebay-toggle-button)
+-   [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-toggle-button/examples)

--- a/src/components/ebay-toggle-button/component.js
+++ b/src/components/ebay-toggle-button/component.js
@@ -1,6 +1,6 @@
 export default class {
     onInput(input) {
-        this.state = { pressed: input.pressed };
+        this.state = { pressed: !!input.pressed };
     }
 
     handleClick(ev) {

--- a/src/components/ebay-toggle-button/examples/multiline-subtitle.marko
+++ b/src/components/ebay-toggle-button/examples/multiline-subtitle.marko
@@ -1,4 +1,5 @@
-<ebay-toggle-button title="Title" layoutType="list" ...input onToggle("emit", "toggle")>
+<ebay-toggle-button layoutType="list" ...input onToggle("emit", "toggle")>
+    Title
     <@subtitle>
         <p>Subtitle 1</p>
         <p>Subtitle 2</p>

--- a/src/components/ebay-toggle-button/examples/with-icon.marko
+++ b/src/components/ebay-toggle-button/examples/with-icon.marko
@@ -1,3 +1,5 @@
-<ebay-toggle-button title="Title" subtitle="Subtitle" layoutType="list" ...input onToggle("emit", "toggle")>
+<ebay-toggle-button layoutType="list" ...input onToggle("emit", "toggle")>
+    Title
+    <@subtitle>Subtitle</@subtitle>
     <@icon><ebay-archive-24-icon/></@icon>
 </ebay-toggle-button>

--- a/src/components/ebay-toggle-button/examples/with-image.marko
+++ b/src/components/ebay-toggle-button/examples/with-image.marko
@@ -1,4 +1,6 @@
 $ const { src, alt, fillPlacement, ...buttonInput } = input
-<ebay-toggle-button title="Title" subtitle="Subtitle" layoutType="list" ...buttonInput onToggle("emit", "toggle")>
+<ebay-toggle-button layoutType="list" ...buttonInput onToggle("emit", "toggle")>
+    Title
+    <@subtitle>Subtitle</@subtitle>
     <@img src=src alt=alt fillPlacement=fillPlacement />
 </ebay-toggle-button>

--- a/src/components/ebay-toggle-button/index.marko
+++ b/src/components/ebay-toggle-button/index.marko
@@ -44,7 +44,14 @@ static var ignoredAttributes = [
         </span>
     </else-if>
     <span class="toggle-button__content">
-        <span class="toggle-button__title">${input.title}</span>
+        <span class="toggle-button__title">
+            <if(input.title)>
+                ${input.title}
+            </if>
+            <else>
+                <${input.renderBody}/>
+            </else>
+        </span>
         <if(input.subtitle)>
             <span class="toggle-button__subtitle">
                 <if(typeof input.subtitle === "string")>

--- a/src/components/ebay-toggle-button/marko-tag.json
+++ b/src/components/ebay-toggle-button/marko-tag.json
@@ -7,6 +7,7 @@
     "@html-attributes": "expression",
     "@pressed": "boolean",
     "@title": "string",
+    "@layout-type": "string",
     "@subtitle <subtitle>": {
         "@*": {
             "targetProperty": null,

--- a/src/components/ebay-toggle-button/toggle-button.stories.js
+++ b/src/components/ebay-toggle-button/toggle-button.stories.js
@@ -24,7 +24,9 @@ export default {
         },
     },
     argTypes: {
-        renderBody: {},
+        renderBody: {
+            control: { type: "text" },
+        },
         layoutType: {
             type: "string",
             control: { type: "select" },
@@ -106,7 +108,7 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {
-    title: "Title",
+    renderBody: "Title",
 };
 
 Default.parameters = {


### PR DESCRIPTION
- Resolves #1908 

> **Warning**
> Must be tested while linked with the `2060-toggle-button-group` branch in `skin`.

## Description

- Add toggle button group to sync with ebay/skin#2095
- I snuck in a few changes for `toggle-button` as well, hopefully they're not too invasive.

## Screenshots

<img width="894" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/ff58c028-ca8c-4c55-b1ef-ff0df7045d41">
<img width="622" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/9489fd1c-b718-45e2-a137-574fb9e51b66">


