### PR TITLE
feat(lightbox-dialog): added size and prev button

### DIFF
--- a/src/components/components/ebay-dialog-base/index.marko
+++ b/src/components/components/ebay-dialog-base/index.marko
@@ -1,7 +1,5 @@
-import { processHtmlAttributes } from "../../../common/html-attributes"
-
+import { processHtmlAttributes } from "../../../common/html-attributes";
 static const isBrowser = typeof window !== "undefined";
-
 static var ignoredAttributes = [
     "open",
     "type",
@@ -31,11 +29,10 @@ static var ignoredAttributes = [
     "rejectText",
     "noHandle",
     "top",
-    "action"
+    "action",
 ];
-
 static var ignoredHeaderAttributes = ["id", "as", "class"];
-
+static var ignoredPrevButtonAttributes = ["id", "class", "a11yText"];
 $ var buttonPosition = input.buttonPosition || "right";
 $ var baseEl = input.baseEl || "div";
 $ var header = input.header;
@@ -43,7 +40,8 @@ $ var header = input.header;
     <${header.as || "h2"}
         class=[header.class, `${input.classPrefix}__title`]
         ...processHtmlAttributes(header, ignoredHeaderAttributes)
-        id=(header.id || component.getElId("dialog-title"))>
+        id=header.id || component.getElId("dialog-title")
+    >
         <${header.renderBody}/>
     </>
 </macro>
@@ -51,11 +49,16 @@ $ var header = input.header;
     <if(buttonPosition !== "hidden")>
         <button
             key="close"
-            class=[input.closeButtonText ? "fake-link" : "icon-btn", input.closeButtonClass, `${input.classPrefix}__close` ]
+            class=[
+                input.closeButtonText ? "fake-link" : "icon-btn",
+                input.closeButtonClass,
+                `${input.classPrefix}__close`,
+            ]
             type="button"
             aria-label=input.a11yCloseText
-            onClick("handleCloseButtonClick")>
-            <if (input.closeButtonText)>
+            onClick("handleCloseButtonClick")
+        >
+            <if(input.closeButtonText)>
                 ${input.closeButtonText}
             </if>
             <else-if(input.closeButton)>
@@ -69,17 +72,16 @@ $ var header = input.header;
 </macro>
 <${baseEl}
     ...processHtmlAttributes(input, ignoredAttributes)
-    aria-labelledby=(
-        input.ariaLabelledby ||
-        (input.header && component.getElId("dialog-title"))
-    )
+    aria-labelledby=input.ariaLabelledby ||
+    (input.header && component.getElId("dialog-title"))
     aria-modal="true"
-    role=(input.role || "dialog")
+    role=input.role || "dialog"
     class=[input.classPrefix, input.class]
     hidden:no-update=!state.open
-    aria-live=(!input.isModal && "polite")
+    aria-live=!input.isModal && "polite"
     onClick("handleDialogClick")
-    onMousedown("handleStartClick")>
+    onMousedown("handleStartClick")
+>
     <if(state.open && isBrowser && !input.ignoreEscape)>
         <subscribe to=document on-keydown("handleKeydown")/>
     </if>
@@ -94,12 +96,31 @@ $ var header = input.header;
             input.windowType
                 ? `${input.classPrefix}__${input.windowType}-window`
                 : `${input.classPrefix}__window`,
-            input.windowClass
-        ]>
+            input.windowClass,
+        ]
+    >
         <if(input.top)>
             <${input.top.renderBody}/>
         </if>
         <div class=`${input.classPrefix}__header`>
+            <if(input.prevButton)>
+                <button
+                    ...processHtmlAttributes(
+                        input.prevButton,
+                        ignoredPrevButtonAttributes
+                    )
+                    class=[
+                        "icon-btn",
+                        "lightbox-dialog__prev",
+                        input.prevButton.class,
+                    ]
+                    type="button"
+                    aria-label=input.prevButton.a11yText
+                    on-click("emit", "prevButtonClick")
+                >
+                    <${input.prevButton}/>
+                </button>
+            </if>
             <if(header && buttonPosition === "right")>
                 <header-content/>
             </if>
@@ -117,7 +138,8 @@ $ var header = input.header;
             id=input.mainId
             class=`${input.classPrefix}__main`
             key="body"
-            onScroll("handleScroll")>
+            onScroll("handleScroll")
+        >
             <${input.renderBody}/>
         </div>
         <if(input.action)>

