### PR TITLE
fix(segmented-button): move types and validSizes to marko file

### DIFF
--- a/.changeset/afraid-mugs-search.md
+++ b/.changeset/afraid-mugs-search.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix segmented-buttons-import error

--- a/src/components/ebay-segmented-buttons/component.ts
+++ b/src/components/ebay-segmented-buttons/component.ts
@@ -1,27 +1,8 @@
-import type { WithNormalizedProps } from "../../global";
-
-export const validSizes = ["large"] as const;
-
-export interface SegmentedButtonsEvent {
-    originalEvent: PointerEvent;
-    index: number;
-    value?: string;
-}
-
-export interface SegmentedButton
-    extends Omit<Marko.Input<"button">, `on${string}`> {
-    selected?: boolean;
-    icon?: Marko.Renderable;
-}
-
-interface SegmentedButtonsInput
-    extends Omit<Marko.Input<"div">, `on${string}`> {
-    buttons?: Marko.RepeatableAttrTag<SegmentedButton>;
-    size?: (typeof validSizes)[number];
-    "on-change"?: (event: SegmentedButtonsEvent) => void;
-}
-
-export interface Input extends WithNormalizedProps<SegmentedButtonsInput> {}
+import type {
+    Input,
+    SegmentedButton,
+    SegmentedButtonsEvent,
+} from "./index.marko";
 
 interface State {
     selectedIndex: number;

--- a/src/components/ebay-segmented-buttons/index.marko
+++ b/src/components/ebay-segmented-buttons/index.marko
@@ -1,6 +1,26 @@
 import { processHtmlAttributes } from "../../common/html-attributes";
+import type { WithNormalizedProps } from "../../global";
 
-import { validSizes } from "./component";
+static const validSizes = ["large"] as const;
+
+export interface SegmentedButtonsEvent {
+    originalEvent: PointerEvent;
+    index: number;
+    value?: string;
+}
+
+export interface SegmentedButton extends Omit<Marko.Input<"button">, `on${string}`> {
+    selected?: boolean;
+    icon?: Marko.Renderable;
+}
+
+static interface SegmentedButtonsInput extends Omit<Marko.Input<"div">, `on${string}`> {
+    buttons?: Marko.RepeatableAttrTag<SegmentedButton>;
+    size?: (typeof validSizes)[number];
+    "on-change"?: (event: SegmentedButtonsEvent) => void;
+}
+
+export interface Input extends WithNormalizedProps<SegmentedButtonsInput> {}
 
 $ let {
     size: inputSize,


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Move types and `validSizes` to the `.marko` file from `component.ts`
