### PR TITLE
fix(highcharts): use dynamic import instead of CDN, with lasso polyfill

### DIFF
--- a/src/common/cdn/index.ts
+++ b/src/common/cdn/index.ts
@@ -72,6 +72,7 @@ export class CDNLoader {
         this.url = `https://ir.ebaystatic.com/cr/v/c1/ebayui/${this.key}/v${
             version || versions[this.key as keyof typeof versions]
         }`;
+        console.log(this.url);
         for (let i = 0; i < this.files.length; i++) {
             if (overrides && overrides[i]) {
                 this.cdnFiles[i] = overrides[i];

--- a/src/common/highcharts/highcharts.ts
+++ b/src/common/highcharts/highcharts.ts
@@ -1,0 +1,7 @@
+import Highcharts from "highcharts";
+import accessibilityModule from "highcharts/modules/accessibility";
+import patternFillModule from "highcharts/modules/pattern-fill";
+
+accessibilityModule(Highcharts);
+patternFillModule(Highcharts);
+export default Highcharts;

--- a/src/common/highcharts/import.ts
+++ b/src/common/highcharts/import.ts
@@ -1,0 +1,3 @@
+export function load() {
+    return import("./highcharts");
+}

--- a/src/common/highcharts/lasso-async.ts
+++ b/src/common/highcharts/lasso-async.ts
@@ -1,0 +1,11 @@
+export function load() {
+    return new Promise((resolve, reject) => {
+        require("lasso-loader").async((err: Error) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(require("./highcharts"));
+            }
+        });
+    });
+}

--- a/src/common/highcharts/lasso-async.ts
+++ b/src/common/highcharts/lasso-async.ts
@@ -1,6 +1,6 @@
 export function load() {
     return new Promise((resolve, reject) => {
-        require("lasso-loader").async((err: Error) => {
+        require("lasso-loader").async(function (err: Error) {
             if (err) {
                 reject(err);
             } else {

--- a/src/common/highcharts/noop.ts
+++ b/src/common/highcharts/noop.ts
@@ -1,0 +1,4 @@
+import type Highcharts from "highcharts";
+export function load(): Promise<{ default: typeof Highcharts }> {
+    return undefined as any;
+}

--- a/src/common/highcharts/package.json
+++ b/src/common/highcharts/package.json
@@ -1,0 +1,10 @@
+{
+    "browser": "./lasso-async.js",
+    "main": "./noop.js",
+    "exports": {
+        ".": {
+            "browser": "./import.js",
+            "default": "./noop.js"
+        }
+    }
+}

--- a/src/components/components/ebay-tooltip-base/component-browser.ts
+++ b/src/components/components/ebay-tooltip-base/component-browser.ts
@@ -36,7 +36,7 @@ class TooltipBase extends Marko.Component<Input> {
     declare hostEl: HTMLElement | null;
     declare overlayEl: HTMLElement | null;
     declare arrowEl: HTMLElement | null;
-    cleanup: (() => void) | undefined;
+    declare cleanup: (() => void) | undefined;
 
     handleExpand() {
         this.emit("base-expand");

--- a/src/components/ebay-bar-chart/bar-chart.stories-ignore.ts
+++ b/src/components/ebay-bar-chart/bar-chart.stories-ignore.ts
@@ -2,7 +2,7 @@ import { tagToString } from "../../../.storybook/storybook-code-source";
 import { addRenderBodies } from "../../../.storybook/utils";
 import Readme from "./README.md";
 import Component from "./index.marko";
-import * as sampleSeriesData from "./examples/data.json";
+import sampleSeriesData from "./examples/data.json";
 const Template = (args) => ({
     input: addRenderBodies(args),
 });

--- a/src/components/ebay-line-chart/line-chart.stories.ts
+++ b/src/components/ebay-line-chart/line-chart.stories.ts
@@ -2,7 +2,7 @@ import { tagToString } from "../../../.storybook/storybook-code-source";
 import { addRenderBodies } from "../../../.storybook/utils";
 import Readme from "./README.md";
 import Component from "./index.marko";
-import * as sampleSeriesData from "./examples/data.json";
+import sampleSeriesData from "./examples/data.json";
 
 const Template = (args) => ({
     input: addRenderBodies(args),
@@ -76,15 +76,6 @@ export default {
             type: { name: "string", require: false },
             description:
                 "A class name that will be added to the main chart container",
-        },
-        cdnHighcharts: {
-            type: { name: "string", require: false },
-            description: "CDN url override for loading highcharts",
-        },
-        cdnHighchartsAccessibility: {
-            type: { name: "string", require: false },
-            description:
-                "CDN url override for loading highcharts accessibility module",
         },
         version: {
             type: { name: "string", require: false },


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Use dynamic import instead of CDN, with lasso polyfill

## Context

- Highcharts was not working on storybook, and some apps reported that it caused errors.
