### PR TITLE
docs: add storybook link to tag descriptions

### DIFF
--- a/src/components/ebay-3d-viewer/marko-tag.json
+++ b/src/components/ebay-3d-viewer/marko-tag.json
@@ -11,5 +11,6 @@
     "@a11y-text": "string",
     "@a11y-start-text": "string",
     "@a11y-load-text": "string",
-    "@error-text": "string"
+    "@error-text": "string",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/media-ebay-3d-viewer)"
 }

--- a/src/components/ebay-alert-dialog/marko-tag.json
+++ b/src/components/ebay-alert-dialog/marko-tag.json
@@ -18,5 +18,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-alert-dialog)"
 }

--- a/src/components/ebay-avatar/marko-tag.json
+++ b/src/components/ebay-avatar/marko-tag.json
@@ -29,5 +29,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/graphics-icons-ebay-avatar)"
 }

--- a/src/components/ebay-badge/marko-tag.json
+++ b/src/components/ebay-badge/marko-tag.json
@@ -8,5 +8,6 @@
     "@type": {
         "enum": ["icon"]
     },
-    "@number": "number"
+    "@number": "number",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/graphics-icons-ebay-badge)"
 }

--- a/src/components/ebay-breadcrumbs/marko-tag.json
+++ b/src/components/ebay-breadcrumbs/marko-tag.json
@@ -37,5 +37,6 @@
         "@rel": "#html-rel",
         "@target": "#html-target",
         "@aria-current": "never"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-breadcrumbs)"
 }

--- a/src/components/ebay-button/marko-tag.json
+++ b/src/components/ebay-button/marko-tag.json
@@ -37,5 +37,6 @@
         "enum": ["none", "loading", "expand"]
     },
     "@target": "#html-target",
-    "@aria-disabled": "never"
+    "@aria-disabled": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-button)"
 }

--- a/src/components/ebay-calendar/marko-tag.json
+++ b/src/components/ebay-calendar/marko-tag.json
@@ -19,5 +19,6 @@
         "a11yTodayText": "string",
         "a11yDisabledText": "string",
         "a11ySeparator": "string"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-date-textbox)"
 }

--- a/src/components/ebay-carousel/marko-tag.json
+++ b/src/components/ebay-carousel/marko-tag.json
@@ -35,5 +35,6 @@
         "@class": "string",
         "@style": "string",
         "@key": "string"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-carousel)"
 }

--- a/src/components/ebay-checkbox/marko-tag.json
+++ b/src/components/ebay-checkbox/marko-tag.json
@@ -18,5 +18,6 @@
     "@name": "#html-name",
     "@readonly": "#html-readonly",
     "@value": "#html-value",
-    "@type": "never"
+    "@type": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-checkbox)"
 }

--- a/src/components/ebay-chip/marko-tag.json
+++ b/src/components/ebay-chip/marko-tag.json
@@ -5,5 +5,6 @@
         "type": "expression"
     },
     "@html-attributes": "expression",
-    "@a11y-delete-button": "string"
+    "@a11y-delete-button": "string",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/building-blocks-ebay-chip)"
 }

--- a/src/components/ebay-chips-combobox/marko-tag.json
+++ b/src/components/ebay-chips-combobox/marko-tag.json
@@ -17,5 +17,6 @@
         },
         "@html-attributes": "expression"
     },
-    "@selected": "array"
+    "@selected": "array",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-combobox)"
 }

--- a/src/components/ebay-combobox/marko-tag.json
+++ b/src/components/ebay-combobox/marko-tag.json
@@ -43,5 +43,6 @@
         "@role": "never",
         "@aria-selected": "never",
         "@sticky": "boolean"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-combobox)"
 }

--- a/src/components/ebay-confirm-dialog/marko-tag.json
+++ b/src/components/ebay-confirm-dialog/marko-tag.json
@@ -36,5 +36,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-confirm-dialog)"
 }

--- a/src/components/ebay-cta-button/marko-tag.json
+++ b/src/components/ebay-cta-button/marko-tag.json
@@ -13,5 +13,6 @@
     "@ping": "#html-ping",
     "@referrerpolicy": "#html-referrerpolicy",
     "@rel": "#html-rel",
