### PR TITLE
feat(chip): add chip component

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Each layer does its bit to enforce and enhance accessibility. We consider this l
 -   [`ebay-carousel`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-carousel)
 -   [`ebay-character-count`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-character-count)
 -   [`ebay-checkbox`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-checkbox)
+-   [`ebay-chip`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-chip)
 -   [`ebay-combobox`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-combobox)
 -   [`ebay-cta-button`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-cta-button)
 -   [`ebay-date-textbox`](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-date-textbox)

--- a/src/components/ebay-chip/README.md
+++ b/src/components/ebay-chip/README.md
@@ -1,0 +1,16 @@
+<h1 style='display: flex; justify-content: space-between; align-items: center;'>
+    <span>
+        ebay-chip
+    </span>
+    <span style='font-weight: normal; font-size: medium; margin-bottom: -15px;'>
+        DS v1.0.0
+    </span>
+</h1>
+
+A discrete highlighted value.
+
+## Examples and Documentation
+
+-   [Storybook](https://ebay.github.io/ebayui-core/?path=/story/building-blocks-ebay-chip)
+-   [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/building-blocks-ebay-chip)
+-   [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-chip/examples)

--- a/src/components/ebay-chip/browser.json
+++ b/src/components/ebay-chip/browser.json
@@ -1,0 +1,9 @@
+{
+    "requireRemap": [
+        {
+            "from": "./style.js",
+            "to": "../../common/empty.js",
+            "if-flag": "ebayui-no-skin"
+        }
+    ]
+}

--- a/src/components/ebay-chip/chip.stories.js
+++ b/src/components/ebay-chip/chip.stories.js
@@ -1,0 +1,67 @@
+import { tagToString } from "../../../.storybook/storybook-code-source";
+import { addRenderBodies } from "../../../.storybook/utils";
+import Readme from "./README.md";
+import Component from "./index.marko";
+
+const Template = (args) => ({
+    input: addRenderBodies(args),
+});
+
+export default {
+    title: "building blocks/ebay-chip",
+    component: Component,
+    parameters: {
+        docs: {
+            description: {
+                component: Readme,
+            },
+        },
+    },
+
+    argTypes: {
+        renderBody: {
+            control: { type: "text" },
+            description: "Text to be displayed in the chip",
+        },
+        deleteButtonLabel: {
+            control: { type: "text" },
+            description:
+                "A11y text for the delete button, also determines if delete button is shown",
+        },
+        onDelete: {
+            action: "on-delete",
+            description: "Triggered when delete button is clicked",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "{ el, checked, originalEvent }",
+                },
+            },
+        },
+    },
+};
+
+export const Standard = Template.bind({});
+Standard.args = {
+    renderBody: "chip text",
+};
+Standard.parameters = {
+    docs: {
+        source: {
+            code: tagToString("ebay-chip", Standard.args),
+        },
+    },
+};
+
+export const WithDelete = Template.bind({});
+WithDelete.args = {
+    renderBody: "chip text",
+    deleteButtonLabel: "Delete",
+};
+WithDelete.parameters = {
+    docs: {
+        source: {
+            code: tagToString("ebay-chip", Standard.args),
+        },
+    },
+};

--- a/src/components/ebay-chip/chip.stories.js
+++ b/src/components/ebay-chip/chip.stories.js
@@ -23,7 +23,7 @@ export default {
             control: { type: "text" },
             description: "Text to be displayed in the chip",
         },
