### PR TITLE
fix(flag): moved flag from icon depdencies to flag

### DIFF
--- a/.changeset/violet-mayflies-rush.md
+++ b/.changeset/violet-mayflies-rush.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+icon: removed flags from depdendencies

--- a/src/components/ebay-flag/style.ts
+++ b/src/components/ebay-flag/style.ts
@@ -1,0 +1,1 @@
+import "@ebay/skin/flag";

--- a/src/components/ebay-icon/style.ts
+++ b/src/components/ebay-icon/style.ts
@@ -1,3 +1,2 @@
 import "@ebay/skin/icon";
 import "@ebay/skin/star-rating";
-import "@ebay/skin/flag";

--- a/src/components/ebay-phone-input/style.ts
+++ b/src/components/ebay-phone-input/style.ts
@@ -1,2 +1,1 @@
 import "@ebay/skin/phone-input";
-import "@ebay/skin/flag";


### PR DESCRIPTION
## Description
* We are loading the flag CSS in icon, this was before the background icon changes. Because of this the CSS is extra large when using icons. So removed flags from icons styles 