-    "@target": "#html-target"
+    "@target": "#html-target",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-cta-button)"
 }

--- a/src/components/ebay-date-textbox/marko-tag.json
+++ b/src/components/ebay-date-textbox/marko-tag.json
@@ -24,5 +24,6 @@
         "a11yInRangeText": "string",
         "a11yRangeEndText": "string",
         "a11ySeparator": "string"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-date-textbox)"
 }

--- a/src/components/ebay-details/marko-tag.json
+++ b/src/components/ebay-details/marko-tag.json
@@ -13,5 +13,6 @@
     },
     "@text": "string",
     "@as": "string",
-    "@open": "boolean"
+    "@open": "boolean",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-details)"
 }

--- a/src/components/ebay-drawer-dialog/marko-tag.json
+++ b/src/components/ebay-drawer-dialog/marko-tag.json
@@ -30,5 +30,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-drawer-dialog)"
 }

--- a/src/components/ebay-education-notice/marko-tag.json
+++ b/src/components/ebay-education-notice/marko-tag.json
@@ -50,5 +50,6 @@
         },
         "@html-attributes": "expression"
     },
-    "@dismissed": "bool"
+    "@dismissed": "bool",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/notices-tips-ebay-education-notice)"
 }

--- a/src/components/ebay-eek/marko-tag.json
+++ b/src/components/ebay-eek/marko-tag.json
@@ -13,5 +13,6 @@
     "@html-attributes": "expression",
     "@top": "string",
     "@bottom": "string",
-    "@range": "string"
+    "@range": "string",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/graphics-icons-ebay-eek)"
 }

--- a/src/components/ebay-fake-link/marko-tag.json
+++ b/src/components/ebay-fake-link/marko-tag.json
@@ -25,5 +25,6 @@
     "@referrerpolicy": "#html-referrerpolicy",
     "@rel": "#html-rel",
     "@target": "#html-target",
-    "@aria-disabled": "never"
+    "@aria-disabled": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-fake-link)"
 }

--- a/src/components/ebay-fake-menu-button/marko-tag.json
+++ b/src/components/ebay-fake-menu-button/marko-tag.json
@@ -54,5 +54,6 @@
         "@class": "string",
         "@style": "string",
         "@separator": "boolean"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-fake-menu-button)"
 }

--- a/src/components/ebay-fake-menu/marko-tag.json
+++ b/src/components/ebay-fake-menu/marko-tag.json
@@ -32,5 +32,6 @@
         "@class": "string",
         "@style": "string",
         "@separator": "boolean"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/building-blocks-ebay-fake-menu)"
 }

--- a/src/components/ebay-fake-tabs/marko-tag.json
+++ b/src/components/ebay-fake-tabs/marko-tag.json
@@ -15,5 +15,6 @@
         },
         "@html-attributes": "expression",
         "@href": "#html-href"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-fake-tabs)"
 }

--- a/src/components/ebay-filter-menu-button/marko-tag.json
+++ b/src/components/ebay-filter-menu-button/marko-tag.json
@@ -36,5 +36,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-filter-menu-button)"
 }

--- a/src/components/ebay-filter-menu/marko-tag.json
+++ b/src/components/ebay-filter-menu/marko-tag.json
@@ -26,5 +26,6 @@
         "@role": "never",
         "@aria-checked": "never",
         "@for": "never"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/building-blocks-ebay-filter-menu)"
 }

--- a/src/components/ebay-filter/marko-tag.json
+++ b/src/components/ebay-filter/marko-tag.json
@@ -19,5 +19,6 @@
     "@rel": "#html-rel",
     "@target": "#html-target",
     "@aria-pressed": "never",
-    "@useAriaPressed": "boolean"
+    "@useAriaPressed": "boolean",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/building-blocks-ebay-filter)"
 }

--- a/src/components/ebay-flag/marko-tag.json
+++ b/src/components/ebay-flag/marko-tag.json
@@ -6,5 +6,6 @@
     },
     "@html-attributes": "expression",
     "@value": "#html-value",
-    "@a11y-text": "string"
+    "@a11y-text": "string",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/graphics-icons-ebay-flag)"
 }