-        deleteButtonLabel: {
+        a11yDeleteButton: {
             control: { type: "text" },
             description:
                 "A11y text for the delete button, also determines if delete button is shown",
@@ -41,14 +41,14 @@ export default {
     },
 };
 
-export const Standard = Template.bind({});
-Standard.args = {
+export const Default = Template.bind({});
+Default.args = {
     renderBody: "chip text",
 };
-Standard.parameters = {
+Default.parameters = {
     docs: {
         source: {
-            code: tagToString("ebay-chip", Standard.args),
+            code: tagToString("ebay-chip", Default.args),
         },
     },
 };
@@ -56,12 +56,12 @@ Standard.parameters = {
 export const WithDelete = Template.bind({});
 WithDelete.args = {
     renderBody: "chip text",
-    deleteButtonLabel: "Delete",
+    a11yDeleteButton: "Delete",
 };
 WithDelete.parameters = {
     docs: {
         source: {
-            code: tagToString("ebay-chip", Standard.args),
+            code: tagToString("ebay-chip", WithDelete.args),
         },
     },
 };

--- a/src/components/ebay-chip/chip.stories.js
+++ b/src/components/ebay-chip/chip.stories.js
@@ -34,7 +34,7 @@ export default {
             table: {
                 category: "Events",
                 defaultValue: {
-                    summary: "{ el, checked, originalEvent }",
+                    summary: "[ Event, HTMLElement ]",
                 },
             },
         },

--- a/src/components/ebay-chip/index.marko
+++ b/src/components/ebay-chip/index.marko
@@ -1,16 +1,16 @@
-$ const textId = component.elId("text");
+import { processHtmlAttributes } from "../../common/html-attributes";
+$ const { renderBody, deleteButtonLabel, ...htmlAttributes } = input;
 
-<span class="chip">
-    <span class="chip__text" id=textId>
+<span class="chip" ...processHtmlAttributes(htmlAttributes)>
+    <span class="chip__text" id:scoped="text">
         <${input.renderBody}/>
     </span>
     <if(input.deleteButtonLabel)>
         <button
             type="button"
             class="chip__button"
-            type="button"
             aria-label=input.deleteButtonLabel
-            aria-describedby=textId
+            aria-describedby:scoped="text"
             on-click("emit", "delete")
         >
             <ebay-close-16-icon/>

--- a/src/components/ebay-chip/index.marko
+++ b/src/components/ebay-chip/index.marko
@@ -1,0 +1,19 @@
+$ const textId = component.elId("text");
+
+<span class="chip">
+    <span class="chip__text" id=textId>
+        <${input.renderBody}/>
+    </span>
+    <if(input.deleteButtonLabel)>
+        <button
+            type="button"
+            class="chip__button"
+            type="button"
+            aria-label=input.deleteButtonLabel
+            aria-describedby=textId
+            on-click("emit", "delete")
+        >
+            <ebay-close-16-icon/>
+        </button>
+    </if>
+</span>

--- a/src/components/ebay-chip/index.marko
+++ b/src/components/ebay-chip/index.marko
@@ -1,15 +1,15 @@
 import { processHtmlAttributes } from "../../common/html-attributes";
-$ const { renderBody, deleteButtonLabel, ...htmlAttributes } = input;
+$ const { renderBody, a11yDeleteButton, ...htmlAttributes } = input;
 
 <span class="chip" ...processHtmlAttributes(htmlAttributes)>
     <span class="chip__text" id:scoped="text">
-        <${input.renderBody}/>
+        <${renderBody}/>
     </span>
-    <if(input.deleteButtonLabel)>
+    <if(a11yDeleteButton)>
         <button
             type="button"
             class="chip__button"
-            aria-label=input.deleteButtonLabel
+            aria-label=a11yDeleteButton
             aria-describedby:scoped="text"
             on-click("emit", "delete")
         >

--- a/src/components/ebay-chip/index.marko
+++ b/src/components/ebay-chip/index.marko
@@ -2,7 +2,7 @@ import { processHtmlAttributes } from "../../common/html-attributes";
 $ const { renderBody, a11yDeleteButton, ...htmlAttributes } = input;
 
 <span class="chip" ...processHtmlAttributes(htmlAttributes)>
-    <span class="chip__text" id:scoped="text">
+    <span class="chip__text" id:scoped="title">
         <${renderBody}/>
     </span>
     <if(a11yDeleteButton)>

--- a/src/components/ebay-chip/marko-tag.json
+++ b/src/components/ebay-chip/marko-tag.json
@@ -5,5 +5,5 @@
         "type": "expression"
     },
     "@html-attributes": "expression",
-    "@delete-button-label": "string"
+    "@a11y-delete-button": "string"
 }

--- a/src/components/ebay-chip/marko-tag.json
+++ b/src/components/ebay-chip/marko-tag.json
@@ -1,0 +1,9 @@
+{
+    "attribute-groups": ["html-attributes"],
+    "@*": {
+        "targetProperty": null,
+        "type": "expression"
+    },
+    "@html-attributes": "expression",
+    "@delete-button-label": "string"
+}

--- a/src/components/ebay-chip/style.js
+++ b/src/components/ebay-chip/style.js
@@ -1,0 +1,1 @@
+require("@ebay/skin/chip");

--- a/src/components/ebay-chip/test/__snapshots__/renders-default-chip-component.expected.html
+++ b/src/components/ebay-chip/test/__snapshots__/renders-default-chip-component.expected.html
@@ -1,0 +1,12 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"chip"[39m
+  [36m>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"chip__text"[39m
+      [33mid[39m=[32m"s0-text"[39m
+    [36m>[39m
+      [0mchip text[0m
+    [36m</span>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-chip/test/__snapshots__/renders-with-close-icon-when-label-is-present.expected.html
+++ b/src/components/ebay-chip/test/__snapshots__/renders-with-close-icon-when-label-is-present.expected.html
@@ -1,0 +1,40 @@
+[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"chip"[39m
+  [36m>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"chip__text"[39m
+      [33mid[39m=[32m"s0-text"[39m
+    [36m>[39m
+      [0mchip text[0m
+    [36m</span>[39m
+    [36m<button[39m
+      [33maria-describedby[39m=[32m"s0-text"[39m
+      [33maria-label[39m=[32m"Delete"[39m
+      [33mclass[39m=[32m"chip__button"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [36m<svg[39m
+        [33maria-hidden[39m=[32m"true"[39m
+        [33mclass[39m=[32m"icon icon--close-16"[39m
+        [33mfocusable[39m=[32m"false"[39m
+      [36m>[39m
+        [36m<defs[39m
+          [33mdata-marko-key[39m=[32m"@defs s0-4-0"[39m
+        [36m>[39m
+          [36m<symbol[39m
+            [33mid[39m=[32m"icon-close-16"[39m
+            [33mviewBox[39m=[32m"0 0 16 16"[39m
+          [36m>[39m
+            [36m<path[39m
+              [33md[39m=[32m"M2.293 2.293a1 1 0 0 1 1.414 0L8 6.586l4.293-4.293a1 1 0 1 1 1.414 1.414L9.414 8l4.293 4.293a1 1 0 0 1-1.414 1.414L8 9.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L6.586 8 2.293 3.707a1 1 0 0 1 0-1.414Z"[39m
+            [36m/>[39m
+          [36m</symbol>[39m
+        [36m</defs>[39m
+        [36m<use[39m
+          [33mxlink:href[39m=[32m"#icon-close-16"[39m
+        [36m/>[39m
+      [36m</svg>[39m
+    [36m</button>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m

--- a/src/components/ebay-chip/test/test.browser.js
+++ b/src/components/ebay-chip/test/test.browser.js
@@ -1,0 +1,28 @@
+import { expect, use } from "chai";
+import chaiDom from "chai-dom";
+import { composeStories } from "@storybook/marko/dist/testing";
+import { render, fireEvent, cleanup } from "@marko/testing-library";
+import * as stories from "../chip.stories"; // import all stories from the stories file
+const { WithDelete } = composeStories(stories);
+
+use(chaiDom);
+afterEach(cleanup);
+
+/** @type import("@marko/testing-library").RenderResult */
+let component;
+
+describe("given delete button is present", () => {
+    beforeEach(async () => {
+        component = await render(WithDelete);
+    });
+
+    describe("when button is clicked", () => {
+        beforeEach(async () => {
+            await fireEvent.click(component.getByRole("button"));
+        });
+
+        it("then it emits the event with correct data", () => {
+            expect(component.emitted("delete")).has.length(1);
+        });
+    });
+});

--- a/src/components/ebay-chip/test/test.server.js
+++ b/src/components/ebay-chip/test/test.server.js
@@ -2,13 +2,13 @@ import { use } from "chai";
 import { composeStories } from "@storybook/marko/dist/testing";
 import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import * as stories from "../chip.stories"; // import all stories from the stories file
-const { Standard, WithDelete } = composeStories(stories);
+const { Default, WithDelete } = composeStories(stories);
 const htmlSnap = snapshotHTML(__dirname);
 
 use(require("chai-dom"));
 
 it("renders default chip component", async () => {
-    await htmlSnap(Standard);
+    await htmlSnap(Default);
 });
 
 it("renders with close icon when label is present", async () => {

--- a/src/components/ebay-chip/test/test.server.js
+++ b/src/components/ebay-chip/test/test.server.js
@@ -1,0 +1,16 @@
+import { use } from "chai";
+import { composeStories } from "@storybook/marko/dist/testing";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../chip.stories"; // import all stories from the stories file
+const { Standard, WithDelete } = composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
+
+use(require("chai-dom"));
+
+it("renders default chip component", async () => {
+    await htmlSnap(Standard);
+});
+
+it("renders with close icon when label is present", async () => {
+    await htmlSnap(WithDelete);
+});

--- a/src/components/ebay-chip/test/test.server.js
+++ b/src/components/ebay-chip/test/test.server.js
@@ -7,10 +7,12 @@ const htmlSnap = snapshotHTML(__dirname);
 
 use(require("chai-dom"));
 
-it("renders default chip component", async () => {
-    await htmlSnap(Default);
-});
+describe("ebay-chip", () => {
+    it("renders static default", async () => {
+        await htmlSnap(Default);
+    });
 
-it("renders with close icon when label is present", async () => {
-    await htmlSnap(WithDelete);
+    it("renders interactive close button when label is provided", async () => {
+        await htmlSnap(WithDelete);
+    });
 });


### PR DESCRIPTION
- Resolves #1973 

> **Note**
> - Must be tested in tandem with ebay/skin#2141

## Description

- Add `ebay-chip` component to ebayui-core

## Screenshots

<img width="132" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/96781cdc-1e13-4279-8b11-2e7fe53a1ecc">
<img width="122" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/2e2a212c-88e8-42f9-9d12-7408abadbe8a">
<img width="114" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/072c8797-58ca-4f5f-a8f9-464735a72a12">

