### PR TITLE
feat(date-textbox): allow clear by setting value to null

### DIFF
--- a/src/components/ebay-date-textbox/component.ts
+++ b/src/components/ebay-date-textbox/component.ts
@@ -66,7 +66,7 @@ class DateTextbox extends Marko.Component<Input, State> {
     }
 
     onInput(input: Input) {
-        if (input.value) {
+        if (input.value !== undefined) {
             this.state.firstSelected = dateArgToISO(input.value);
         }
         if (input.rangeEnd) {

--- a/src/components/ebay-date-textbox/date-textbox.stories.ts
+++ b/src/components/ebay-date-textbox/date-textbox.stories.ts
@@ -7,6 +7,8 @@ import Readme from "./README.md";
 import Component from "./index.marko";
 import LocalizedTemplate from "./examples/localized.marko";
 import LocalizedTemplateCode from "./examples/localized.marko?raw";
+import WithClearTemplate from "./examples/with-clear.marko";
+import WithClearTemplateCode from "./examples/with-clear.marko?raw";
 
 const Template = (args) => ({
     input: addRenderBodies(args),
@@ -223,5 +225,10 @@ Default.parameters = {
 
 export const Localized = buildExtensionTemplate(
     LocalizedTemplate,
-    LocalizedTemplateCode
+    LocalizedTemplateCode,
+);
+
+export const WithClear = buildExtensionTemplate(
+    WithClearTemplate,
+    WithClearTemplateCode,
 );

--- a/src/components/ebay-date-textbox/examples/with-clear.marko
+++ b/src/components/ebay-date-textbox/examples/with-clear.marko
@@ -1,0 +1,21 @@
+class {
+    onCreate() {
+        this.state = {
+            value: null,
+        };
+    }
+
+    handleChange({ selected }) {
+        this.state.value = selected;
+    }
+
+    clear() {
+        this.state.value = null;
+    }
+}
+
+<ebay-date-textbox value=state.value onChange("handleChange")/>
+
+<ebay-button onClick("clear")>
+    Clear
+</ebay-button>


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

- resolves #2036 

## Description

- Allow textbox to be cleared by setting `value` to `null`

## Screenshots

<img width="427" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/609929fc-fb77-4808-8437-12630f99ea02">
