### PR TITLE
fix(calendar): issue with time zones

### DIFF
--- a/src/components/ebay-calendar/component.js
+++ b/src/components/ebay-calendar/component.js
@@ -461,8 +461,7 @@ export function toISO(date) {
  * @param {DayISO} iso
  */
 export function fromISO(iso) {
-    const [year, month, day] = iso.split("-");
-    return new Date(+year, +month - 1, +day);
+    return new Date(iso);
 }
 
 /**
@@ -470,10 +469,9 @@ export function fromISO(iso) {
  * @param {number} days
  */
 export function offsetISO(iso, days) {
-    const curr = fromISO(iso);
-    return toISO(
-        new Date(curr.getFullYear(), curr.getMonth(), curr.getDate() + days)
-    );
+    const date = fromISO(iso);
+    date.setDate(date.getDate() + days);
+    return toISO(date);
 }
 
 /**


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

JavaScript's native `Date` constructor does not always work as was expected across time zones, so `offsetISO` had a bug where in some cases it was one day behind. This meant that `offsetISO(date, 1)` sometimes returned the original date instead of the next day, which led to infinite loops in a few places.
