### PR TITLE
feat(section-notice): added education variant

### DIFF
--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -28,7 +28,7 @@ $ var prefixClass = input.prefixClass;
 <${input.root || 'section'}
     aria-labelledby=!input.noA11yLabel && component.elId('status')
     aria-roledescription=input.a11yRoleDescription
-    class=[prefixClass, input.class, input.status === 'education' && input.prominent && `${prefixClass}--prominent`]
+    class=[prefixClass, input.class, input.status === 'education' && input.prominent && `${prefixClass}--education`]
     ...processHtmlAttributes(input, ignoredAttributes)
 >
     <if(input.icon !== 'none')>

--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -1,4 +1,5 @@
 import { processHtmlAttributes } from '../../../common/html-attributes';
+import LightBulbIcon from '<ebay-lightbulb-24-icon>';
 static {
     var ignoredAttributes = [
         'status',
@@ -17,6 +18,8 @@ static {
         'mainRoot',
         'noA11yLabel',
         'a11yDismissText',
+        'educationIcon',
+        'prominent',
     ];
 }
 $ var status = input.status;
@@ -25,7 +28,7 @@ $ var prefixClass = input.prefixClass;
 <${input.root || 'section'}
     aria-labelledby=!input.noA11yLabel && component.elId('status')
     aria-roledescription=input.a11yRoleDescription
-    class=[prefixClass, input.class]
+    class=[prefixClass, input.class, input.status === 'education' && input.prominent ? `${prefixClass}--prominent` : '' ]
     ...processHtmlAttributes(input, ignoredAttributes)
 >
     <if(input.icon !== 'none')>
@@ -50,6 +53,12 @@ $ var prefixClass = input.prefixClass;
                     a11y-text=input.a11yIconText || input.a11yText
                     class=input.iconClass
                 />
+            </else-if>
+            <else-if(status === 'education' && input.type === 'section')>
+                <${input.educationIcon || LightBulbIcon}
+                    a11y-variant='label'
+                    a11y-text=input.a11yIconText || input.a11yText
+                    class=input.iconClass/>
             </else-if>
         </>
     </if>

--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -28,7 +28,7 @@ $ var prefixClass = input.prefixClass;
 <${input.root || 'section'}
     aria-labelledby=!input.noA11yLabel && component.elId('status')
     aria-roledescription=input.a11yRoleDescription
-    class=[prefixClass, input.class, input.status === 'education' && input.prominent ? `${prefixClass}--prominent` : '' ]
+    class=[prefixClass, input.class, input.status === 'education' && input.prominent && `${prefixClass}--prominent`]
     ...processHtmlAttributes(input, ignoredAttributes)
 >
     <if(input.icon !== 'none')>

--- a/src/components/components/ebay-notice-base/test/mock/index.js
+++ b/src/components/components/ebay-notice-base/test/mock/index.js
@@ -32,3 +32,13 @@ export const titleFooterNotice = {
         renderBody: createRenderBody("footer"),
     },
 };
+
+export const educationSectionNotice = {
+    prefixClass: "section-notice",
+    status: "education",
+    a11yText: "education label",
+    class: "section-notice--education",
+    renderBody: createRenderBody("body"),
+    type: "section",
+    prominent: true,
+};

