### PR TITLE
feat(date-textbox): allow server rendering w/ document === undefined

### DIFF
--- a/src/components/ebay-date-textbox/component.ts
+++ b/src/components/ebay-date-textbox/component.ts
@@ -49,7 +49,9 @@ class DateTextbox extends Marko.Component<Input, State> {
             popover: false,
         };
 
-        this.calculateNumMonths();
+        if (typeof document !== "undefined") {
+            this.calculateNumMonths();
+        }
     }
 
     onMount() {
@@ -79,7 +81,6 @@ class DateTextbox extends Marko.Component<Input, State> {
 
     calculateNumMonths() {
         this.state.numMonths =
-            typeof document !== "undefined" &&
             document.documentElement.clientWidth < MIN_WIDTH_FOR_DOUBLE_PANE
                 ? 1
                 : 2;

--- a/src/components/ebay-date-textbox/component.ts
+++ b/src/components/ebay-date-textbox/component.ts
@@ -79,6 +79,7 @@ class DateTextbox extends Marko.Component<Input, State> {
 
     calculateNumMonths() {
         this.state.numMonths =
+            typeof document !== "undefined" &&
             document.documentElement.clientWidth < MIN_WIDTH_FOR_DOUBLE_PANE
                 ? 1
                 : 2;


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

When date textbox is server-rendered, it produces an error because document is not defined.