### PR TITLE
fix(page-notice): update marko-tag.json

### DIFF
--- a/.changeset/three-bottles-develop.md
+++ b/.changeset/three-bottles-develop.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(page-notice): update marko-tag.json

--- a/src/components/ebay-page-notice/marko-tag.json
+++ b/src/components/ebay-page-notice/marko-tag.json
@@ -10,6 +10,7 @@
     },
     "@icon": "string",
     "@a11y-icon-text": "string",
+    "@a11y-dismiss-text": "string",
     "@title <title>": {
         "attribute-groups": ["html-attributes"],
         "@*": {


### PR DESCRIPTION
- fixes #2179 

## Context

- In certain applications, leaving input out of `marko-tag.json` prevents transformation into `camelCase` from `snake-case`