--- a/src/components/ebay-lightbox-dialog/examples/focus.marko
+++ b/src/components/ebay-lightbox-dialog/examples/focus.marko
@@ -3,6 +3,8 @@
     a11y-close-text='Close Dialog'
     open=state.open
     on-close('closeDialog')
+    on-open("emit", "open")
+    ...input
 >
     <@header>Heading</@header>
     <p>
@@ -13,13 +15,17 @@
 </ebay-lightbox-dialog>
 <ebay-button on-click('openDialog')>Open Dialog</ebay-button>
 class {
+    onInput(input) {
+        this.state = { open: input.open };
+    }
     onCreate() {
         this.state = { open: false };
     }
     openDialog() {
         this.state.open = true;
     }
-    closeDialog() {
+    closeDialog(e) {
         this.state.open = false;
+        this.emit("close", e);
     }
 }

--- a/src/components/ebay-lightbox-dialog/examples/scrolling.marko
+++ b/src/components/ebay-lightbox-dialog/examples/scrolling.marko
@@ -1,13 +1,16 @@
 class {
+    onInput(input) {
+        this.state = { open: input.open };
+    }
     onCreate() {
         this.state = { open: false };
     }
     openDialog() {
         this.state.open = true;
     }
-    closeDialog() {
+    closeDialog(e) {
         this.state.open = false;
-        this.emit("close");
+        this.emit("close", e);
     }
 }
 

--- a/src/components/ebay-lightbox-dialog/examples/with-footer.marko
+++ b/src/components/ebay-lightbox-dialog/examples/with-footer.marko
@@ -1,20 +1,43 @@
-<ebay-lightbox-dialog a11y-close-text='Close Dialog' open=state.open on-close('closeDialog')>
+<ebay-lightbox-dialog
+    a11y-close-text="Close Dialog"
+    open=state.open
+    on-close("closeDialog")
+    on-open("emit", "open")
+    ...input
+>
     <@header>Heading</@header>
     <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
-    <p><a href='http://www.ebay.com'>www.ebay.com</a></p>
-    <@footer><button.btn>Button 1</button><button.btn>Button 2</button></@footer>
+    <p>
+        <a href="http://www.ebay.com">
+            www.ebay.com
+        </a>
+    </p>
+    <@footer>
+        <button class="btn">
+            Button 1
+        </button>
+        <button class="btn">
+            Button 2
+        </button>
+    </@footer>
 </ebay-lightbox-dialog>
-<ebay-button on-click('openDialog')>Open Dialog</ebay-button>
+<ebay-button on-click("openDialog")>
+    Open Dialog
+</ebay-button>
 class {
+    onInput(input) {
+        this.state = { open: input.open };
+    }
     onCreate() {
         this.state = { open: false };
     }
     openDialog() {
         this.state.open = true;
     }
-    closeDialog() {
+    closeDialog(e) {
         this.state.open = false;
+        this.emit("close", e);
     }
 }

--- a/src/components/ebay-lightbox-dialog/examples/with-prev-button.marko
+++ b/src/components/ebay-lightbox-dialog/examples/with-prev-button.marko
@@ -1,31 +1,15 @@
-class {
-    onInput(input) {
-        this.state = { open: input.open };
-    }
-    onCreate(input) {
-        this.state = { open: input.open || false };
-    }
-    openDialog() {
-        this.state.open = true;
-    }
-    closeDialog(e) {
-        this.state.open = false;
-        this.emit("close", e);
-    }
-}
-
 <ebay-lightbox-dialog
     a11y-close-text="Close Dialog"
     open=state.open
     on-close("closeDialog")
     on-open("emit", "open")
+    on-prevButtonClick("emit", "prev-button-click")
     ...input
 >
-    <if(input.header && input.header.renderBody)>
-        <@header ...input.header>
-            <${input.header.renderBody}/>
-        </@header>
-    </if>
+    <@header>Heading</@header>
+    <@prev-button a11y-text="Go back">
+        <ebay-chevron-left-16-icon/>
+    </@prev-button>
     <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
@@ -35,7 +19,21 @@ class {
         </a>
     </p>
 </ebay-lightbox-dialog>
-
 <ebay-button on-click("openDialog")>
     Open Dialog
 </ebay-button>
+class {
+    onInput(input) {
+        this.state = { open: input.open };
+    }
+    onCreate() {
+        this.state = { open: false };
+    }
+    openDialog() {
+        this.state.open = true;
+    }
+    closeDialog(e) {
+        this.state.open = false;
+        this.emit("close", e);
+    }
+}

--- a/src/components/ebay-lightbox-dialog/index.marko
+++ b/src/components/ebay-lightbox-dialog/index.marko
@@ -1,5 +1,6 @@
 $ var isMini = input.variant === "_mini";
 $ var buttonPosition = input.buttonPosition || 'right';
+$ var validSizes = ['wide', 'narrow'];
 
 <ebay-dialog-base
     ...input
@@ -7,11 +8,15 @@ $ var buttonPosition = input.buttonPosition || 'right';
     class-prefix="lightbox-dialog"
     on-open("emit", "open")
     on-close("emit", "close")
+    on-prevButtonClick("emit", "prevButtonClick")
     button-position=buttonPosition
-    class=[input.class, "lightbox-dialog--mask-fade", input.bannerImgSrc && "lightbox-dialog--expressive"]
+    class=[input.class, "lightbox-dialog--mask-fade", input.bannerImgSrc && "lightbox-dialog--expressive",
+        validSizes.includes(input.size) && `lightbox-dialog--${input.size}`,
+    ]
     window-class=[
         "lightbox-dialog__window--fade",
-        isMini && "lightbox-dialog__window--mini"
+        isMini && "lightbox-dialog__window--mini",
+
     ]>
     <if(input.bannerImgSrc)>
         <@top>

--- a/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
+++ b/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
@@ -7,6 +7,10 @@ import Component from "./examples/default.marko";
 import code from "./examples/default.marko?raw";
 import ScrollingTemplate from "./examples/scrolling.marko";
 import ScrollingTemplateCode from "./examples/scrolling.marko?raw";
+import WithPrevButtonTemplate from "./examples/with-prev-button.marko";
+import WithPrevButtonCode from "./examples/with-prev-button.marko?raw";
+import WithFooterTemplate from "./examples/with-footer.marko";
+import WithFooterCode from "./examples/with-footer.marko?raw";
 
 const Template = (args) => ({
     input: addRenderBodies(args),
@@ -58,16 +62,35 @@ export default {
                 category: "@attribute tags",
             },
         },
+        prevButton: {
+            name: "@prevButton",
+            control: { type: "object" },
+            table: {
+                category: "@attribute tags",
+            },
+            description:
+                "Previous button, shows up before header. Usually a chevron-left icon.",
+        },
         bannerImgSrc: {
             control: { type: "text" },
             description: "Image source for the expressive variant",
+        },
+        size: {
+            options: ["regular", "wide", "narrow"],
+            description: "The size of the dialog",
+            table: {
+                defaultValue: {
+                    summary: "regular",
+                },
+            },
+            type: { category: "Options" },
         },
         bannerImgPosition: {
             control: { type: "text" },
             description:
                 "Position of the image within the given bounds using the CSS `background-position` property. Options include [keywords, lengths, and edge distances](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position)",
         },
-        onOpen: {
+        "on-open": {
             action: "on-open",
             description: "Triggered on dialog opened",
             table: {
@@ -77,9 +100,19 @@ export default {
                 },
             },
         },
-        onClose: {
+        "on-close": {
             action: "on-close",
             description: "Triggered on dialog closed.",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
+        "on-prev-button-click": {
+            action: "on-prev-button-click",
+            description: "Triggered when previous button is clicked",
             table: {
                 category: "Events",
                 defaultValue: {
@@ -98,6 +131,7 @@ Default.args = {
     footer: {
         renderBody: "",
     },
+    a11yCloseText: "Close dialog",
 };
 
 Default.parameters = {
@@ -133,3 +167,13 @@ Expressive.parameters = {
         },
     },
 };
+
+export const WithPrevButton = buildExtensionTemplate(
+    WithPrevButtonTemplate,
+    WithPrevButtonCode
+);
+
+export const WithFooter = buildExtensionTemplate(
+    WithFooterTemplate,
+    WithFooterCode
+);

--- a/src/components/ebay-lightbox-dialog/marko-tag.json
+++ b/src/components/ebay-lightbox-dialog/marko-tag.json
@@ -19,6 +19,16 @@
         },
         "@html-attributes": "expression"
     },
+    "@prevButton <prev-button>": {
+        "attribute-groups": ["html-attributes"],
+        "@*": {
+            "targetProperty": null,
+            "type": "expression"
+        },
+        "@a11y-text": "string",
+        "@html-attributes": "expression"
+    },
+
     "@footer <footer>": {
         "attribute-groups": ["html-attributes"],
         "@*": {

--- a/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-basic-version.expected.html
+++ b/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-basic-version.expected.html
@@ -1,0 +1,73 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"lightbox-dialog lightbox-dialog--mask-fade"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"lightbox-dialog__window lightbox-dialog__window--fade"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"lightbox-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading Text[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close dialog"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__footer"[39m
+      [36m/>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-expressive-version.expected.html
+++ b/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-expressive-version.expected.html
@@ -1,0 +1,79 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mbanner-img-position[39m=[32m"top"[39m
+    [33mbanner-img-src[39m=[32m"http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg"[39m
+    [33mclass[39m=[32m"lightbox-dialog lightbox-dialog--mask-fade lightbox-dialog--expressive"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"lightbox-dialog__window lightbox-dialog__window--fade"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__image"[39m
+        [33mstyle[39m=[32m"background-image:url(http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg);background-position:top;"[39m
+      [36m/>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"lightbox-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading Text[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__footer"[39m
+      [36m/>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-in-open-state.expected.html
+++ b/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-in-open-state.expected.html
@@ -1,0 +1,72 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"lightbox-dialog lightbox-dialog--mask-fade"[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"lightbox-dialog__window lightbox-dialog__window--fade"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"lightbox-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading Text[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close dialog"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__footer"[39m
+      [36m/>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-scrolling-dialog.expected.html
+++ b/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-scrolling-dialog.expected.html
@@ -1,0 +1,78 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"lightbox-dialog lightbox-dialog--mask-fade"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"lightbox-dialog__window lightbox-dialog__window--fade"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"lightbox-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidata...

--- a/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-size-narrow.expected.html
+++ b/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-size-narrow.expected.html
@@ -1,0 +1,74 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"lightbox-dialog lightbox-dialog--mask-fade lightbox-dialog--narrow"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+    [33msize[39m=[32m"narrow"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"lightbox-dialog__window lightbox-dialog__window--fade"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"lightbox-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading Text[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close dialog"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__footer"[39m
+      [36m/>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-size-wide.expected.html
+++ b/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-size-wide.expected.html
@@ -1,0 +1,74 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"lightbox-dialog lightbox-dialog--mask-fade lightbox-dialog--wide"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+    [33msize[39m=[32m"wide"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"lightbox-dialog__window lightbox-dialog__window--fade"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"lightbox-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading Text[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close dialog"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__footer"[39m
+      [36m/>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-with-header-and-footer.expected.html
+++ b/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-with-header-and-footer.expected.html
@@ -1,0 +1,84 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"lightbox-dialog lightbox-dialog--mask-fade"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"lightbox-dialog__window lightbox-dialog__window--fade"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__header"[39m
+      [36m>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"lightbox-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__footer"[39m
+      [36m>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn"[39m
+        [36m>[39m
+          [0mButton 1[0m
+        [36m</button>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn"[39m
+        [36m>[39m
+          [0mButton 2[0m
+        [36m</button>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-with-previous-button.expected.html
+++ b/src/components/ebay-lightbox-dialog/test/__snapshots__/renders-with-previous-button.expected.html
@@ -1,0 +1,96 @@
+[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33maria-labelledby[39m=[32m"s0-0-0-dialog-title"[39m
+    [33maria-modal[39m=[32m"true"[39m
+    [33mclass[39m=[32m"lightbox-dialog lightbox-dialog--mask-fade"[39m
+    [33mhidden[39m=[32m""[39m
+    [33mprev-button[39m=[32m"[object Object]"[39m
+    [33mrole[39m=[32m"dialog"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"lightbox-dialog__window lightbox-dialog__window--fade"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__header"[39m
+      [36m>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Go back"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__prev"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--chevron-left-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-chevron-left-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M3.293 8.708a1 1 0 0 1 0-1.415l6-6a1 1 0 0 1 1.414 1.414L5.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414l-6-6Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-chevron-left-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+        [36m<h2[39m
+          [33mclass[39m=[32m"lightbox-dialog__title"[39m
+          [33mid[39m=[32m"s0-0-0-dialog-title"[39m
+        [36m>[39m
+          [0mHeading[0m
+        [36m</h2>[39m
+        [36m<button[39m
+          [33maria-label[39m=[32m"Close Dialog"[39m
+          [33mclass[39m=[32m"icon-btn lightbox-dialog__close"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--close-16"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-close-16"[39m
+                [33mviewBox[39m=[32m"0 0 16 16"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mxlink:href[39m=[32m"#icon-close-16"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</button>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"lightbox-dialog__main"[39m
+      [36m>[39m
+        [36m<p>[39m
+          [0mLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.[0m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"http://www.ebay.com"[39m
+          [36m>[39m
+            [0mwww.ebay.com[0m
+          [36m</a>[39m
+        [36m</p>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+  [36m<button[39m
+    [33mclass[39m=[32m"btn btn--secondary"[39m
+    [33mdata-ebayui[39m=[32m""[39m
+    [33mtype[39m=[32m"button"[39m
+  [36m>[39m
+    [0mOpen Dialog[0m
+  [36m</button>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-lightbox-dialog/test/test.server.js
+++ b/src/components/ebay-lightbox-dialog/test/test.server.js
@@ -1,59 +1,46 @@
-import { expect, use } from "chai";
-import { render } from "@marko/testing-library";
+import { use } from "chai";
+import { composeStories } from "@storybook/marko/dist/testing";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import { testPassThroughAttributes } from "../../../common/test-utils/server";
-import template from "..";
-import * as mock from "./mock";
+import * as stories from "../lightbox-dialog.stories"; // import all stories from the stories file
+const { Default, Scrolling, Expressive, WithPrevButton, WithFooter } =
+    composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
 
 use(require("chai-dom"));
 
 describe("dialog", () => {
     it("renders basic version", async () => {
-        const input = mock.Dialog;
-        const { getByRole, getByLabelText, getByText } = await render(
-            template,
-            input
-        );
-        const dialog = getByRole("dialog", { hidden: true });
-
-        expect(dialog).has.attr("hidden");
-        expect(dialog).has.class("lightbox-dialog");
-        expect(getByLabelText(input.a11yCloseText)).has.class(
-            "lightbox-dialog__close"
-        );
-        expect(getByText(input.renderBody.text)).has.class(
-            "lightbox-dialog__main"
-        );
+        await htmlSnap(Default);
     });
 
     it("renders with header and footer", async () => {
-        const input = mock.headerFooterDialog;
-        const { getByRole, getByLabelText, getByText } = await render(
-            template,
-            input
-        );
-
-        const dialog = getByRole("dialog", { hidden: true });
-        expect(dialog).has.attr("hidden");
-        expect(dialog).has.class("lightbox-dialog");
-        expect(getByLabelText(input.a11yCloseText)).has.class(
-            "lightbox-dialog__close"
-        );
-        expect(getByText(input.renderBody.text)).has.class(
-            "lightbox-dialog__main"
-        );
-        expect(getByText(input.header.renderBody.text).parentElement).has.class(
-            "lightbox-dialog__header"
-        );
-        expect(getByText(input.footer.renderBody.text)).has.class(
-            "lightbox-dialog__footer"
-        );
+        await htmlSnap(WithFooter);
     });
 
     it("renders in open state", async () => {
-        const input = mock.dialogOpen;
-        const { getByRole } = await render(template, input);
-        expect(getByRole("dialog")).does.not.have.attr("hidden");
+        await htmlSnap(Default, { open: true });
     });
 
-    testPassThroughAttributes(template);
+    it("renders scrolling dialog", async () => {
+        await htmlSnap(Scrolling);
+    });
+
+    it("renders with previous button", async () => {
+        await htmlSnap(WithPrevButton);
+    });
+
+    it("renders expressive version", async () => {
+        await htmlSnap(Expressive);
+    });
+
+    it("renders size=wide", async () => {
+        await htmlSnap(Default, { size: "wide" });
+    });
+
+    it("renders size=narrow", async () => {
+        await htmlSnap(Default, { size: "narrow" });
+    });
+
+    testPassThroughAttributes(Default);
 });


### PR DESCRIPTION
## Description
* Added size=narrow and wide options
* Added prev button support
* Cleaned up tests and examples

## References
https://github.com/eBay/ebayui-core/issues/1955

## Screenshots
With prev button
<img width="746" alt="Screen Shot 2023-08-08 at 4 59 28 PM" src="https://github.com/eBay/ebayui-core/assets/1755269/25bf8e73-3580-44e2-ae4a-3bab98d30c39">

size=wide
<img width="1053" alt="Screen Shot 2023-08-08 at 4 59 46 PM" src="https://github.com/eBay/ebayui-core/assets/1755269/8ceb7c41-5584-4358-964e-3c0503a6d9a8">

size=narrow
<img width="569" alt="Screen Shot 2023-08-08 at 4 59 52 PM" src="https://github.com/eBay/ebayui-core/assets/1755269/794a3edf-98c1-4dec-b86d-6aaa1373f4a2">