--- a/src/components/ebay-fullscreen-dialog/marko-tag.json
+++ b/src/components/ebay-fullscreen-dialog/marko-tag.json
@@ -29,5 +29,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-fullscreen-dialog)"
 }

--- a/src/components/ebay-icon-button/marko-tag.json
+++ b/src/components/ebay-icon-button/marko-tag.json
@@ -30,5 +30,6 @@
     "@referrerpolicy": "#html-referrerpolicy",
     "@rel": "#html-rel",
     "@target": "#html-target",
-    "@aria-disabled": "never"
+    "@aria-disabled": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-icon-button)"
 }

--- a/src/components/ebay-icon/marko-tag.json
+++ b/src/components/ebay-icon/marko-tag.json
@@ -13,5 +13,6 @@
     "@_themes": "expression",
     "@_def": "expression",
     "@role": "never",
-    "@aria-labelledby": "never"
+    "@aria-labelledby": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/graphics-icons-ebay-icon)"
 }

--- a/src/components/ebay-image-placeholder/marko-tag.json
+++ b/src/components/ebay-image-placeholder/marko-tag.json
@@ -12,5 +12,6 @@
     "@no-skin-classes": "boolean",
     "@_themes": "expression",
     "@role": "never",
-    "@aria-labelledby": "never"
+    "@aria-labelledby": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/graphics-icons-ebay-image-placeholder)"
 }

--- a/src/components/ebay-infotip/marko-tag.json
+++ b/src/components/ebay-infotip/marko-tag.json
@@ -69,5 +69,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-infotip)"
 }

--- a/src/components/ebay-inline-notice/marko-tag.json
+++ b/src/components/ebay-inline-notice/marko-tag.json
@@ -10,5 +10,6 @@
     },
     "@icon": "string",
     "@a11y-text": "string",
-    "@aria-labelledby": "never"
+    "@aria-labelledby": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/notices-tips-ebay-inline-notice)"
 }

--- a/src/components/ebay-lightbox-dialog/marko-tag.json
+++ b/src/components/ebay-lightbox-dialog/marko-tag.json
@@ -36,5 +36,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-lightbox-dialog)"
 }

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -48,5 +48,6 @@
         "@role": "never",
         "@tabindex": "never",
         "@aria-selected": "never"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-listbox-button)"
 }

--- a/src/components/ebay-listbox/marko-tag.json
+++ b/src/components/ebay-listbox/marko-tag.json
@@ -38,5 +38,6 @@
         "@role": "never",
         "@tabindex": "never",
         "@aria-selected": "never"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/building-blocks-ebay-listbox)"
 }

--- a/src/components/ebay-menu-button/marko-tag.json
+++ b/src/components/ebay-menu-button/marko-tag.json
@@ -59,5 +59,6 @@
         "@class": "string",
         "@style": "string",
         "@separator": "boolean"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-menu-button)"
 }

--- a/src/components/ebay-menu/marko-tag.json
+++ b/src/components/ebay-menu/marko-tag.json
@@ -31,5 +31,6 @@
         "@class": "string",
         "@style": "string",
         "@separator": "boolean"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/building-blocks-ebay-menu)"
 }

--- a/src/components/ebay-page-notice/marko-tag.json
+++ b/src/components/ebay-page-notice/marko-tag.json
@@ -34,5 +34,6 @@
         },
         "@html-attributes": "expression"
     },
-    "@dismissed": "bool"
+    "@dismissed": "bool",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/notices-tips-ebay-page-notice)"
 }

--- a/src/components/ebay-pagination/marko-tag.json
+++ b/src/components/ebay-pagination/marko-tag.json
@@ -34,5 +34,6 @@
         "@rel": "#html-rel",
         "@target": "#html-target",
         "@aria-current": "never"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-pagination)"
 }

--- a/src/components/ebay-panel-dialog/marko-tag.json
+++ b/src/components/ebay-panel-dialog/marko-tag.json
@@ -34,5 +34,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-panel-dialog)"
 }

--- a/src/components/ebay-phone-input/marko-tag.json
+++ b/src/components/ebay-phone-input/marko-tag.json
@@ -11,5 +11,6 @@
     "@floating-label": "string",
     "@country-code": "string",
     "@value": "string",