--- a/src/components/components/ebay-notice-base/test/test.server.js
+++ b/src/components/components/ebay-notice-base/test/test.server.js
@@ -74,7 +74,7 @@ describe("notice-icon", () => {
         );
         expect(containerUsingLabel).has.class(input.class);
         expect(containerUsingLabel).has.class(
-            `${input.prefixClass}--prominent`
+            `${input.prefixClass}--education`
         );
 
         expect(getByLabelText(input.a11yText)).has.class("icon--lightbulb-24");

--- a/src/components/components/ebay-notice-base/test/test.server.js
+++ b/src/components/components/ebay-notice-base/test/test.server.js
@@ -63,6 +63,23 @@ describe("notice-icon", () => {
         expect(title).has.class(`${input.prefixClass}__title`);
     });
 
+    it("renders education notice", async () => {
+        const input = mock.educationSectionNotice;
+        const { getByLabelText } = await render(template, input);
+        const status = getByLabelText(input.a11yText).parentElement;
+        expect(status).has.class(`${input.prefixClass}__header`);
+
+        const containerUsingLabel = status.closest(
+            `[aria-labelledby="${status.id}"]`
+        );
+        expect(containerUsingLabel).has.class(input.class);
+        expect(containerUsingLabel).has.class(
+            `${input.prefixClass}--prominent`
+        );
+
+        expect(getByLabelText(input.a11yText)).has.class("icon--lightbulb-24");
+    });
+
     testPassThroughAttributes(template, {
         input: mock.defaultNotice,
     });

--- a/src/components/ebay-section-notice/examples/with-action.marko
+++ b/src/components/ebay-section-notice/examples/with-action.marko
@@ -3,7 +3,7 @@
         <div>Notice title</div>
     </@title>
     <@footer>
-        <div>H</div>
+        <ebay-fake-link>Footer</ebay-fake-link>
     </@footer>
     <p>
         <strong>Error:</strong> Please take another look at the following:

--- a/src/components/ebay-section-notice/examples/with-icon.marko
+++ b/src/components/ebay-section-notice/examples/with-icon.marko
@@ -1,0 +1,12 @@
+<ebay-section-notice ...input>
+    <@title>
+        <div>Notice title</div>
+    </@title>
+    <@educationIcon><ebay-the-ebay-vault-24-fit-icon a11y-text="ebay vault"/></@educationIcon>
+    <p>
+        The eBay vault will store items for you.
+    </p>
+    <p>
+        <a href="#">Try it</a>
+    </p>
+</ebay-section-notice>

--- a/src/components/ebay-section-notice/examples/with-icon.marko
+++ b/src/components/ebay-section-notice/examples/with-icon.marko
@@ -1,8 +1,8 @@
-<ebay-section-notice ...input>
+import TheVaultIcon from '<ebay-the-ebay-vault-24-fit-icon>'
+<ebay-section-notice ...input educationIcon=TheVaultIcon a11y-text="ebay vault">
     <@title>
         <div>Notice title</div>
     </@title>
-    <@educationIcon><ebay-the-ebay-vault-24-fit-icon a11y-text="ebay vault"/></@educationIcon>
     <p>
         The eBay vault will store items for you.
     </p>

--- a/src/components/ebay-section-notice/index.marko
+++ b/src/components/ebay-section-notice/index.marko
@@ -3,6 +3,7 @@
         ...input
         role='region'
         prefix-class='section-notice'
+        type='section'
         main-root='span'
         a11yRoleDescription=input.a11yRoleDescription || 'Notice'
         class=[input.status && `section-notice--${input.status}`, input.class]

--- a/src/components/ebay-section-notice/index.marko
+++ b/src/components/ebay-section-notice/index.marko
@@ -6,7 +6,7 @@
         type='section'
         main-root='span'
         a11yRoleDescription=input.a11yRoleDescription || 'Notice'
-        class=[input.status && `section-notice--${input.status}`, input.class]
+        class=[input.status === 'education' && 'section-notice--large-icon', input.class]
         on-dismiss('onDismiss')
     />
 </if>

--- a/src/components/ebay-section-notice/section-notice.stories.js
+++ b/src/components/ebay-section-notice/section-notice.stories.js
@@ -7,6 +7,8 @@ import Readme from "./README.md";
 import Component from "./index.marko";
 import withAction from "./examples/with-action.marko";
 import withActionCode from "./examples/with-action.marko?raw";
+import withIcon from "./examples/with-icon.marko";
+import withIconCode from "./examples/with-icon.marko?raw";
 import withDismiss from "./examples/with-dismiss.marko";
 import withDismissCode from "./examples/with-dismiss.marko?raw";
 
@@ -34,7 +36,7 @@ export default {
             },
 
             description: "The icon used and status of the notice",
-            options: ["attention", "confirmation", "information"],
+            options: ["attention", "confirmation", "information", "education"],
             type: "select",
         },
         icon: {
@@ -47,6 +49,28 @@ export default {
             type: "select",
             description:
                 'matches whatever is specified by the "status", or if none hides icon',
+        },
+        educationIcon: {
+            name: "@educationIcon",
+            description:
+                "For status education, an `<ebay-[name]-icon>` to show as the button's icon",
+            table: {
+                category: "Education tags",
+                defaultValue: {
+                    summary: "ebay-lightbulb-24-icon",
+                },
+            },
+        },
+        prominent: {
+            description:
+                "For status education, whether notice on the page should be prominent",
+            type: "boolean",
+            defaultValue: {
+                summary: "false",
+            },
+            table: {
+                category: "Education tags",
+            },
         },
         a11yText: {
             description: "adding description for the notice for a11y users",
@@ -147,5 +171,15 @@ export const WithDismiss = buildExtensionTemplate(
         a11yDismissText: "Dismiss Notice",
         status: "information",
         icon: null,
+    }
+);
+
+export const WithEducationIcon = buildExtensionTemplate(
+    withIcon,
+    withIconCode,
+    {
+        a11yText: "education",
+        status: "education",
+        prominent: false,
     }
 );

--- a/src/components/ebay-section-notice/test/test.server.js
+++ b/src/components/ebay-section-notice/test/test.server.js
@@ -15,7 +15,7 @@ describe("section-notice", () => {
         const containerUsingLabel = status.closest(
             `[aria-labelledby="${status.id}"]`
         );
-        expect(containerUsingLabel).has.class("section-notice--information");
+        expect(containerUsingLabel).has.class("section-notice");
 
         const content = getByText(input.renderBody.text);
         expect(content).has.class("section-notice__main");
@@ -23,7 +23,6 @@ describe("section-notice", () => {
 
         const container = content.parentElement;
         expect(container).has.class("section-notice");
-        expect(container).has.class("section-notice--information");
     });
 
     it("renders with light", async () => {
@@ -31,7 +30,6 @@ describe("section-notice", () => {
         const { getByText } = await render(template, input);
         const container = getByText(input.renderBody.text).parentElement;
         expect(container).has.class("section-notice");
-        expect(container).does.not.have.class("section-notice--attention");
 
         const footer = getByText(input.footer.renderBody.text);
         expect(footer).has.class("section-notice__footer");


### PR DESCRIPTION
## Description

Added education variant to `ebay-section-notice`. By default section notice with status education shows lightbulb icon but has the ability to override to a custom icon if needed. This specific variant also has the ability to make the notice prominent by setting the prominent tag.

## Context

#1975 

## References

[Skin Issue](https://github.com/eBay/skin/issues/1987)
[Figma](https://www.figma.com/file/zEBdEhbonrBOGzZ0fXzWvM/eBay-Design-System?node-id=90732%3A97760&t=N2QRCppwp2G1BjRO-11)

## Screenshots
**Default**
<img width="1680" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/3e9e2af7-bbc7-4abe-9d03-51013fc8dac2">

**With Prominence**
<img width="1680" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/737d20a6-e98a-46a0-b1f8-9e3e5409b1a0">

**With custom Icon**
<img width="1680" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/5b12ea24-71c6-419b-b99d-2f90bb4214cf">



