### PR TITLE
docs(select): remove unused attr and convert example to class

### DIFF
--- a/src/components/ebay-select/examples/external-label.marko
+++ b/src/components/ebay-select/examples/external-label.marko
@@ -1,15 +1,22 @@
-import type { Input as SelectInput } from "<ebay-select>"
-export type Input = SelectInput;
+class {
+    onCreate() {
+        this.state = {
+            selected: null
+        }
+    }
 
-class {}
+    handleChange({ index }) {
+        this.state.selected = index;
+    }
+}
 
 <span class="field">
     <label class="field__label field__label--start" for="select">
         Option
     </label>
-    <ebay-select ...input name="formFieldName" id="select">
-        <@option value="1" text="Option 1"/>
-        <@option value="2" text="Option 2"/>
-        <@option value="3" text="Option 3"/>
+    <ebay-select ...input name="formFieldName" id="select" on-change("handleChange")>
+        <for|option, i| of=input.options>
+            <@option value=option.value text=option.text selected=i === state.selected/>
+        </for>
     </ebay-select>
 </span>

--- a/src/components/ebay-select/select.stories.ts
+++ b/src/components/ebay-select/select.stories.ts
@@ -31,11 +31,6 @@ export default {
     },
 
     argTypes: {
-        selected: {
-            control: { type: "number" },
-            description:
-                "allows you to set the selected index option to `selected`",
-        },
         floatingLabel: {
             type: "string",
             control: { type: "string" },
@@ -64,6 +59,14 @@ export default {
             control: { type: "text" },
             description:
                 "used for the `value` attribute of the native `<option>`",
+            table: {
+                category: "@option attributes",
+            },
+        },
+        selected: {
+            control: { type: "text" },
+            description:
+                "used to determine which option is selected. This should be included in one and only one option.",
             table: {
                 category: "@option attributes",
             },
@@ -130,6 +133,27 @@ ExternalLabel.parameters = {
             code: WithLabelCode,
         },
     },
+};
+
+ExternalLabel.args = {
+    options: [
+        {
+            text: "Select an option",
+            value: "",
+        },
+        {
+            text: "option 1",
+            value: "option 1",
+        },
+        {
+            text: "option 2",
+            value: "option 2",
+        },
+        {
+            text: "option 3",
+            value: "option 3",
+        },
+    ],
 };
 
 export const Disabled = (args) => ({


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Storybook docs were inaccurate, as `selected` is unused at the root level
  - Moved `selected` into `@option attributes`
- Updated the `external-label` test so it keeps track of state, so now there is an example that works on rerender.
