### PR TITLE
fix(listbox-button): removed btn--form when listbox is borderless

### DIFF
--- a/.changeset/sour-months-search.md
+++ b/.changeset/sour-months-search.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+listbox-button: removed btn--form whenn listbox is borderless

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -40,8 +40,7 @@ $ var isForm = variant === 'form';
         class=[
             "listbox-button__control",
             'btn',
-            'btn--form',
-            borderless && "btn--borderless",
+            borderless ? "btn--borderless" : 'btn--form',
             truncate && "btn--truncated",
             floatingLabel && "btn--floating-label"
         ]


### PR DESCRIPTION
## Description
Removed `btn--from` from listbox button when its borderless

## References
https://github.com/eBay/ebayui-core/issues/2126

## Screenshots
<img width="316" alt="Screenshot 2024-03-18 at 1 18 58 PM" src="https://github.com/eBay/ebayui-core/assets/1755269/7d697ba0-8b2c-4ed7-a63f-dd31e09a09a8">
