### PR TITLE
docs(storybook): updated event names to improve DX

### DIFF
--- a/src/components/ebay-3d-viewer/3dViewer.stories.js
+++ b/src/components/ebay-3d-viewer/3dViewer.stories.js
@@ -108,7 +108,7 @@ export default {
                 },
             },
         },
-        onLoadError: {
+        "onLoad-error": {
             action: "on-load-error",
             description: "Triggered when loading error happens",
             table: {
@@ -118,7 +118,7 @@ export default {
                 },
             },
         },
-        "on-model-visibility": {
+        "onModel-visibility": {
             action: "on-model-visibility",
             description: "Triggered when model is visible",
             table: {
@@ -128,7 +128,7 @@ export default {
                 },
             },
         },
-        "on-render-scale": {
+        "onRender-scale": {
             action: "on-render-scale",
             description: "Triggered when model scales",
             table: {
@@ -138,7 +138,7 @@ export default {
                 },
             },
         },
-        "on-poster-dismissed": {
+        "onPoster-dismissed": {
             action: "on-poster-dismissed",
             description:
                 "Triggered when there's a placeholder image and it is removed",

--- a/src/components/ebay-calendar/calendar.stories.js
+++ b/src/components/ebay-calendar/calendar.stories.js
@@ -1,0 +1,283 @@
+import {
+    addRenderBodies,
+    buildExtensionTemplate,
+} from "../../../.storybook/utils";
+import { tagToString } from "../../../.storybook/storybook-code-source";
+import Readme from "./README.md";
+import Component from "./index.marko";
+import WithLinksTemplate from "./examples/links.marko";
+import WithLinksTemplateCode from "./examples/links.marko?raw";
+import WithSpecificLinksTemplate from "./examples/linkMap.marko";
+import WithSpecificLinksTemplateCode from "./examples/linkMap.marko?raw";
+
+const Template = (args) => ({
+    input: addRenderBodies(args),
+});
+
+export default {
+    title: "building blocks/ebay-calendar",
+    component: Component,
+    parameters: {
+        docs: {
+            description: {
+                component: Readme,
+            },
+        },
+    },
+
+    argTypes: {
+        navigable: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description:
+                "If true, a header is included that allows for navigation between months",
+            table: {
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
+        interactive: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description:
+                "Date cells are contained in buttons for interactive calendars, and spans otherwise",
+            table: {
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
+        numMonths: {
+            type: "number",
+            control: { type: "number" },
+            description: "Number of months to be displayed at once",
+            table: {
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
+        range: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description: "True if selecting a range, false if a single value",
+            table: {
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
+        selected: {
+            type: "text|array",
+            control: { type: "object" },
+            description:
+                "Date or list of dates that are selected, represented as an ISO string or an array of ISO strings",
+            table: {
+                defaultValue: {
+                    summary: "undefined",
+                },
+            },
+        },
+        locale: {
+            type: "text",
+            control: { type: "text" },
+            description: "Locale of the date picker",
+            table: {
+                defaultValue: {
+                    summary: "navigator.language",
+                },
+            },
+        },
+        disableBefore: {
+            type: "date",
+            control: { type: "date" },
+            description: "First date that may be selected",
+            table: {
+                defaultValue: {
+                    summary: "undefined",
+                },
+            },
+        },
+        disableAfter: {
+            type: "date",
+            control: { type: "date" },
+            description: "Last date that may be selected",
+            table: {
+                defaultValue: {
+                    summary: "undefined",
+                },
+            },
+        },
+        disableWeekdays: {
+            type: "array",
+            control: { type: "array" },
+            description:
+                "List of weekdays that are disabled. Must be an array of numbers, where Sunday is `0` and Saturday is `6`",
+            table: {
+                defaultValue: {
+                    summary: "undefined",
+                },
+            },
+        },
+        disableList: {
+            type: "array",
+            control: { type: "array" },
+            description:
+                "List of specific days that are disabled. Should be a list of ISO strings, but also accepts timestamps or `Date` objects",
+            table: {
+                defaultValue: {
+                    summary: "undefined",
+                },
+            },
+        },
+        linkBuilder: {
+            type: "callback",
+            control: { type: "callback" },
+            description:
+                "Function used to build the href for each date. The function is passed the date as a `Date` object, and should return a url string. For dates that don't have a link, the function should return a falsy value",
+            table: {
+                defaultValue: {
+                    summary: "undefined",
+                },
+            },
+        },
+        getA11yShowMonthText: {
+            type: "callback",
+            control: { type: "callback" },
+            description:
+                "Function used to get the text for showing previous and next months",
+            table: {
+                defaultValue: {
+                    summary: "(monthName) => `Show ${monthName}`",
+                },
+            },
+        },
+        a11ySelectedText: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Text to be read by screen readers when a date is selected",
+            table: {
+                defaultValue: {
+                    summary: "selected",
+                },
+            },
+        },
+        a11yRangeStartText: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Text to be read by screen readers when a date is the start of a range",
+            table: {
+                defaultValue: {
+                    summary: "start of range",
+                },
+            },
+        },
+        a11yInRangeText: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Text to be read by screen readers when a date is in a range",
+            table: {
+                defaultValue: {
+                    summary: "in range",
+                },
+            },
+        },
+        a11yRangeEndText: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Text to be read by screen readers when a date is the end of a range",
+            table: {
+                defaultValue: {
+                    summary: "end of range",
+                },
+            },
+        },
+        a11yTodayText: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Text to be read by screen readers when a date is the current date",
+            table: {
+                defaultValue: {
+                    summary: "today",
+                },
+            },
+        },
+        a11yDisabledText: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Text to be read by screen readers when a date is disabled",
+            table: {
+                defaultValue: {
+                    summary: "inactive",
+                },
+            },
+        },
+        a11ySeparator: {
+            type: "text",
+            control: { type: "text" },
+            description:
+                "Text to be read by screen readers to separate properties",
+            table: {
+                defaultValue: {
+                    summary: " - ",
+                },
+            },
+        },
+        onSelect: {
+            action: "on-select",
+            description: "Triggered when a date is selected",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "{ iso }",
+                },
+            },
+        },
+        "onMonth-change": {
+            action: "on-month-change",
+            description: "Triggered during month navigation",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "{ iso }",
+                },
+            },
+        },
+        onFocus: {
+            action: "on-focus",
+            description:
+                "Triggered when a day is focused on, typically via keyboard events",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "{ iso }",
+                },
+            },
+        },
+    },
+};
+
+export const Default = Template.bind({});
+Default.parameters = {
+    docs: {
+        source: {
+            code: tagToString("ebay-calendar", {}),
+        },
+    },
+};
+
+export const WithLinks = buildExtensionTemplate(
+    WithLinksTemplate,
+    WithLinksTemplateCode
+);
+export const WithSpecificLinks = buildExtensionTemplate(
+    WithSpecificLinksTemplate,
+    WithSpecificLinksTemplateCode
+);

