### PR TITLE
feat(date-textbox): add collapseOnSelect

### DIFF
--- a/src/components/ebay-date-textbox/component.js
+++ b/src/components/ebay-date-textbox/component.js
@@ -17,6 +17,7 @@ const MIN_WIDTH_FOR_DOUBLE_PANE = 600;
  *   disableWeekdays?: number[],
  *   disableList?: (Date | number | string)[],
  *   inputPlaceholderText?: string | [string, string],
+ *   collapseOnSelect?: boolean,
  *   getA11yShowMonthText?: (monthName: string) => string,
  *   a11yOpenPopoverText?: string,
  *   a11ySelectedText?: string,
@@ -46,6 +47,7 @@ export default class extends Marko.Component {
     }
 
     onMount() {
+        /** @type {any} */
         this.expander = new Expander(/** @type {HTMLElement} */ (this.el), {
             hostSelector: ".ebay-date-textbox--main > .icon-btn",
             contentSelector: ".date-textbox__popover",
@@ -131,7 +133,12 @@ export default class extends Marko.Component {
                 } else {
                     this.state.secondSelected = selected;
                 }
+                if (this.input.collapseOnSelect) {
+                    this.expander.expanded = false;
+                }
             }
+        } else if (this.input.collapseOnSelect) {
+            this.expander.expanded = false;
         }
 
         this.emitSelectedChange();

--- a/src/components/ebay-date-textbox/date-textbox.stories.js
+++ b/src/components/ebay-date-textbox/date-textbox.stories.js
@@ -108,6 +108,17 @@ export default {
                 },
             },
         },
+        collapseOnSelect: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description:
+                "Whether the calendar should collapse after a date is selected",
+            table: {
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
         getA11yShowMonthText: {
             type: "callback",
             control: { type: "callback" },


### PR DESCRIPTION
- Fixes #1971 

## Description

- Add `collapseOnSelect` option for date-textbox
- Defaults to `false` so this is not breaking, but maybe in the future it should default to `true` for single select and `false` for range
