### PR TITLE
feat(badge): add custom max value

### DIFF
--- a/src/components/ebay-badge/badge.stories.js
+++ b/src/components/ebay-badge/badge.stories.js
@@ -20,6 +20,16 @@ export default {
             type: "number",
             description: "Used as the number to be placed in the badge",
         },
+        max: {
+            type: "number",
+            table: {
+                defaultValue: {
+                    summary: 99,
+                },
+            },
+            description:
+                'Maximum displayed number on the badge, after which a `+` will be concatenated (e.g. "99+")',
+        },
         "aria-label": {
             description:
                 'A descriptive label of what the badge represents (e.g. "5 unread items")',

--- a/src/components/ebay-badge/index.marko
+++ b/src/components/ebay-badge/index.marko
@@ -2,12 +2,13 @@ import { processHtmlAttributes } from "../../common/html-attributes";
 
 static var ignoredAttributes = ["type", "number"];
 $ var number = Math.round(input.number);
+$ var max = Math.round(input.max ?? 99)
 
 <if(number > 0)>
     <span
         ...processHtmlAttributes(input, ignoredAttributes)
         role=(input.type !== "menu" && input.type !== "icon" && "img")
         class=["badge", input.class]>
-        ${number > 99 ? "99+" : number}
+        ${number > max ? `${max}+` : number}
     </span>
 </if>

--- a/src/components/ebay-badge/test/test.server.js
+++ b/src/components/ebay-badge/test/test.server.js
@@ -47,4 +47,9 @@ it("truncates when the value is greater than 99", async () => {
     expect(getByText(/\d+/)).has.text("99+");
 });
 
+it("truncates when the value is greater than custom max", async () => {
+    const { getByText } = await render(template, { number: 30, max: 10 });
+    expect(getByText(/\d+/)).has.text("10+");
+});
+
 testPassThroughAttributes(template, { input: { number: 1 } });


### PR DESCRIPTION
- Resolves #1995 

## Description

Added new `max` attribute to `ebay-badge` which enables truncation to values besides 99

## Context

I considered naming this `truncateAfter` instead of `max`, but this seems simpler. Let me know if there is opposition to this.

## Screenshots

<img width="57" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/487c15e6-eb6e-476d-9c4e-354ba3dc903d">

