### PR TITLE
fix(date-textbox): pass 'range' to calendar

### DIFF
--- a/src/components/ebay-date-textbox/index.marko
+++ b/src/components/ebay-date-textbox/index.marko
@@ -39,6 +39,7 @@ $ const [rangeStartPlaceholder, mainPlaceholder] = (
         </if>
         <ebay-calendar
             ...calendarInput
+            range=range
             interactive
             navigable
             numMonths=state.numMonths


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Pass `range` also to `ebay-calendar` to proper render the range

## Context

`...calendarInput` doesn't have `range` included since it is used also on date-textbox, so it needs to be passed down

## Screenshots

Before:

<img width="685" alt="Screen Shot 2024-01-09 at 5 39 17 PM" src="https://github.com/eBay/ebayui-core/assets/2222191/70d8c93c-df4d-4e37-b799-ff1b6f2a000a">

After:
<img width="685" alt="Screen Shot 2024-01-09 at 5 39 36 PM" src="https://github.com/eBay/ebayui-core/assets/2222191/d7559593-097d-4e36-9ca3-9dbe5ee5053d">

