### PR TITLE
fix(tooltip-base): added a check in case tooltip is not initialized

### DIFF
--- a/src/components/components/ebay-tooltip-base/component-browser.ts
+++ b/src/components/components/ebay-tooltip-base/component-browser.ts
@@ -40,7 +40,9 @@ class TooltipBase extends Marko.Component<Input> {
 
     handleExpand() {
         this.emit("base-expand");
-        this.updateTip();
+        if (this.hostEl && this.overlayEl) {
+            this.updateTip();
+        }
     }
 
     handleCollapse() {


### PR DESCRIPTION

## Description
* Added check if host is defined before expanding tooltip

## References
https://github.com/eBay/ebayui-core/issues/2053