### PR TITLE
feat(listbox-button): added error state

### DIFF
--- a/src/components/ebay-listbox-button/component.ts
+++ b/src/components/ebay-listbox-button/component.ts
@@ -19,6 +19,7 @@ interface ListboxButtonInput extends Omit<Marko.Input<"div">, `on${string}`> {
     disabled?: boolean;
     "button-name"?: string;
     invalid?: boolean;
+    hasError?: boolean;
     "prefix-label"?: string;
     "collapse-on-select"?: boolean;
     "on-expand"?: () => void;

--- a/src/components/ebay-listbox-button/examples/with-error.marko
+++ b/src/components/ebay-listbox-button/examples/with-error.marko
@@ -1,0 +1,12 @@
+<span class="field">
+    <ebay-listbox-button name="formFieldName" hasError aria-describedby:scoped="listbox-description">
+        <@option value="1" text="Option 1" selected/>
+        <@option value="2" text="Option 2"/>
+        <@option value="3" text="Option 3"/>
+    </ebay-listbox-button>
+
+    <div class="field__description field__description--attention" id:scoped="listbox-description">
+        <ebay-attention-filled-16-icon/>
+        <span>There was an error</span>
+    </div>
+</span>

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -18,6 +18,8 @@ $ const {
     collapseOnSelect,
     listSelection,
     variant,
+    hasError,
+    ariaDescribedby: describedby,
     ...htmlInput
 } = input;
 
@@ -30,7 +32,7 @@ $ var isForm = variant === 'form';
 <${truncate && !fluid ? "div" : "span"}
     ...processHtmlAttributes(htmlInput)
     key="container"
-    class=["listbox-button", inputClass, fluid && "listbox-button--fluid", isForm && `listbox-button--form`]
+    class=["listbox-button", inputClass, fluid && "listbox-button--fluid", isForm && `listbox-button--form`, hasError && 'listbox-button--error']
     on-expander-expand("handleExpand")
     on-expander-collapse("handleCollapse")>
     <button
@@ -48,6 +50,7 @@ $ var isForm = variant === 'form';
         disabled=disabled
         name=buttonName
         aria-haspopup="listbox"
+        aria-describedby=describedby
         aria-labelledby=(labelId && `${prefixId} ${labelId}`)
         aria-invalid=(invalid && "true")>
         <span class="btn__cell">

--- a/src/components/ebay-listbox-button/listbox-button.stories.ts
+++ b/src/components/ebay-listbox-button/listbox-button.stories.ts
@@ -7,6 +7,10 @@ import Readme from "./README.md";
 import Component from "./index.marko";
 import WithDescriptionTemplate from "./examples/with-description.marko";
 import WithDescriptionTemplateCode from "./examples/with-description.marko?raw";
+import WithErrorTemplate from "./examples/with-error.marko";
+import WithErrorTemplateCode from "./examples/with-error.marko?raw";
+
+
 
 const Template = (args) => ({
     input: addRenderBodies(args),
@@ -48,6 +52,11 @@ export default {
             control: { type: "boolean" },
             description:
                 "will truncate the text of the button onto a single line, and adds an ellipsis, when the buttons text overflows",
+        },
+        hasError: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description: "whether listbox is in an error state or not",
         },
         collapseOnSelect: {
             type: "boolean",
@@ -176,3 +185,9 @@ export const withDescription = buildExtensionTemplate(
     WithDescriptionTemplate,
     WithDescriptionTemplateCode
 );
+
+export const withError = buildExtensionTemplate(
+    WithErrorTemplate,
+    WithErrorTemplateCode
+);
+

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -8,6 +8,7 @@
     "@grow": "boolean",
     "@borderless": "boolean",
     "@collapseOnSelect": "boolean",
+    "@hasError": "boolean",
     "@fluid": "boolean",
     "@invalid": "boolean",
     "@truncate": "boolean",
@@ -15,6 +16,7 @@
     "@prefix-label": "string",
     "@floating-label": "string",
     "@unselected-text": "string",
+    "@aria-describedby": "string",
     "@list-selection": {
         "enum": ["manual", "auto"]
     },

--- a/src/components/ebay-listbox-button/test/test.server.js
+++ b/src/components/ebay-listbox-button/test/test.server.js
@@ -2,7 +2,7 @@ import { composeStories } from "@storybook/marko";
 import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import * as stories from "../listbox-button.stories";
 
-const { Default, withDescription } = composeStories(stories);
+const { Default, withDescription, withError } = composeStories(stories);
 
 const htmlSnap = snapshotHTML(__dirname);
 
@@ -41,5 +41,9 @@ describe("listbox", () => {
 
     it("renders with description", async () => {
         await htmlSnap(withDescription);
+    });
+
+    it("renders with error", async () => {
+        await htmlSnap(withError);
     });
 });


### PR DESCRIPTION
## Description
In order to support new listbox error, added a new error state
We can use `isInvalid` attribute but that was existing and I did not want to overload it.

## References
https://github.com/eBay/ebayui-core/issues/2057

## Screenshots

<img width="216" alt="Screenshot 2024-01-18 at 9 53 51 AM" src="https://github.com/eBay/ebayui-core/assets/1755269/1c944921-e81c-4540-8cf2-df05d3d5d38c">
