### PR TITLE
fix: added a check to not rerender dialog when closing/opening

### DIFF
--- a/src/components/components/ebay-dialog-base/component.js
+++ b/src/components/components/ebay-dialog-base/component.js
@@ -88,7 +88,9 @@ export default {
 
     onInput(input) {
         input.isModal = input.isModal !== false;
-        this.state = { open: input.open || false };
+        if (!this.isAnimating) {
+            this.state = { open: input.open || false };
+        }
     },
 
     onRender() {
@@ -197,11 +199,13 @@ export default {
                     this.rootEl.removeAttribute("hidden");
                     this._triggerFocus(focusEl);
                     this.emit("open");
+                    this.isAnimating = false;
                 } else {
                     this._triggerBodyScroll(false);
                     const activeElement = this.getActiveElement();
                     this.rootEl.setAttribute("hidden", "");
                     this.emit("close");
+                    this.isAnimating = false;
 
                     if (
                         // Skip restoring focus if the focused element was changed via the dialog-close event
@@ -228,6 +232,7 @@ export default {
                 if (!isFirstRender) {
                     this._prevFocusEl = this.getActiveElement(this.input);
                     this._triggerBodyScroll(true);
+                    this.isAnimating = true;
                     this.cancelTransition = transition(
                         {
                             el: this.rootEl,
@@ -237,11 +242,13 @@ export default {
                         onFinishTransition
                     );
                 } else {
+                    this.isAnimating = false;
                     this.rootEl.removeAttribute("hidden");
                     runTraps();
                 }
             } else {
                 if (!isFirstRender) {
+                    this.isAnimating = true;
                     this.cancelTransition = transition(
                         {
                             el: this.rootEl,
@@ -251,6 +258,7 @@ export default {
                         onFinishTransition
                     );
                 } else {
+                    this.isAnimating = false;
                     this.rootEl.setAttribute("hidden", "");
                 }
             }

--- a/src/components/components/ebay-dialog-base/test/test.browser.js
+++ b/src/components/components/ebay-dialog-base/test/test.browser.js
@@ -251,7 +251,10 @@ describe("given an open dialog", () => {
             });
 
             describe("when it is rerendered with the same input", () => {
-                beforeEach(async () => await component.rerender(input));
+                beforeEach(async () => {
+                    await new Promise((resolve) => setTimeout(resolve, 600));
+                    await component.rerender(input);
+                });
                 thenItIsOpen();
             });
         }

--- a/src/components/ebay-drawer-dialog/index.marko
+++ b/src/components/ebay-drawer-dialog/index.marko
@@ -10,6 +10,7 @@ $ var handleLabel = (!state.expanded ?
     on-scroll('handleScroll')
     on-open("emit", "open")
     on-close("emit", "close")
+    on-toggled("emit", "toggled")
     class=[
         input.class,
         "drawer-dialog--mask-fade-slow"


### PR DESCRIPTION
## Description
* Added a check if the dialog is animating. If so, then do not rerender the state.
* There was some issues with tests and timing, so I added a delay before the test

## References
#1984 