### PR TITLE
fix(breadcrumb): use right arguments

### DIFF
--- a/src/components/ebay-breadcrumbs/component.ts
+++ b/src/components/ebay-breadcrumbs/component.ts
@@ -25,12 +25,12 @@ class Breadcrumbs extends Marko.Component<Input, State> {
     declare cachedWidths: number[];
     declare newInput: boolean;
 
-    handleClick({ originalEvent }: MenuEvent) {
+    handleClick(originalEvent: KeyboardEvent) {
         this.emit("select", { originalEvent, el: originalEvent?.target });
     }
 
-    handleMenuBreadcrumb({ originalEvent, el }: MenuEvent) {
-        this.emit("select", { originalEvent, el });
+    handleMenuBreadcrumb(originalEvent: MenuEvent) {
+        this.emit("select", { originalEvent, el: originalEvent?.el });
     }
 
     onCreate() {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

<!--- What are the changes? -->
Fixes the arguments being emitted. This also brings in the fix made here https://github.com/eBay/ebayui-core/pull/2015

Reproducible here https://opensource.ebay.com/ebayui-core/?path=/docs/navigation-disclosure-ebay-breadcrumbs--documentation

## Context

<!--- Why did you make these changes, and why in this particular way? -->

## References

<!-- Include links to JIRA, Github, etc. if appropriate. -->

## Screenshots

<!-- Upload screenshots if appropriate. -->
<img width="490" alt="Screen Shot 2024-01-11 at 2 46 50 PM" src="https://github.com/eBay/ebayui-core/assets/5200733/59dc5d57-5bf7-44bc-8d46-fa6a8d797227">