### PR TITLE
fix: added button type "button" for ebay-drawer-dialog handle

### DIFF
--- a/src/components/ebay-drawer-dialog/index.marko
+++ b/src/components/ebay-drawer-dialog/index.marko
@@ -23,6 +23,7 @@ $ var handleLabel = (!state.expanded ?
             <@top>
                 <button
                     aria-label=handleLabel
+                    type="button"
                     class=`drawer-dialog__handle`
                     onClick("handleExpand")
                     onTouchStart("handleTouchStart")

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-basic-version.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-basic-version.expected.html
@@ -12,6 +12,7 @@
       [36m<button[39m
         [33maria-label[39m=[32m"Maximize Drawer"[39m
         [33mclass[39m=[32m"drawer-dialog__handle"[39m
+        [33mtype[39m=[32m"button"[39m
       [36m/>[39m
       [36m<div[39m
         [33mclass[39m=[32m"drawer-dialog__header"[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-in-expanded-state.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-in-expanded-state.expected.html
@@ -12,6 +12,7 @@
       [36m<button[39m
         [33maria-label[39m=[32m"Minimize Drawer"[39m
         [33mclass[39m=[32m"drawer-dialog__handle"[39m
+        [33mtype[39m=[32m"button"[39m
       [36m/>[39m
       [36m<div[39m
         [33mclass[39m=[32m"drawer-dialog__header"[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-in-open-state.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-in-open-state.expected.html
@@ -11,6 +11,7 @@
       [36m<button[39m
         [33maria-label[39m=[32m"Maximize Drawer"[39m
         [33mclass[39m=[32m"drawer-dialog__handle"[39m
+        [33mtype[39m=[32m"button"[39m
       [36m/>[39m
       [36m<div[39m
         [33mclass[39m=[32m"drawer-dialog__header"[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-with-footer-version.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-with-footer-version.expected.html
@@ -12,6 +12,7 @@
       [36m<button[39m
         [33maria-label[39m=[32m"Maximize Drawer"[39m
         [33mclass[39m=[32m"drawer-dialog__handle"[39m
+        [33mtype[39m=[32m"button"[39m
       [36m/>[39m
       [36m<div[39m
         [33mclass[39m=[32m"drawer-dialog__header"[39m

--- a/src/components/ebay-drawer-dialog/test/__snapshots__/renders-with-text-close.expected.html
+++ b/src/components/ebay-drawer-dialog/test/__snapshots__/renders-with-text-close.expected.html
@@ -12,6 +12,7 @@
       [36m<button[39m
         [33maria-label[39m=[32m"Maximize Drawer"[39m
         [33mclass[39m=[32m"drawer-dialog__handle"[39m
+        [33mtype[39m=[32m"button"[39m
       [36m/>[39m
       [36m<div[39m
         [33mclass[39m=[32m"drawer-dialog__header"[39m

--- a/src/components/ebay-infotip/test/__snapshots__/renders-default.expected.html
+++ b/src/components/ebay-infotip/test/__snapshots__/renders-default.expected.html
@@ -46,6 +46,7 @@
             [36m<button[39m
               [33maria-label[39m=[32m"Maximize Drawer"[39m
               [33mclass[39m=[32m"drawer-dialog__handle"[39m
+              [33mtype[39m=[32m"button"[39m
             [36m/>[39m
             [36m<div[39m
               [33mclass[39m=[32m"drawer-dialog__header"[39m


### PR DESCRIPTION
## Description

Added `type="button"` to the ebay-drawer-dialog handle. Since by default without type any button inside a form will be treated as a "submit" button. This causes the handle to unintentionally submit a form wrapped around the dialog.

The close icon correctly already has `type="button"`:
https://github.com/eBay/ebayui-core/blob/84ba5f3ddb47105d4d3a0baba71941c181c6ef25/src/components/components/ebay-dialog-base/index.marko#L50-L69

## Context

I wrapped the drawer-dialog with a form, now the handle triggers the form submit, unless I specifically prevent it. What I cant prevent is that when in a form field enter is pressed, instead of submitting the form, the handle gets triggered.

Wrapping the dialog in a form is kind of necessary if you want to have the submit buttons in the footer, since the footer is only allowed as a direct child of the dialog component.

In any case, I think this change should be a no-brainer.

## Issue

fixes #1953
