### PR TITLE
feat(confirm/alert-dialog): added spread to buttons and fixed events

### DIFF
--- a/src/components/ebay-alert-dialog/alert-dialog.stories.ts
+++ b/src/components/ebay-alert-dialog/alert-dialog.stories.ts
@@ -32,9 +32,12 @@ export default {
             description:
                 "An id for an element which will receive focus when the dialog closes. Defaults to the last clicked element before the dialog is opened",
         },
-        "confirm-text": {
-            control: { type: "text" },
-            description: "Text for OK button",
+        confirm: {
+            name: "@confirm",
+            table: {
+                category: "@attribute tags",
+            },
+            description: "Render body will be text for OK button",
         },
         header: {
             name: "@header",
@@ -49,6 +52,9 @@ export const Standard = Template.bind({});
 Standard.args = {
     header: {
         renderBody: `Alert!`,
+    },
+    confirm: {
+        renderBody: `OK`,
     },
     renderBody: `You must acknowledge this alert to continue.`,
 };

--- a/src/components/ebay-alert-dialog/alert-dialog.stories.ts
+++ b/src/components/ebay-alert-dialog/alert-dialog.stories.ts
@@ -45,6 +45,36 @@ export default {
                 category: "@attribute tags",
             },
         },
+        onOpen: {
+            action: "on-open",
+            description: "Triggered on dialog open",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
+        onConfirm: {
+            action: "on-confirm",
+            description: "Triggered on dialog confirm button click",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
+        onClose: {
+            action: "on-close",
+            description: "Triggered when dialog is closed",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            }
+        }
     },
 };
 

--- a/src/components/ebay-alert-dialog/examples/default.marko
+++ b/src/components/ebay-alert-dialog/examples/default.marko
@@ -1,17 +1,19 @@
 export interface Input {
-    confirmText?: string;
     renderBody?: Marko.Body;
     header: {
+        renderBody?: Marko.Body;
+    }
+    confirm: {
         renderBody?: Marko.Body;
     }
 }
 
 <ebay-alert-dialog
-    confirmText=input.confirmText || 'OK'
     open=state.open
     on-confirm('closeDialog')
 >
     <@header><${input.header.renderBody}/></@header>
+    <@confirm><${input.confirm.renderBody}/></@confirm>
     <${input.renderBody}/>
     <p>
         This 'alert' text should be 1-2 lines.

--- a/src/components/ebay-alert-dialog/examples/default.marko
+++ b/src/components/ebay-alert-dialog/examples/default.marko
@@ -10,6 +10,8 @@ export interface Input {
 
 <ebay-alert-dialog
     open=state.open
+    on-open('emit', 'open')
+    on-close('emit', 'close')
     on-confirm('closeDialog')
 >
     <@header><${input.header.renderBody}/></@header>
@@ -34,5 +36,6 @@ class {
     }
     closeDialog() {
         this.state.open = false;
+        this.emit('confirm')
     }
 }

--- a/src/components/ebay-alert-dialog/index.marko
+++ b/src/components/ebay-alert-dialog/index.marko
@@ -7,6 +7,12 @@ static interface AlertDialogInput extends Omit<BaseInput, `on${string}`> {
     "on-open"?: () => void;
     "on-close"?: () => void;
     "on-confirm"?: () => void;
+    confirm?: Marko.AttrTag<
+        Marko.Input<`h${number}`> & {
+            renderBody?: Marko.Body;
+        }
+    >;
+
 }
 
 export interface Input extends WithNormalizedProps<AlertDialogInput> {}
@@ -17,6 +23,7 @@ $ var mainId = component.getElId("alert-dialog-main");
 $ const {
     class: inputClass,
     confirmText,
+    confirm,
     ...restInput
 } = input;
 