-    "@aria-disabled": "never"
+    "@aria-disabled": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-phone-input-button)"
 }

--- a/src/components/ebay-progress-bar-expressive/marko-tag.json
+++ b/src/components/ebay-progress-bar-expressive/marko-tag.json
@@ -15,5 +15,6 @@
     "@size": {
         "enum": ["large", "medium"]
     },
-    "@a11yText": "string"
+    "@a11yText": "string",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/progress-ebay-progress-bar-expressive)"
 }

--- a/src/components/ebay-progress-bar/marko-tag.json
+++ b/src/components/ebay-progress-bar/marko-tag.json
@@ -7,5 +7,6 @@
     "@html-attributes": "expression",
     "@role": "never",
     "@value": "#html-value",
-    "@max": "#html-max"
+    "@max": "#html-max",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/progress-ebay-progress-bar)"
 }

--- a/src/components/ebay-progress-spinner/marko-tag.json
+++ b/src/components/ebay-progress-spinner/marko-tag.json
@@ -8,5 +8,6 @@
         "type": "expression"
     },
     "@html-attributes": "expression",
-    "@role": "never"
+    "@role": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/progress-ebay-progress-spinner)"
 }

--- a/src/components/ebay-progress-stepper/marko-tag.json
+++ b/src/components/ebay-progress-stepper/marko-tag.json
@@ -24,5 +24,6 @@
         "@current": "boolean",
         "@a11y-text": "string",
         "@number": "number"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/progress-ebay-progress-stepper)"
 }

--- a/src/components/ebay-radio/marko-tag.json
+++ b/src/components/ebay-radio/marko-tag.json
@@ -12,5 +12,6 @@
     "@name": "#html-name",
     "@readonly": "#html-readonly",
     "@value": "#html-value",
-    "@type": "never"
+    "@type": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-radio)"
 }

--- a/src/components/ebay-section-notice/marko-tag.json
+++ b/src/components/ebay-section-notice/marko-tag.json
@@ -35,5 +35,6 @@
         },
         "@html-attributes": "expression"
     },
-    "@dismissed": "bool"
+    "@dismissed": "bool",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/notices-tips-ebay-section-notice)"
 }

--- a/src/components/ebay-section-title/marko-tag.json
+++ b/src/components/ebay-section-title/marko-tag.json
@@ -41,5 +41,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-section-title)"
 }

--- a/src/components/ebay-segmented-buttons/marko-tag.json
+++ b/src/components/ebay-segmented-buttons/marko-tag.json
@@ -29,5 +29,6 @@
         }
     },
     "@target": "#html-target",
-    "@aria-disabled": "never"
+    "@aria-disabled": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-segmented-buttons)"
 }

--- a/src/components/ebay-select/marko-tag.json
+++ b/src/components/ebay-select/marko-tag.json
@@ -27,5 +27,6 @@
         "@label": "#html-label",
         "@selected": "#html-selected",
         "@value": "#html-value"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-select)"
 }

--- a/src/components/ebay-signal/marko-tag.json
+++ b/src/components/ebay-signal/marko-tag.json
@@ -8,5 +8,6 @@
     "@role": "never",
     "@status": {
         "enum": ["neutral", "time-sensitive", "recent", "trustworthy"]
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/graphics-icons-ebay-signal)"
 }

--- a/src/components/ebay-skeleton/marko-tag.json
+++ b/src/components/ebay-skeleton/marko-tag.json
@@ -10,5 +10,6 @@
         "enum": ["small", "large"]
     },
     "@multiline": "boolean",
-    "@a11yText": "string"
+    "@a11yText": "string",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/docs/building-blocks-ebay-skeleton--documentation)"
 }

--- a/src/components/ebay-snackbar-dialog/marko-tag.json
+++ b/src/components/ebay-snackbar-dialog/marko-tag.json
@@ -16,5 +16,6 @@
         "attribute-groups": ["html-attributes"],
         "@action-text": "string",
         "@access-key": "string"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-snackbar-dialog)"
 }

--- a/src/components/ebay-split-button/marko-tag.json
+++ b/src/components/ebay-split-button/marko-tag.json
@@ -32,5 +32,6 @@
         "@separator": "boolean"
     },
     "@target": "#html-target",
