### PR TITLE
refactor(ts): export event interfaces and allow empty select

### DIFF
--- a/src/components/ebay-chips-combobox/component.ts
+++ b/src/components/ebay-chips-combobox/component.ts
@@ -2,7 +2,7 @@ import { AttrString } from "marko/tags-html";
 import type { WithNormalizedProps } from "../../global";
 import { handleEnterKeydown } from "../../common/event-utils";
 
-interface ChipsComboboxEvent {
+export interface ChipsComboboxEvent {
     selected: string[];
 }
 

--- a/src/components/ebay-select/component.ts
+++ b/src/components/ebay-select/component.ts
@@ -8,7 +8,7 @@ export interface Option extends Omit<Marko.Input<"option">, `on${string}`> {
 }
 
 interface SelectInput extends Omit<Marko.Input<"select">, `on${string}`> {
-    options: Marko.RepeatableAttrTag<Option>;
+    options?: Marko.RepeatableAttrTag<Option>;
     "floating-label"?: AttrString;
     "is-large"?: boolean;
     borderless?: boolean;
@@ -36,7 +36,7 @@ class Select extends Marko.Component<Input, State> {
     handleChange(event: Event | { target: { selectedIndex: number } }) {
         const { selectedIndex } = event.target as HTMLSelectElement;
         const el = this.getEls("option")[selectedIndex];
-        const option = [...this.input.options][selectedIndex];
+        const option = [...(this.input.options || [])][selectedIndex];
 
         this.state.selectedIndex = selectedIndex;
 

--- a/src/components/ebay-select/index.marko
+++ b/src/components/ebay-select/index.marko
@@ -6,12 +6,12 @@ $ const {
     style,
     disabled,
     borderless,
-    options,
+    options: inputOptions,
     floatingLabel,
     isLarge,
     ...htmlInput
 } = input;
-
+$ const options = [...(inputOptions || [])];
 static var itemIgnoredAttributes = ["selected", "optgroup"];
 
 static interface OptGroup {
@@ -23,7 +23,7 @@ static function isGroup(optionOrGroup: Option | OptGroup): optionOrGroup is OptG
     return !!optionOrGroup.optgroup;
 }
 
-$ var selectedOption = [...options][state.selectedIndex];
+$ var selectedOption = options[state.selectedIndex];
 $ var list: (Option | OptGroup)[] = [];
 $ var optgroups: Record<string, OptGroup> = {};
 $ var id = component.selectId

--- a/src/components/ebay-tabs/component.ts
+++ b/src/components/ebay-tabs/component.ts
@@ -11,8 +11,8 @@ export interface TabsEvent {
 }
 
 interface TabsInput extends Omit<Marko.Input<"div">, `on${string}`> {
-    tabs: Marko.AttrTag<Tab>[];
-    panels: Marko.AttrTag<Panel>[];
+    tabs?: Marko.RepeatableAttrTag<Tab>;
+    panels?: Marko.RepeatableAttrTag<Panel>;
     activation?: "auto" | "manual";
     fake?: boolean;
     "selected-index"?: number | string;
@@ -23,6 +23,8 @@ export interface Input extends WithNormalizedProps<TabsInput> {}
 
 export interface State {
     selectedIndex: number;
+    tabs: Tab[];
+    panels: Panel[];
 }
 
 class Tabs extends Marko.Component<Input, State> {
@@ -42,7 +44,7 @@ class Tabs extends Marko.Component<Input, State> {
             event.preventDefault();
 
             const { input, state } = this;
-            const len = input.tabs.length;
+            const len = state.tabs.length;
             const keyCode = event.charCode || event.keyCode;
             const direction = keyCode === 37 || keyCode === 38 ? -1 : 1;
             const selectedIndex = (state.selectedIndex + len + direction) % len;
@@ -59,18 +61,18 @@ class Tabs extends Marko.Component<Input, State> {
     }
 
     onCreate() {
-        this.state = { selectedIndex: 0 };
+        this.state = { selectedIndex: 0, tabs: [], panels: [] };
     }
 
     onInput(input: Input) {
         const { state } = this;
-        input.tabs = input.tabs || [];
-        input.panels = input.panels || [];
+        state.tabs = [...(input.tabs || [])];
+        state.panels = [...(input.panels || [])];
 
         if (!isNaN(input.selectedIndex as number)) {
             state.selectedIndex =
                 parseInt(input.selectedIndex as string, 10) %
-                (input.tabs.length || 1);
+                (state.tabs.length || 1);
         }
     }
 

--- a/src/components/ebay-tabs/index.marko
+++ b/src/components/ebay-tabs/index.marko
@@ -5,14 +5,14 @@ $ const {
     class: inputClass,
     selectedIndex,
     activation,
-    tabs = [],
-    panels = [],
+    tabs,
+    panels,
     ...htmlInput
 } = input;
 
 <div ...processHtmlAttributes(htmlInput) class=['tabs', inputClass]>
     <div.tabs__items role='tablist' key='tabs'>
-        <for|tab, i| of=tabs>
+        <for|tab, i| of=state.tabs>
             $ var isSelected = state.selectedIndex === i;
             <div
                 ...processHtmlAttributes(tab, itemAnchorIgnoredAttributes)
@@ -30,7 +30,7 @@ $ const {
         </for>
     </div>
     <div.tabs__content>
-        <for|panel, i| of=panels>
+        <for|panel, i| of=state.panels>
             $ var isSelected = state.selectedIndex === i;
             <div
                 ...processHtmlAttributes(panel)

--- a/src/components/ebay-toggle-button-group/component.ts
+++ b/src/components/ebay-toggle-button-group/component.ts
@@ -4,7 +4,7 @@ import type {
     Input as ToggleButtonInput,
 } from "../ebay-toggle-button/component";
 
-interface ToggleButtonGroupEvent {
+export interface ToggleButtonGroupEvent {
     originalEvent: MouseEvent;
     pressed: number[];
 }

--- a/src/components/ebay-toggle-button-group/component.ts
+++ b/src/components/ebay-toggle-button-group/component.ts
@@ -11,7 +11,7 @@ export interface ToggleButtonGroupEvent {
 
 interface ToggleButtonGroupInput
     extends Omit<Marko.Input<"span">, `on${string}`> {
-    buttons: Omit<ToggleButtonInput, `on${string}`>[];
+    buttons?: Marko.RepeatableAttrTag<Omit<ToggleButtonInput, `on${string}`>>;
     columns?: number;
     variant?: "checkbox" | "radio" | "radio-toggle";
     layoutType?: ToggleButtonInput["layoutType"];
@@ -31,7 +31,7 @@ class ToggleButtonGroup extends Marko.Component<Input, State> {
 
     onInput(input: Input) {
         this.state.pressed = Object.fromEntries(
-            input.buttons.map(({ pressed }, i) => [i, !!pressed]),
+            [...(input.buttons || [])].map(({ pressed }, i) => [i, !!pressed]),
         );
     }
 

--- a/src/components/ebay-toggle-button-group/index.marko
+++ b/src/components/ebay-toggle-button-group/index.marko
@@ -4,7 +4,7 @@ $ const {
     class: inputClass,
     columns,
     layoutType: baseLayoutType,
-    buttons,
+    buttons = [],
     ...htmlInput
 } = input;
 


### PR DESCRIPTION
## Description

- Export event interfaces so that teams don't have to do type gymnastics to find them.
- Remove mandatory type for `@` tags in `select`, `toggle-button-group`, and `tabs`; mostly so users don't need to cast in situations like this:
  ```marko
  select
    for|option| of=options as [Option, ...Option[]]
      @option ...option
  ```