@@ -39,8 +46,15 @@ $ const {
             on-click("emit", "confirm")
             key="confirm"
             id=confirmId
-            class="alert-dialog__acknowledge">
-            ${confirmText}
+            class="alert-dialog__acknowledge"
+            ...confirm
+            >
+            <if(confirmText)>
+                ${confirmText}
+            </if>
+            <else>
+                <${confirm}/>
+            </else>
         </ebay-button>
     </@footer>
 </ebay-dialog-base>

--- a/src/components/ebay-confirm-dialog/confirm-dialog.stories.ts
+++ b/src/components/ebay-confirm-dialog/confirm-dialog.stories.ts
@@ -32,13 +32,19 @@ export default {
             description:
                 "An id for an element which will receive focus when the dialog closes. Defaults to the last clicked element before the dialog is opened",
         },
-        confirmText: {
-            control: { type: "text" },
-            description: "Text for confirm button",
+        confirm: {
+            name: "@confirm",
+            table: {
+                category: "@attribute tags",
+            },
+            description: "Render body will be text for confirm button",
         },
-        rejectText: {
-            control: { type: "text" },
-            description: "Text for reject button",
+        reject: {
+            name: "@reject",
+            table: {
+                category: "@attribute tags",
+            },
+            description: "Render body will be text for reject button",
         },
         header: {
             name: "@header",
@@ -91,10 +97,14 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {
-    confirmText: "Delete",
-    rejectText: "Cancel",
     header: {
         renderBody: `Delete Address?`,
+    },
+    confirm: {
+        renderBody: `Delete`,
+    },
+    reject: {
+        renderBody: `Cancel`,
     },
     renderBody: `You will permanently lose this address.`,
 };

--- a/src/components/ebay-confirm-dialog/confirm-dialog.stories.ts
+++ b/src/components/ebay-confirm-dialog/confirm-dialog.stories.ts
@@ -72,6 +72,17 @@ export default {
                 },
             },
         },
+        onClose: {
+            action: "on-close",
+            description: "Triggered when dialog is closed",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
+
         onConfirm: {
             action: "on-confirm",
             description: "Triggered on dialog confirm button click",
@@ -84,7 +95,7 @@ export default {
         },
         onReject: {
             action: "on-reject",
-            description: "Triggered when dialog is closed",
+            description: "Triggered when reject button is clicked",
             table: {
                 category: "Events",
                 defaultValue: {

--- a/src/components/ebay-confirm-dialog/examples/default.marko
+++ b/src/components/ebay-confirm-dialog/examples/default.marko
@@ -1,14 +1,18 @@
 export interface Input {
-    confirmText?: string;
     renderBody?: Marko.Body;
     header: {
         renderBody?: Marko.Body;
     }
+    reject: {
+        renderBody?: Marko.Body;
+    }
+    confirm: {
+        renderBody?: Marko.Body;
+    }
+
 }
 
 <ebay-confirm-dialog
-    reject-text='Cancel'
-    confirm-text='Delete'
     open=state.open
     on-open("emit", "open")
     on-reject('closeDialog')
@@ -16,6 +20,8 @@ export interface Input {
     ...input
 >
     <@header><${input.header.renderBody}/></@header>
+    <@confirm><${input.confirm.renderBody}/></@confirm>
+    <@reject><${input.reject.renderBody}/></@reject>
     <${input.renderBody}/>
     <p>
         This 'confirm' text should be 1-2 lines.

--- a/src/components/ebay-confirm-dialog/examples/default.marko
+++ b/src/components/ebay-confirm-dialog/examples/default.marko
@@ -15,6 +15,7 @@ export interface Input {
 <ebay-confirm-dialog
     open=state.open
     on-open("emit", "open")
+    on-close("emit", "close")
     on-reject('closeDialog')
     on-confirm('success')
     ...input
@@ -35,7 +36,6 @@ class {
     }
     openDialog() {
         this.state.open = true;
-        this.emit('open');
     }
     closeDialog(ev) {
         this.state.open = false;

--- a/src/components/ebay-confirm-dialog/index.marko
+++ b/src/components/ebay-confirm-dialog/index.marko
@@ -10,6 +10,17 @@ static interface ConfirmDialogInput extends Omit<BaseInput, `on${string}`> {
     "on-open"?: DialogBaseInput["on-open"];
     "on-reject"?: ButtonInput["on-click"] | DialogBaseInput["on-close"];
     "on-confirm"?: ButtonInput["on-click"];
+    confirm?: Marko.AttrTag<
+        Marko.Input<`h${number}`> & {
+            renderBody?: Marko.Body;
+        }
+    >;
+    reject?: Marko.AttrTag<
+        Marko.Input<`h${number}`> & {
+            renderBody?: Marko.Body;
+        }
+    >;
+
     "confirm-cta-variant"?: typeof validConfirmCTAVariants[number];
 }
 
@@ -22,7 +33,8 @@ static  var validConfirmCTAVariants = [
     "destructive"
 ];
 
-$ const { confirmCtaVariant, rejectText, confirmText, class: inputClass, ...dialogInput } = input;
+$ const { confirmCtaVariant, rejectText, confirmText, class: inputClass, reject, confirm, ...dialogInput } = input;
+
 <ebay-dialog-base
     ...dialogInput
     on-open("emit", "open")
@@ -37,8 +49,16 @@ $ const { confirmCtaVariant, rejectText, confirmText, class: inputClass, ...dial
         <ebay-button
             on-click("emit", "reject")
             id=cancelId
-            class="confirm-dialog__reject">
-            ${rejectText}
+            class="confirm-dialog__reject"
+            ...reject
+            >
+
+            <if(rejectText)>
+                ${rejectText}
+            </if>
+            <else>
+                <${reject}/>
+            </else>
         </ebay-button>
         <ebay-button
             priority="primary"
@@ -48,8 +68,14 @@ $ const { confirmCtaVariant, rejectText, confirmText, class: inputClass, ...dial
             class=[
                 "confirm-dialog__confirm",
                 confirmCtaVariant && validConfirmCTAVariants.includes(confirmCtaVariant) && `btn--${confirmCtaVariant}`
-            ]>
-            ${confirmText}
+            ]
+            ...confirm>
+            <if(confirmText)>
+                ${confirmText}
+            </if>
+            <else>
+                <${confirm}/>
+            </else>
         </ebay-button>
     </@footer>
 </ebay-dialog-base>

--- a/src/components/ebay-confirm-dialog/index.marko
+++ b/src/components/ebay-confirm-dialog/index.marko
@@ -8,6 +8,7 @@ static interface ConfirmDialogInput extends Omit<BaseInput, `on${string}`> {
     "reject-text"?: AttrString;
     "confirm-text"?: AttrString;
     "on-open"?: DialogBaseInput["on-open"];
+    "on-close"?: DialogBaseInput["on-close"];
     "on-reject"?: ButtonInput["on-click"] | DialogBaseInput["on-close"];
     "on-confirm"?: ButtonInput["on-click"];
     confirm?: Marko.AttrTag<
@@ -38,7 +39,7 @@ $ const { confirmCtaVariant, rejectText, confirmText, class: inputClass, reject,
 <ebay-dialog-base
     ...dialogInput
     on-open("emit", "open")
-    on-close("emit", "reject")
+    on-close("emit", "close")
     main-id=mainId
     focus=confirmId
     class-prefix="confirm-dialog"

--- a/src/components/ebay-confirm-dialog/marko-tag.json
+++ b/src/components/ebay-confirm-dialog/marko-tag.json
@@ -20,5 +20,21 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
+    },
+    "@confirm <confirm>": {
+        "attribute-groups": ["html-attributes"],
+        "@*": {
+            "targetProperty": null,
+            "type": "expression"
+        },
+        "@html-attributes": "expression"
+    },
+    "@reject <reject>": {
+        "attribute-groups": ["html-attributes"],
+        "@*": {
+            "targetProperty": null,
+            "type": "expression"
+        },
+        "@html-attributes": "expression"
     }
 }


### PR DESCRIPTION

## Description
* Changed alert and confirm dialog to accept attribute tags (to allow passthrough attributes)
* Fixed reject event to only bubble once. 
* Changed some storybook stories

## References
https://github.com/eBay/ebayui-core/issues/2042

