### PR TITLE
fix(calendar): timezone bug

### DIFF
--- a/src/components/ebay-calendar/calendar.stories.js
+++ b/src/components/ebay-calendar/calendar.stories.js
@@ -124,7 +124,7 @@ export default {
             type: "array",
             control: { type: "array" },
             description:
-                "List of specific days that are disabled. Should be a list of date objects, but also accepts timestamps or ISO strings",
+                "List of specific days that are disabled. Should be a list of ISO strings, but also accepts timestamps or `Date` objects",
             table: {
                 defaultValue: {
                     summary: "undefined",
@@ -135,7 +135,7 @@ export default {
             type: "callback",
             control: { type: "callback" },
             description:
-                "Function used to build the href for each date. The function is passed the date as a Date object, and should return a url string. For dates that don't have a link, the function should return a falsy value",
+                "Function used to build the href for each date. The function is passed the date as a `Date` object, and should return a url string. For dates that don't have a link, the function should return a falsy value",
             table: {
                 defaultValue: {
                     summary: "undefined",

--- a/src/components/ebay-calendar/component.js
+++ b/src/components/ebay-calendar/component.js
@@ -230,7 +230,11 @@ export default class extends Marko.Component {
      */
     getMonthDate(offset) {
         const baseDate = fromISO(this.state.baseISO);
-        return new Date(baseDate.getFullYear(), baseDate.getMonth() + offset);
+        const date = new Date(
+            baseDate.getUTCFullYear(),
+            baseDate.getUTCMonth() + offset
+        );
+        return date;
     }
 
     getFirstVisibleISO() {
@@ -241,8 +245,8 @@ export default class extends Marko.Component {
         const baseDate = fromISO(this.state.baseISO);
         return toISO(
             new Date(
-                baseDate.getFullYear(),
-                baseDate.getMonth() +
+                baseDate.getUTCFullYear(),
+                baseDate.getUTCMonth() +
                     this.state.offset +
                     (input.numMonths || 1),
                 0
@@ -470,7 +474,7 @@ export function fromISO(iso) {
  */
 export function offsetISO(iso, days) {
     const date = fromISO(iso);
-    date.setDate(date.getDate() + days);
+    date.setUTCDate(date.getUTCDate() + days);
     return toISO(date);
 }
 

--- a/src/components/ebay-calendar/component.js
+++ b/src/components/ebay-calendar/component.js
@@ -143,7 +143,7 @@ export default class extends Marko.Component {
         return (
             (this.state.disableBefore && iso < this.state.disableBefore) ||
             (this.state.disableAfter && iso > this.state.disableAfter) ||
-            this.state.disableWeekdays.includes(fromISO(iso).getDay()) ||
+            this.state.disableWeekdays.includes(fromISO(iso).getUTCDay()) ||
             this.state.disableList.includes(iso)
         );
     }

--- a/src/components/ebay-date-textbox/date-textbox.stories.js
+++ b/src/components/ebay-date-textbox/date-textbox.stories.js
@@ -67,7 +67,8 @@ export default {
         disableBefore: {
             type: "date",
             control: { type: "date" },
-            description: "First date that may be selected",
+            description:
+                "First date that may be selected. Should be an ISO string, but also accepts a timestamp or `Date` object",
             table: {
                 defaultValue: {
                     summary: "undefined",
@@ -77,7 +78,8 @@ export default {
         disableAfter: {
             type: "date",
             control: { type: "date" },
-            description: "Last date that may be selected",
+            description:
+                "Last date that may be selected. Should be an ISO string, but also accepts a timestamp or `Date` object",
             table: {
                 defaultValue: {
                     summary: "undefined",
@@ -99,7 +101,7 @@ export default {
             type: "array",
             control: { type: "array" },
             description:
-                "List of specific days that are disabled. Should be a list of date objects, but also accepts timestamps or ISO strings",
+                "List of specific days that are disabled. Should be a list of ISO strings, but also accepts timestamps or `Date` objects",
             table: {
                 defaultValue: {
                     summary: "undefined",


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->
- Fixes #1964 

## Description

- Fix bug for `disableWeekdays` in the `ebay-calendar` and `ebay-date-input` components.
