### PR TITLE
refactor(infotip): heading is not required by ts

### DIFF
--- a/src/components/components/ebay-tooltip-overlay/component-browser.ts
+++ b/src/components/components/ebay-tooltip-overlay/component-browser.ts
@@ -8,9 +8,9 @@ interface TooltipOverlayInput {
     "style-right"?: string;
     "style-bottom"?: string;
     heading?: Marko.Input<"span"> & {
-        as: Marko.NativeTags;
-        renderBody: Marko.Body;
-    };
+        as?: Marko.NativeTags;
+        renderBody?: Marko.Body;
+    } & Iterable<any>;
     id?: string;
     type: keyof typeof typeRoles;
     content?: Marko.AttrTag<Marko.Input<"span">>;

--- a/src/components/ebay-infotip/component.ts
+++ b/src/components/ebay-infotip/component.ts
@@ -11,10 +11,10 @@ interface InfotipInput extends Omit<Marko.Input<"span">, `on${string}`> {
     placement?: TooltipBaseInput["placement"];
     disabled?: boolean;
     icon?: Marko.AttrTag<{ renderBody: Marko.Renderable }>;
-    heading: Marko.Input<"span"> & {
-        as: Marko.NativeTags;
-        renderBody: Marko.Renderable;
-    };
+    heading?: Marko.Input<"span"> & {
+        as?: Marko.NativeTags;
+        renderBody?: Marko.Renderable;
+    } & Iterable<any>;
     content: Marko.AttrTag<Marko.Input<"span">>;
     "a11y-close-button-text"?: AttrString;
     "on-expand"?: () => void;

--- a/src/components/ebay-infotip/examples/custom-icon.marko
+++ b/src/components/ebay-infotip/examples/custom-icon.marko
@@ -1,5 +1,5 @@
 <ebay-infotip
-    a11y-close-text="Dismiss infotip"
+    a11y-close-button-text="Dismiss infotip"
     aria-label="Important information">
     <@icon>
         <ebay-settings-24-icon/>

--- a/src/components/ebay-section-title/examples/infotip.marko
+++ b/src/components/ebay-section-title/examples/infotip.marko
@@ -3,7 +3,7 @@
     <@subtitle>Plus, guaranteed best prices.</@subtitle>
     <@info>
         <ebay-infotip
-            a11y-close-text="Dismiss infotip"
+            a11y-close-button-text="Dismiss infotip"
             aria-label="Important information"
             pointer="top-left">
             <@heading>Important</@heading>

--- a/src/components/ebay-section-title/index.marko
+++ b/src/components/ebay-section-title/index.marko
@@ -4,10 +4,10 @@ import type { AttrString } from 'marko/tags-html';
 
 static interface SectionTitleInput extends Omit<Marko.Input<"div">, `on${string}` | "title"> {
     "cta-text"?: AttrString;
-    title?: Omit<Marko.Input<"h2">, `on${string}`>;
+    title?: Marko.AttrTag<Omit<Marko.Input<"h2">, `on${string}`>>;
     href?: string;
-    subtitle?: Omit<Marko.Input<"span">, `on${string}`>;
-    info?: Omit<Marko.Input<"div">, `on${string}`>;
+    subtitle?: Marko.AttrTag<Omit<Marko.Input<"span">, `on${string}`>>;
+    info?: Marko.AttrTag<Omit<Marko.Input<"div">, `on${string}`>>;
     overflow?: Omit<Marko.Input<"div">, `on${string}`>;
 }
 


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Ensured that `heading` is optional in `ebay-infotip`
- Made a few bonus type changes in order to resolve related errors that came up
