### PR TITLE
fix(breadcrumbs): added missing a11y text for collapsed button

### DIFF
--- a/src/components/ebay-breadcrumbs/breadcrumbs.stories.js
+++ b/src/components/ebay-breadcrumbs/breadcrumbs.stories.js
@@ -40,6 +40,10 @@ export default {
             },
             description: "heading tag for breadcrumb ",
         },
+        a11yMenuButtonText: {
+            control: { type: "text" },
+            description: "a11y text for the collapsed menu button",
+        },
         href: {
             name: "href",
             table: {
@@ -71,6 +75,7 @@ export const heading = Template.bind({});
 
 heading.args = {
     a11yHeadingText: "Current pages",
+    a11yMenuButtonText: "menu",
     items: [
         {
             href: "http://www.ebay.com/",

--- a/src/components/ebay-breadcrumbs/index.marko
+++ b/src/components/ebay-breadcrumbs/index.marko
@@ -22,7 +22,7 @@ $ var anyHref = (input.items || []).some((element) => element.href != null);
                         transparent
                         icon=DotsIcon
                         collapse-on-select
-                        a11y-text="menu"
+                        a11y-text=input.a11yMenuButtonText
                         on-select('handleMenuBreadcrumb')
                     >
                         <for|i| of=state.hiddenIndex>

--- a/src/components/ebay-breadcrumbs/index.marko
+++ b/src/components/ebay-breadcrumbs/index.marko
@@ -22,6 +22,7 @@ $ var anyHref = (input.items || []).some((element) => element.href != null);
                         transparent
                         icon=DotsIcon
                         collapse-on-select
+                        a11y-text="menu"
                         on-select('handleMenuBreadcrumb')
                     >
                         <for|i| of=state.hiddenIndex>

--- a/src/components/ebay-breadcrumbs/marko-tag.json
+++ b/src/components/ebay-breadcrumbs/marko-tag.json
@@ -7,6 +7,7 @@
     "@html-attributes": "expression",
     "@a11y-heading-text": "string",
     "@a11y-heading-tag": "string",
+    "@a11y-menu-button-text": "string",
     "@aria-labelledby": "never",
     "@role": "never",
     "@items <item>[]": {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

Fixed an accessibility issue where button doesn't have `aria-label` when collapsed.

## Context

#1987

## Screenshots

<img width="1110" alt="image" src="https://github.com/eBay/ebayui-core/assets/6342519/f7ebdcc0-9da0-40d4-a66b-1862c8af5534">
