### PR TITLE
fix(signal): custom class passthrough

### DIFF
--- a/.changeset/hungry-taxis-behave.md
+++ b/.changeset/hungry-taxis-behave.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Fix signal custom class passthrough

--- a/src/components/ebay-signal/index.marko
+++ b/src/components/ebay-signal/index.marko
@@ -8,10 +8,12 @@ static interface SignalInput extends Omit<Marko.Input<"span">, `on${string}`> {
 export interface Input extends WithNormalizedProps<SignalInput> {}
 
 $ const {
+    class: inputClass,
     status = "neutral",
     ...htmlAttributes
 } = input;
 
-<span ...processHtmlAttributes(htmlAttributes) class=`signal signal--${status}`>
+<span ...processHtmlAttributes(htmlAttributes)
+    class=[inputClass, "signal", `signal--${status}`]>
     <${input.renderBody}/>
 </span>

--- a/src/components/ebay-signal/test/mock/index.js
+++ b/src/components/ebay-signal/test/mock/index.js
@@ -23,3 +23,8 @@ export const basicTimeSensitive = {
     status: "time-sensitive",
     renderBody: createRenderBody("time sensitive"),
 };
+
+export const basicWithClass = {
+    renderBody: createRenderBody("neutral"),
+    class: "custom-class",
+};

--- a/src/components/ebay-signal/test/test.server.js
+++ b/src/components/ebay-signal/test/test.server.js
@@ -50,4 +50,12 @@ describe("signal", () => {
         expect(el).has.class("signal");
         expect(el).has.class("signal--neutral");
     });
+
+    it("renders with custom class", async () => {
+        const input = mock.basicWithClass;
+        const { getByText } = await render(template, input);
+        const el = getByText(/neutral/i);
+
+        expect(el).has.class("custom-class");
+    });
 });


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
* Resolves #2121

## Context
* Adding use of `inputClass` as in other components.
