### PR TITLE
fix(date-textbox): SSR issue & dates past year 9999

### DIFF
--- a/src/components/ebay-calendar/component.ts
+++ b/src/components/ebay-calendar/component.ts
@@ -83,6 +83,14 @@ class Calendar extends Marko.Component<Input, State> {
         };
     }
 
+    onMount() {
+        // recalculate on the browser in case firstDayOfWeek is not supported
+        const { firstDayOfWeek } = getWeekdayInfo(
+            localeOverride(this.input.locale),
+        );
+        this.state.firstDayOfWeek = firstDayOfWeek;
+    }
+
     onInput(input: Input) {
         if (input.selected) {
             // If no selected times are visible, snap the view to the first one

--- a/src/components/ebay-calendar/date-utils.ts
+++ b/src/components/ebay-calendar/date-utils.ts
@@ -32,7 +32,8 @@ export function getWeekdayInfo(localeName: string) {
 export function dateArgToISO(arg: DateConstructor["arguments"]) {
     if (!arg) return undefined;
     if (/^\d\d\d\d-\d\d-\d\d$/g.test(arg)) return arg;
-    return toISO(new Date(arg));
+    const date = toISO(new Date(arg));
+    return /^\d\d\d\d-\d\d-\d\d$/g.test(date) ? date : undefined;
 }
 
 export function toISO(date: Date): DayISO {

--- a/src/components/ebay-date-textbox/component.ts
+++ b/src/components/ebay-date-textbox/component.ts
@@ -1,5 +1,5 @@
 import Expander from "makeup-expander";
-import { toISO, type DayISO, dateArgToISO } from "../ebay-calendar/date-utils";
+import { type DayISO, dateArgToISO } from "../ebay-calendar/date-utils";
 import type { WithNormalizedProps } from "../../global";
 import type { AttrString } from "marko/tags-html";
 
@@ -89,7 +89,7 @@ class DateTextbox extends Marko.Component<Input, State> {
 
     handleInputChange(index: number, { value }: { value: string }) {
         const valueDate = new Date(value);
-        const iso = isNaN(valueDate.getTime()) ? null : toISO(valueDate);
+        const iso = isNaN(valueDate.getTime()) ? null : dateArgToISO(valueDate);
         if (index === 0) {
             this.state.firstSelected = iso;
         } else {

--- a/src/components/ebay-menu-button/examples/prefix-label.marko
+++ b/src/components/ebay-menu-button/examples/prefix-label.marko
@@ -1,4 +1,4 @@
-import { MenuButtonEvent } from "../component";
+import type { MenuButtonEvent } from "../component";
 class {
     declare state: {
         labelText?: string | null;


### PR DESCRIPTION
## Description

- Added `type` to an import to prevent errors in storybook (bonus change)
- Force client recalculation of `firstDayOfWeek` in case the browser doesn't support it but the server does (fixes #2099)
- Ensure that selected dates can be represented in `YYYY-MM-DD` format (fixes #2087)