### PR TITLE
feat(date-textbox): add disabled state

### DIFF
--- a/src/components/ebay-date-textbox/component.ts
+++ b/src/components/ebay-date-textbox/component.ts
@@ -10,6 +10,7 @@ interface DateTextboxInput {
     rangeEnd?: Date | number | string;
     locale?: string;
     range?: boolean;
+    disabled?: boolean;
     "disable-before"?: Date | number | string;
     "disable-after"?: Date | number | string;
     "disable-weekdays"?: number[];
@@ -100,7 +101,7 @@ class DateTextbox extends Marko.Component<Input, State> {
     }
 
     openPopover() {
-        this.state.popover = true;
+        this.state.popover = !this.input.disabled && true;
     }
 
     closePopover() {

--- a/src/components/ebay-date-textbox/component.ts
+++ b/src/components/ebay-date-textbox/component.ts
@@ -101,7 +101,7 @@ class DateTextbox extends Marko.Component<Input, State> {
     }
 
     openPopover() {
-        this.state.popover = !this.input.disabled && true;
+        this.state.popover = true;
     }
 
     closePopover() {

--- a/src/components/ebay-date-textbox/date-textbox.stories.ts
+++ b/src/components/ebay-date-textbox/date-textbox.stories.ts
@@ -73,6 +73,17 @@ export default {
                 },
             },
         },
+        disabled: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description:
+                "If true, the textbox is disabled and popover cannot be opened.",
+            table: {
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
         disableBefore: {
             type: "date",
             control: { type: "date" },

--- a/src/components/ebay-date-textbox/index.marko
+++ b/src/components/ebay-date-textbox/index.marko
@@ -3,6 +3,7 @@ $ const {
     range,
     inputPlaceholderText = "YYYY-MM-DD",
     floatingLabel,
+    disabled,
     ...calendarInput
 } = input;
 $ const [rangeStartPlaceholder, mainPlaceholder] = (
@@ -27,6 +28,7 @@ $ const [rangeStartFloatingLabel, mainFloatingLabel] = (
             placeholder=rangeStartPlaceholder
             floating-label=rangeStartFloatingLabel
             value=state.firstSelected
+            disabled=disabled
             on-blur("handleInputChange", 0)
         />
     </if>
@@ -36,6 +38,7 @@ $ const [rangeStartFloatingLabel, mainFloatingLabel] = (
         placeholder=mainPlaceholder
         buttonAriaLabel=a11yOpenPopoverText
         value=(range ? state.secondSelected : state.firstSelected)
+        disabled=disabled
         on-blur("handleInputChange", range ? 1 : 0)
     >
         <@postfix-icon>

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -89,6 +89,7 @@ $ var defaultTag = fluid ? "div" : "span";
                 class="icon-btn icon-btn--transparent"
                 aria-label=buttonAriaLabel
                 type=(buttonAriaLabel && "button")
+                disabled=disabled
                 on-click("forwardEvent", "button-click")>
                 <${postfixIcon}/>
             </>


### PR DESCRIPTION
- Fixes #2117

## Description

- Add disabled state to `ebay-date-textbox`

## Screenshots

<img width="239" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/68e0ffce-7a2e-46ea-a942-fbaf87cdc557">
<img width="238" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/8a15c73c-13d8-42ba-81cd-0ed7aa8ecd53">
