### PR TITLE
fix(toggle-button-group): add event handler types

### DIFF
--- a/src/components/ebay-toggle-button-group/component.ts
+++ b/src/components/ebay-toggle-button-group/component.ts
@@ -15,6 +15,7 @@ interface ToggleButtonGroupInput
     columns?: number;
     variant?: "checkbox" | "radio" | "radio-toggle";
     layoutType?: ToggleButtonInput["layoutType"];
+    "on-change"?: (event: ToggleButtonGroupEvent) => void;
 }
 
 export interface Input extends WithNormalizedProps<ToggleButtonGroupInput> {}


### PR DESCRIPTION
- Fixes #2064 

## Description

- Add event handler type to `ebay-toggle-button-group`