--- a/src/components/ebay-carousel/carousel.stories.js
+++ b/src/components/ebay-carousel/carousel.stories.js
@@ -158,7 +158,7 @@ export default {
         //     'Badge (only with variant=icon)'
         //     )
         // },
-        onCarouselUpdate: {
+        "onCarousel-update": {
             action: "on-carousel-update",
             description:
                 "called whenever item visibility changes, including initialization",

--- a/src/components/ebay-combobox/combobox.stories.js
+++ b/src/components/ebay-combobox/combobox.stories.js
@@ -117,7 +117,7 @@ export default {
 
             description: "same as the `onChange` event, which fires on blur",
         },
-        onInputChange: {
+        "onInput-change": {
             action: "on-input-change",
             table: {
                 category: "Events",
@@ -139,7 +139,7 @@ export default {
             description:
                 "similar to a `<select>`, which fires when an option is clicked or selected",
         },
-        onFloatingLabelInit: {
+        "onFloating-label-init": {
             action: "on-floating-label-init",
             table: {
                 category: "Events",

--- a/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
+++ b/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
@@ -123,8 +123,8 @@ export default {
                 },
             },
         },
-        "onPrev-button-click": {
-            action: "on-prev-button-click",
+        onPrevButtonClick: {
+            action: "on-prevButtonClick",
             description: "Triggered when previous button is clicked",
             table: {
                 category: "Events",

--- a/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
+++ b/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.js
@@ -103,7 +103,7 @@ export default {
             description:
                 "A11y text for draggable handle when dialog is minimized and clicking handle will maximize the dialog (small screen only).",
         },
-        "on-open": {
+        onOpen: {
             action: "on-open",
             description: "Triggered on dialog opened",
             table: {
@@ -113,7 +113,7 @@ export default {
                 },
             },
         },
-        "on-close": {
+        onClose: {
             action: "on-close",
             description: "Triggered on dialog closed.",
             table: {
@@ -123,7 +123,7 @@ export default {
                 },
             },
         },
-        "on-prev-button-click": {
+        "onPrev-button-click": {
             action: "on-prev-button-click",
             description: "Triggered when previous button is clicked",
             table: {

--- a/src/components/ebay-textbox/textbox.stories.js
+++ b/src/components/ebay-textbox/textbox.stories.js
@@ -115,7 +115,7 @@ export default {
                 },
             },
         },
-        onInputChange: {
+        "onInput-change": {
             action: "on-input-change",
             description: "Triggered when the value of the input is changed",
             table: {

--- a/src/components/ebay-video/video.stories.js
+++ b/src/components/ebay-video/video.stories.js
@@ -96,7 +96,7 @@ export default {
                 category: "@attribute tags",
             },
         },
-        onLoadError: {
+        "onLoad-error": {
             action: "on-load-error",
             description:
                 "Triggered when there is a load error with video player or source",


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

Updated event handler names to improve consistency and DX across storybook stories.
- Two-word events are refactored to use camel case e.g `onClick`
- More than two-word events are refactored to use hyphen after first two words e.g `onInput-change`
- I refactored all the stories except `ebay-video`

## References

Fixes #1958 