-    "@aria-disabled": "never"
+    "@aria-disabled": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-split-button)"
 }

--- a/src/components/ebay-star-rating-select/marko-tag.json
+++ b/src/components/ebay-star-rating-select/marko-tag.json
@@ -9,5 +9,6 @@
     "@disabled": "#html-disabled",
     "@form": "#html-form",
     "@a11y-text": "string",
-    "@a11y-star-text": "array"
+    "@a11y-star-text": "array",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-star-rating-select)"
 }

--- a/src/components/ebay-star-rating/marko-tag.json
+++ b/src/components/ebay-star-rating/marko-tag.json
@@ -6,5 +6,6 @@
     },
     "@html-attributes": "expression",
     "@value": "#html-value",
-    "@a11y-text": "string"
+    "@a11y-text": "string",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/graphics-icons-ebay-star-rating)"
 }

--- a/src/components/ebay-switch/marko-tag.json
+++ b/src/components/ebay-switch/marko-tag.json
@@ -13,5 +13,6 @@
     "@readonly": "#html-readonly",
     "@value": "#html-value",
     "@type": "never",
-    "@role": "never"
+    "@role": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-switch)"
 }

--- a/src/components/ebay-tabs/marko-tag.json
+++ b/src/components/ebay-tabs/marko-tag.json
@@ -28,5 +28,6 @@
         "@aria-labelledby": "never",
         "@role": "never",
         "@hidden": "never"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-tabs)"
 }

--- a/src/components/ebay-textbox/marko-tag.json
+++ b/src/components/ebay-textbox/marko-tag.json
@@ -45,5 +45,6 @@
     "@required": "#html-required",
     "@size": "#html-size",
     "@value": "#html-value",
-    "@aria-invalid": "never"
+    "@aria-invalid": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-textbox)"
 }

--- a/src/components/ebay-toast-dialog/marko-tag.json
+++ b/src/components/ebay-toast-dialog/marko-tag.json
@@ -25,5 +25,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/dialogs-ebay-toast-dialog)"
 }

--- a/src/components/ebay-toggle-button-group/marko-tag.json
+++ b/src/components/ebay-toggle-button-group/marko-tag.json
@@ -14,5 +14,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-toggle-button-group)"
 }

--- a/src/components/ebay-toggle-button/marko-tag.json
+++ b/src/components/ebay-toggle-button/marko-tag.json
@@ -30,5 +30,6 @@
         "@html-attributes": "expression",
         "@src": "string",
         "@size": "string"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/buttons-ebay-toggle-button)"
 }

--- a/src/components/ebay-tooltip/marko-tag.json
+++ b/src/components/ebay-tooltip/marko-tag.json
@@ -64,5 +64,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/notices-tips-ebay-tooltip)"
 }

--- a/src/components/ebay-tourtip/marko-tag.json
+++ b/src/components/ebay-tourtip/marko-tag.json
@@ -73,5 +73,6 @@
             "type": "expression"
         },
         "@html-attributes": "expression"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/notices-tips-ebay-tourtip)"
 }

--- a/src/components/ebay-tri-state-checkbox/marko-tag.json
+++ b/src/components/ebay-tri-state-checkbox/marko-tag.json
@@ -19,5 +19,6 @@
     "@name": "#html-name",
     "@readonly": "#html-readonly",
     "@value": "#html-value",
-    "@type": "never"
+    "@type": "never",
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/form-input-ebay-tri-state-checkbox)"
 }

--- a/src/components/ebay-video/marko-tag.json
+++ b/src/components/ebay-video/marko-tag.json
@@ -33,5 +33,6 @@
         },
         "@src": "string",
         "@type": "string"
-    }
+    },
+    "description": "[view documentation](https://ebay.github.io/ebayui-core/?path=/story/media-ebay-video)"
 }


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Adds a storybook link to the description of each `marko-tag.json`, for easy access in VSCode.

## Context

- I realized the APIs were a little difficult to find

## Screenshots

<img width="555" alt="Screenshot 2024-05-01 at 11 54 19 AM" src="https://github.com/eBay/ebayui-core/assets/26027232/c8bdb0a4-aa6a-4f43-8a64-c2346cb5e96f">
