### PR TITLE
fix(ts): include global .d.ts files in dist

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -40,3 +40,13 @@ fs.writeFileSync(
     markoConfigPath,
     fs.readFileSync(markoConfigPath, "utf-8").replace(/\.\/src\//g, "./dist/"),
 );
+
+// copy over `types.d.ts` and `makeup.d.ts` files
+fs.copyFileSync(
+    path.join(rootDir, "src/types.d.ts"),
+    path.join(rootDir, "dist/types.d.ts"),
+);
+fs.copyFileSync(
+    path.join(rootDir, "src/makeup.d.ts"),
+    path.join(rootDir, "dist/makeup.d.ts"),
+);


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Global types from `types.d.ts` and `makeup.d.ts` were not copied into `dist` automatically by `mtc` or `tsc`, so they needed to be copied automatically.

