### PR TITLE
feat(carousel): updated icons to be 16px

### DIFF
--- a/.changeset/eleven-roses-study.md
+++ b/.changeset/eleven-roses-study.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+ebay-carousel: updated paddles to use 16px icons

--- a/src/components/ebay-carousel/index.marko
+++ b/src/components/ebay-carousel/index.marko
@@ -29,7 +29,7 @@ $ var config = data.config;
             aria-label=data.a11yPreviousText
             aria-disabled=data.prevControlDisabled && 'true'
         >
-            <ebay-chevron-left-12-icon/>
+            <ebay-chevron-left-16-icon/>
         </button>
         <div class=[
             'carousel__viewport',
@@ -74,7 +74,7 @@ $ var config = data.config;
             key='next'
             id:scoped='next'
         >
-            <ebay-chevron-right-12-icon/>
+            <ebay-chevron-right-16-icon/>
         </button>
         <if(data.autoplayInterval && !data.bothControlsDisabled)>
             <button.carousel__playback


### PR DESCRIPTION
Added carousel icons to be 16px

This will be released as a patch.

<img width="1256" alt="Screenshot 2024-03-18 at 11 18 27 AM" src="https://github.com/eBay/ebayui-core/assets/1755269/18f9b12c-766b-42f3-851f-a06870d5000b">

https://github.com/eBay/ebayui-core/issues/2132