### PR TITLE
docs(lightbox-dialog): add note

### DIFF
--- a/src/components/ebay-lightbox-dialog/README.md
+++ b/src/components/ebay-lightbox-dialog/README.md
@@ -7,6 +7,10 @@
     </span>
 </h1>
 
+## Notes / FAQ
+
+-   `@header` is _required_, and styles will break if you do not include it
+
 ## Examples and Documentation
 
 -   [Storybook](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-lightbox-dialog)

--- a/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
+++ b/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
@@ -49,10 +49,13 @@ export default {
         },
         header: {
             name: "@header",
+            type: { required: true },
             control: { type: "object" },
             table: {
                 category: "@attribute tags",
             },
+            description:
+                "The header text for the content of the dialog. This is a required attribute.",
         },
         footer: {
             name: "@footer",


### PR DESCRIPTION
## Description

I think it would be nice to add a "Notes / FAQ" section to the README for components that have frequent questions asked about them. What do you all think of this idea?

## Context

I spent more time debugging a component than I should have, even though we have run into this problem before