### PR TITLE
fix(notice-base): stop dismissing on all keydowns

### DIFF
--- a/.changeset/green-penguins-agree.md
+++ b/.changeset/green-penguins-agree.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Notice base dismiss keydown fix

--- a/src/components/components/ebay-notice-base/index.marko
+++ b/src/components/components/ebay-notice-base/index.marko
@@ -105,7 +105,6 @@ $ const isEducation = prefixClass === 'education-notice';
                 aria-label=`${a11yDismissText}`
                 class=['fake-link', `${prefixClass}__dismiss`]
                 onClick('emit', 'dismiss')
-                onKeydown('emit', 'dismiss')
             >
                 <ebay-close-16-icon.icon.icon--close-16/>
             </button>


### PR DESCRIPTION
- Fixes #2145 

## Description

- Prevent notice base from emitting a dismiss event on keydown, instead only emit on click