### PR TITLE
docs: storybook sync up with event arguments

### DIFF
--- a/src/components/ebay-confirm-dialog/confirm-dialog.stories.js
+++ b/src/components/ebay-confirm-dialog/confirm-dialog.stories.js
@@ -56,7 +56,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },
@@ -66,7 +66,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },
@@ -76,7 +76,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },

--- a/src/components/ebay-drawer-dialog/drawer-dialog.stories.js
+++ b/src/components/ebay-drawer-dialog/drawer-dialog.stories.js
@@ -84,7 +84,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },
@@ -95,7 +95,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },
@@ -106,7 +106,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },
@@ -117,7 +117,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },

--- a/src/components/ebay-fake-menu-button/component.js
+++ b/src/components/ebay-fake-menu-button/component.js
@@ -46,12 +46,9 @@ export default {
             originalEvent,
             index,
         };
-        eventObj = Object.entries(eventObj)
-            .filter(([, value]) => value !== undefined)
-            .reduce((obj, [key, value]) => {
-                obj[key] = value;
-                return obj;
-            }, {});
+        eventObj = Object.fromEntries(
+            Object.entries(eventObj).filter(([, value]) => value !== undefined)
+        );
         this.emit(`${eventType}`, eventObj);
     },
 

--- a/src/components/ebay-fake-menu-button/component.js
+++ b/src/components/ebay-fake-menu-button/component.js
@@ -41,11 +41,17 @@ export default {
         this.emitComponentEvent({ eventType: "mousedown", el, originalEvent });
     },
     emitComponentEvent({ eventType, el, originalEvent, index }) {
-        const eventObj = {
+        let eventObj = {
             el,
             originalEvent,
             index,
         };
+        eventObj = Object.entries(eventObj)
+            .filter(([, value]) => value !== undefined)
+            .reduce((obj, [key, value]) => {
+                obj[key] = value;
+                return obj;
+            }, {});
         this.emit(`${eventType}`, eventObj);
     },
 

--- a/src/components/ebay-fake-menu-button/fake-menu-button.stories.js
+++ b/src/components/ebay-fake-menu-button/fake-menu-button.stories.js
@@ -153,7 +153,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ el, originalEvent, index }",
+                    summary: "",
                 },
             },
         },
@@ -163,7 +163,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ el, originalEvent, index }",
+                    summary: "",
                 },
             },
         },
@@ -174,7 +174,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ el, originalEvent, index }",
+                    summary: "",
                 },
             },
         },
@@ -213,7 +213,7 @@ Standard.args = {
 Standard.parameters = {
     docs: {
         source: {
-            code: tagToString("ebay-menu-button", Standard.args, {
+            code: tagToString("ebay-fake-menu-button", Standard.args, {
                 items: "item",
             }),
         },

--- a/src/components/ebay-page-notice/page-notice.stories.js
+++ b/src/components/ebay-page-notice/page-notice.stories.js
@@ -91,7 +91,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },

--- a/src/components/ebay-section-notice/section-notice.stories.js
+++ b/src/components/ebay-section-notice/section-notice.stories.js
@@ -92,7 +92,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ originalEvent }",
+                    summary: "",
                 },
             },
         },


### PR DESCRIPTION
## Description

Updated storybook documentation to sync up with the component events. Both DOM and component events are being emitted and storybook displays these events in actions tab. During this process for some component events, marko class information is being emitted. We decided to leave that extra information as is. Other-than that, the callback arguments were appropriately corrected in the storybook documentation.

## References
Fixes following 
#1930
#1892 
#1887
#1890

## Screenshots

**Page/Section notice**
<img width="1696" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/bec90f5e-d5af-4a1a-89da-61b58f4e1e72">
<img width="1696" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/8e91d183-1a82-4cfe-87d9-e65c50379c9e">

**Fake menu button**
<img width="1687" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/0e90dc85-439d-4950-9d71-bee8759a33d2">

**Confirm dialog**
<img width="1687" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/949823a3-14ce-43bb-87bf-3740710bca63">

**Drawer dialog**
<img width="1687" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/4e20baf8-4152-40a1-9139-7ef9ae69db28">


