### PR TITLE
fix(select,combobox): added disabled to input

### DIFF
--- a/src/components/ebay-combobox/index.marko
+++ b/src/components/ebay-combobox/index.marko
@@ -68,6 +68,7 @@ $ var id = inputId || component.getElId("input");
             key="combobox"
             type="text"
             role="combobox"
+            disabled=disabled
             value=state.currentValue
             aria-autocomplete=component.autocomplete
             aria-roledescription=roledescription

--- a/src/components/ebay-select/index.marko
+++ b/src/components/ebay-select/index.marko
@@ -66,6 +66,7 @@ $ for (const option of options) {
         style=style>
         <select
             ...processHtmlAttributes(htmlInput)
+            disabled=disabled
             id=id
             onChange("handleChange")>
             <for|optionOrGroup| of=list>


### PR DESCRIPTION
## Description
Added disabled to input which is being removed by spread. 

## References
https://github.com/eBay/ebayui-core/issues/2054

