### PR TITLE
fix(fake/menu/button): updated documentation for badge

### DIFF
--- a/src/components/ebay-fake-menu-button/fake-menu-button.stories.ts
+++ b/src/components/ebay-fake-menu-button/fake-menu-button.stories.ts
@@ -127,12 +127,16 @@ export default {
         },
         badgeNumber: {
             description: "used as the number to be placed in the badge",
+            controls: { hideNoControlsWarning: true },
             table: {
                 category: "@item attribute tags",
             },
         },
-        badgeAriaLabel: {
-            description: "passed as the `aria-label` directly to the badge",
+        'aria-label': {
+            controls: { hideNoControlsWarning: true },
+            description:
+                "Passed as the `aria-label` directly to the badge. Required only if badge number is provided",
+
             table: {
                 category: "@item attribute tags",
             },

--- a/src/components/ebay-fake-menu/fake-menu.stories.ts
+++ b/src/components/ebay-fake-menu/fake-menu.stories.ts
@@ -89,19 +89,20 @@ export default {
                 "the value to use with event responses for for the `checked` array",
         },
         "badge-number": {
-            control: { type: "text" },
+            controls: { hideNoControlsWarning: true },
             table: {
                 category: "@item attributes",
             },
             description: "used as the number to be placed in the badge",
         },
-        "badge-aria-label": {
-            control: { type: "text" },
-            table: {
-                category: "@item attributes",
-            },
+        'aria-label': {
+            controls: { hideNoControlsWarning: true },
             description:
-                "Yes (only if badge number is provided) | passed as the `aria-label` directly to the badge",
+                "Passed as the `aria-label` directly to the badge. Required only if badge number is provided",
+
+            table: {
+                category: "@item attribute tags",
+            },
         },
         onKeydown: {
             action: "on-keydown",

--- a/src/components/ebay-menu-button/examples/badged-items.marko
+++ b/src/components/ebay-menu-button/examples/badged-items.marko
@@ -6,7 +6,7 @@
     on-select('emit', 'select')
     ...input
 >
-    <@item badgeNumber=1>item 1 that has very long text</@item>
-    <@item badgeNumber=99>item 2</@item>
-    <@item badgeNumber=10>item 3</@item>
+    <@item badgeNumber=1 aria-label="1 item unread">item 1 that has very long text</@item>
+    <@item badgeNumber=99 aria-label="99 items unread">item 2</@item>
+    <@item badgeNumber=10 aria-label="10 item unread">item 3</@item>
 </ebay-menu-button>

--- a/src/components/ebay-menu-button/menu-button.stories.ts
+++ b/src/components/ebay-menu-button/menu-button.stories.ts
@@ -140,13 +140,17 @@ export default {
             },
         },
         badgeNumber: {
+            controls: { hideNoControlsWarning: true },
             description: "used as the number to be placed in the badge",
             table: {
                 category: "@item attribute tags",
             },
         },
-        badgeAriaLabel: {
-            description: "passed as the `aria-label` directly to the badge",
+        'aria-label': {
+            controls: { hideNoControlsWarning: true },
+            description:
+                "Passed as the `aria-label` directly to the badge. Required only if badge number is provided",
+
             table: {
                 category: "@item attribute tags",
             },

--- a/src/components/ebay-menu/examples/badged.marko
+++ b/src/components/ebay-menu/examples/badged.marko
@@ -4,7 +4,7 @@
     on-change('emit', 'change')
     on-select('emit', 'select')
 >
-    <@item badgeNumber=1>item 1 that has very long text</@item>
-    <@item badgeNumber=99>item 2</@item>
-    <@item badgeNumber=10>item 3</@item>
+    <@item badgeNumber=1 aria-label="1 item unread">item 1 that has very long text</@item>
+    <@item badgeNumber=99 aria-label="99 items unread">item 2</@item>
+    <@item badgeNumber=10 aria-label="10 item unread">item 3</@item>
 </ebay-menu>

--- a/src/components/ebay-menu/menu.stories.ts
+++ b/src/components/ebay-menu/menu.stories.ts
@@ -59,19 +59,19 @@ export default {
                 "the value to use with event responses for for the `checked` array",
         },
         badgeNumber: {
-            control: { type: "text" },
+            controls: { hideNoControlsWarning: true },
             table: {
                 category: "@item attributes",
             },
             description: "used as the number to be placed in the badge",
         },
-        badgeAriaLabel: {
-            control: { type: "text" },
+        'aria-label': {
+            controls: { hideNoControlsWarning: true },
             table: {
                 category: "@item attributes",
             },
             description:
-                "Yes (only if badge number is provided) | passed as the `aria-label` directly to the badge",
+                "Passed as the `aria-label` directly to the badge. Required only if badge number is provided",
         },
         onKeydown: {
             action: "on-keydown",


### PR DESCRIPTION
## Description
* Updated documentation for all menu variants. Added badge as `aria-label` since this was passthrough.

## References
#2025