### PR TITLE
fix(section-notice): education icon type

### DIFF
--- a/src/components/components/ebay-notice-base/component.ts
+++ b/src/components/components/ebay-notice-base/component.ts
@@ -32,7 +32,7 @@ interface NoticeBaseInput
             renderBody?: Marko.Renderable;
         }
     >;
-    "education-icon"?: Marko.Renderable;
+    "education-icon"?: Marko.AttrTag<Marko.Renderable> | Marko.Renderable;
     prominent?: boolean;
     "on-dismiss"?: () => void;
 }

--- a/src/components/ebay-section-notice/examples/with-icon.marko
+++ b/src/components/ebay-section-notice/examples/with-icon.marko
@@ -1,5 +1,7 @@
-import TheVaultIcon from '<ebay-the-ebay-vault-24-icon>'
-<ebay-section-notice ...input educationIcon=TheVaultIcon a11y-text="ebay vault">
+<ebay-section-notice ...input a11y-text="ebay vault">
+    <@education-icon>
+        <ebay-the-ebay-vault-24-icon />
+    </@education-icon>
     <@title>
         <div>Notice title</div>
     </@title>


### PR DESCRIPTION
- Resolves #2115
- Also, modified an example to show attr tag usage. This is the preferred method, I think.