### PR TITLE
fix(tourtip): removed unused events

### DIFF
--- a/src/components/ebay-tourtip/index.marko
+++ b/src/components/ebay-tourtip/index.marko
@@ -28,9 +28,7 @@ $ var pointer = input.pointer || "bottom";
         style-left=input.styleLeft
         style-top=input.styleTop
         style-right=input.styleRight
-        style-bottom=input.styleBottom
-        onBase-collapse("handleCollapse")
-        onBase-expand("handleExpand")>
+        style-bottom=input.styleBottom>
         <span
             ...processHtmlAttributes(input, ignoredAttributes)
             class=["tourtip", state.expanded && 'tourtip--expanded']>


### PR DESCRIPTION
## Description
* Removed tourtip events for expander. These were being listented to but in fact tourtip is not using expander. See https://github.com/eBay/ebayui-core/blob/master/src/components/components/ebay-tooltip-base/component-browser.js#L60
* These events were bring triggered if a nested component was using expander, like listbox, causing the tourtip to close prematurely. 


## References
https://github.com/eBay/ebayui-core/issues/1993
