### PR TITLE
feat(textbox): prefix & postfix

### DIFF
--- a/.changeset/early-zoos-poke.md
+++ b/.changeset/early-zoos-poke.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+Add prefix and postfix to textbox

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-defaults.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-defaults.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-localized.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-localized.expected.txt
@@ -33,7 +33,7 @@
         [0mEinde[0m
       [36m</label>[39m
       [36m<span[39m
-        [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+        [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
       [36m>[39m
         [36m<input[39m
           [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-with-clear.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-with-clear.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-with-custom-today.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-with-custom-today.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-with-floating-label-array-with-ranged.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-with-floating-label-array-with-ranged.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-with-floating-label-array-without-ranged.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-with-floating-label-array-without-ranged.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-with-floating-label.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-with-floating-label.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-with-placeholder-array-with-ranged.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-with-placeholder-array-with-ranged.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-with-placeholder-array-without-ranged.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-with-placeholder-array-without-ranged.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-date-textbox/test/__snapshots__/renders-with-placeholder.expected.txt
+++ b/src/components/ebay-date-textbox/test/__snapshots__/renders-with-placeholder.expected.txt
@@ -3,7 +3,7 @@
     [33mclass[39m=[32m"date-textbox"[39m
   [36m>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox ebay-date-textbox--main textbox--icon-end"[39m
+      [33mclass[39m=[32m"textbox ebay-date-textbox--main"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-phone-input/index.marko
+++ b/src/components/ebay-phone-input/index.marko
@@ -66,8 +66,8 @@ $ const [selectedCountry] = state.countryNames[state.index];
         onChange("forwardEvent", "change")
         onInput-change("forwardEvent", "change")
     >
-        <@prefixText>
+        <@prefix-text>
             + ${countries[selectedCountry].callingCode}
-        </@prefixText>
+        </@prefix-text>
     </ebay-textbox>
 </span>

--- a/src/components/ebay-textbox/component-browser.ts
+++ b/src/components/ebay-textbox/component-browser.ts
@@ -50,6 +50,18 @@ class Textbox extends Marko.Component<Input> {
         (this.getEl("input") as HTMLInputElement).focus();
     }
 
+    /** Can be removed after `:has` is fully supported */
+    onFocus(e: FocusEvent, el: HTMLInputElement) {
+        this.forwardEvent("focus", e, el);
+        el.parentElement?.classList.add("textbox--focus");
+    }
+
+    /** Can be removed after `:has` is fully supported */
+    onBlur(e: FocusEvent, el: HTMLInputElement) {
+        this.forwardEvent("blur", e, el);
+        el.parentElement?.classList.remove("textbox--focus");
+    }
+
     _setupMakeup() {
         // TODO: makeup-floating-label should be updated so that we can remove the event listeners.
         // It probably makes more sense to just move this functionality into Marko though.

--- a/src/components/ebay-textbox/component-browser.ts
+++ b/src/components/ebay-textbox/component-browser.ts
@@ -17,6 +17,7 @@ interface TextboxInput extends Omit<Marko.Input<"textarea">, `on${string}`> {
     "floating-label-static"?: boolean;
     "prefix-icon"?: Marko.AttrTag<{ renderBody: Marko.Body }>;
     "prefix-text"?: Marko.AttrTag<{ renderBody: Marko.Body }>;
+    "postfix-text"?: Marko.AttrTag<{ renderBody: Marko.Body }>;
     "postfix-icon"?: Marko.AttrTag<{ renderBody: Marko.Body }>;
     invalid?: boolean;
     "button-aria-label"?: AttrString;

--- a/src/components/ebay-textbox/examples/fully-decorated.marko
+++ b/src/components/ebay-textbox/examples/fully-decorated.marko
@@ -1,5 +1,5 @@
 <ebay-textbox
-    placeholder="name"
+    placeholder="0.00"
     on-change("emit", "change")
     on-input-change("emit", "inputChange")
     on-focus("emit", "focus")
@@ -10,9 +10,13 @@
     on-invalid("emit", "invalid")
     on-floating-label-init("emit", "floating-label-init")
     on-button-click("emit", "button-click")
-    ...input
 >
+    <@prefix-icon>
+        <ebay-mail-24-icon/>
+    </@prefix-icon>
+    <@prefix-text>$</@prefix-text>
+    <@postfix-text>/mo</@postfix-text>
     <@postfix-icon>
-        <ebay-profile-24-icon/>
+        <ebay-close-24-icon/>
     </@postfix-icon>
 </ebay-textbox>

--- a/src/components/ebay-textbox/examples/prefix-icon.marko
+++ b/src/components/ebay-textbox/examples/prefix-icon.marko
@@ -10,6 +10,7 @@
     on-invalid("emit", "invalid")
     on-floating-label-init("emit", "floating-label-init")
     on-button-click("emit", "button-click")
+    ...input
 >
     <@prefix-icon>
         <ebay-mail-24-icon/>

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -24,6 +24,7 @@ $ const {
     type,
     value,
     prefixText,
+    postfixText,
     ...htmlInput
 } = input;
 
@@ -33,7 +34,9 @@ $ var hasIcon = prefixIcon || isPostfix;
 $ var isLarge = inputSize === "large";
 $ var displayIcon = Boolean(!multiline && hasIcon);
 $ var prefixId = prefixText && component.getElId("prefix");
+$ var postfixId = postfixText && component.getElId("postfix");
 $ var defaultTag = fluid ? "div" : "span";
+
 <${floatingLabel && defaultTag} class=["floating-label", isLarge && "floating-label--large", opaqueLabel && "floating-label--opaque"]>
     <if(floatingLabel)>
         <label
@@ -47,11 +50,7 @@ $ var defaultTag = fluid ? "div" : "span";
     </if>
     <${defaultTag}
         style=style
-        class=[
-            "textbox",
-            inputClass,
-            displayIcon && isPostfix && "textbox--icon-end"
-        ]>
+        class=["textbox", inputClass, isLarge && "textbox--large", fluid && "textbox--fluid"]>
         <if(displayIcon && prefixIcon)>
             <${prefixIcon}/>
         </if>
@@ -61,15 +60,11 @@ $ var defaultTag = fluid ? "div" : "span";
             </span>
         </if>
         <${multiline ? "textarea" : "input"}
-            aria-describedby=prefixId
+            aria-describedby=[prefixId, postfixId].filter(Boolean).join(" ")
             ...processHtmlAttributes(htmlInput)
             id=id
             key="input"
-            class=[
-                "textbox__control",
-                fluid && "textbox__control--fluid",
-                isLarge && "textbox__control--large"
-            ]
+            class="textbox__control"
             type=(!multiline && (type || "text"))
             value=(!multiline && value)
             disabled=disabled
@@ -84,6 +79,11 @@ $ var defaultTag = fluid ? "div" : "span";
             onInvalid("forwardEvent", "invalid")>
             <if(multiline && value)>${value}</if>
         </>
+        <if(postfixText)>
+            <span id=postfixId ...postfixText>
+                <${postfixText} />
+            </span>
+        </if>
         <if(displayIcon && postfixIcon)>
             <${buttonAriaLabel && "button"}
                 class="icon-btn icon-btn--transparent"

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -25,6 +25,7 @@ $ const {
     value,
     prefixText,
     postfixText,
+    readonly,
     ...htmlInput
 } = input;
 
@@ -50,7 +51,17 @@ $ var defaultTag = fluid ? "div" : "span";
     </if>
     <${defaultTag}
         style=style
-        class=["textbox", inputClass, isLarge && "textbox--large", fluid && "textbox--fluid"]>
+        class=[
+            "textbox",
+            /** start remove after `:has` support */
+            disabled && "textbox--disabled",
+            invalid && "textbox--invalid",
+            readonly && "textbox--readonly",
+            /** end remove after `:has` support */
+            isLarge && "textbox--large",
+            fluid && "textbox--fluid",
+            inputClass,
+        ]>
         <if(displayIcon && prefixIcon)>
             <${prefixIcon}/>
         </if>
@@ -60,7 +71,7 @@ $ var defaultTag = fluid ? "div" : "span";
             </span>
         </if>
         <${multiline ? "textarea" : "input"}
-            aria-describedby=[prefixId, postfixId].filter(Boolean).join(" ")
+            aria-describedby=[prefixId, postfixId].filter(Boolean).join(" ") || undefined
             ...processHtmlAttributes(htmlInput)
             id=id
             key="input"
@@ -69,13 +80,14 @@ $ var defaultTag = fluid ? "div" : "span";
             value=(!multiline && value)
             disabled=disabled
             aria-invalid=(invalid && "true")
+            readonly=readonly
             onKeydown("forwardEvent", "keydown")
             onKeypress("forwardEvent", "keypress")
             onKeyup("forwardEvent", "keyup")
             onChange("forwardEvent", "change")
             onInput("forwardEvent", "input-change")
-            onFocus("forwardEvent", "focus")
-            onBlur("forwardEvent", "blur")
+            onFocus("onFocus")
+            onBlur("onBlur")
             onInvalid("forwardEvent", "invalid")>
             <if(multiline && value)>${value}</if>
         </>

--- a/src/components/ebay-textbox/test/__snapshots__/renders-a-disabled-input-textbox-with-disabled-floating-label.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-a-disabled-input-textbox-with-disabled-floating-label.expected.txt
@@ -9,7 +9,7 @@
       [0mEmail address[0m
     [36m</label>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox"[39m
+      [33mclass[39m=[32m"textbox textbox--disabled"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-a-disabled-input-textbox.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-a-disabled-input-textbox.expected.txt
@@ -9,7 +9,7 @@
       [0mEmail address[0m
     [36m</label>[39m
     [36m<span[39m
-      [33mclass[39m=[32m"textbox"[39m
+      [33mclass[39m=[32m"textbox textbox--disabled"[39m
     [36m>[39m
       [36m<input[39m
         [33mclass[39m=[32m"textbox__control"[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-a-input-textbox-with-invalid-error-state.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-a-input-textbox-with-invalid-error-state.expected.txt
@@ -1,11 +1,11 @@
 [36m<DocumentFragment>[39m
   [36m<span[39m
-    [33mclass[39m=[32m"textbox"[39m
+    [33mclass[39m=[32m"textbox textbox--invalid"[39m
   [36m>[39m
     [36m<input[39m
       [33maria-invalid[39m=[32m"true"[39m
       [33mclass[39m=[32m"textbox__control"[39m
-      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"forwardEvent s0 false 5\",\"onblur\":\"forwardEvent s0 false 6\",\"oninvalid\":\"forwardEvent s0 false 7\"}"[39m
+      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"onFocus s0 false\",\"onblur\":\"onBlur s0 false\",\"oninvalid\":\"forwardEvent s0 false 5\"}"[39m
       [33mdata-marko-key[39m=[32m"@input s0"[39m
       [33mid[39m=[32m"s0-textbox"[39m
       [33mtype[39m=[32m"text"[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-a-textarea-element-with-postfix-icon-button.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-a-textarea-element-with-postfix-icon-button.expected.txt
@@ -1,6 +1,6 @@
 [36m<DocumentFragment>[39m
   [36m<span[39m
-    [33mclass[39m=[32m"textbox textbox--icon-end"[39m
+    [33mclass[39m=[32m"textbox"[39m
   [36m>[39m
     [36m<svg[39m
       [33maria-hidden[39m=[32m"true"[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-a-textarea-element-with-postfix-icon.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-a-textarea-element-with-postfix-icon.expected.txt
@@ -1,10 +1,10 @@
 [36m<DocumentFragment>[39m
   [36m<span[39m
-    [33mclass[39m=[32m"textbox textbox--icon-end"[39m
+    [33mclass[39m=[32m"textbox"[39m
   [36m>[39m
     [36m<input[39m
       [33mclass[39m=[32m"textbox__control"[39m
-      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0-0 false 0\",\"onkeypress\":\"forwardEvent s0-0 false 1\",\"onkeyup\":\"forwardEvent s0-0 false 2\",\"onchange\":\"forwardEvent s0-0 false 3\",\"oninput\":\"forwardEvent s0-0 false 4\",\"onfocus\":\"forwardEvent s0-0 false 5\",\"onblur\":\"forwardEvent s0-0 false 6\",\"oninvalid\":\"forwardEvent s0-0 false 7\"}"[39m
+      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0-0 false 0\",\"onkeypress\":\"forwardEvent s0-0 false 1\",\"onkeyup\":\"forwardEvent s0-0 false 2\",\"onchange\":\"forwardEvent s0-0 false 3\",\"oninput\":\"forwardEvent s0-0 false 4\",\"onfocus\":\"onFocus s0-0 false\",\"onblur\":\"onBlur s0-0 false\",\"oninvalid\":\"forwardEvent s0-0 false 5\"}"[39m
       [33mdata-marko-key[39m=[32m"@input s0-0"[39m
       [33mid[39m=[32m"s0-0-textbox"[39m
       [33mplaceholder[39m=[32m"name"[39m
@@ -13,11 +13,11 @@
     [36m<svg[39m
       [33maria-hidden[39m=[32m"true"[39m
       [33mclass[39m=[32m"icon icon--24"[39m
-      [33mdata-marko-key[39m=[32m"@svg s0-0-7-1-0"[39m
+      [33mdata-marko-key[39m=[32m"@svg s0-0-9-1-0"[39m
       [33mfocusable[39m=[32m"false"[39m
     [36m>[39m
       [36m<defs[39m
-        [33mdata-marko-key[39m=[32m"@defs s0-0-7-1-0"[39m
+        [33mdata-marko-key[39m=[32m"@defs s0-0-9-1-0"[39m
       [36m>[39m
         [36m<symbol[39m
           [33mid[39m=[32m"icon-profile-24"[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-a-textarea-element-with-prefix-icon.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-a-textarea-element-with-prefix-icon.expected.txt
@@ -28,7 +28,7 @@
     [36m</svg>[39m
     [36m<input[39m
       [33mclass[39m=[32m"textbox__control"[39m
-      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0-0 false 0\",\"onkeypress\":\"forwardEvent s0-0 false 1\",\"onkeyup\":\"forwardEvent s0-0 false 2\",\"onchange\":\"forwardEvent s0-0 false 3\",\"oninput\":\"forwardEvent s0-0 false 4\",\"onfocus\":\"forwardEvent s0-0 false 5\",\"onblur\":\"forwardEvent s0-0 false 6\",\"oninvalid\":\"forwardEvent s0-0 false 7\"}"[39m
+      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0-0 false 0\",\"onkeypress\":\"forwardEvent s0-0 false 1\",\"onkeyup\":\"forwardEvent s0-0 false 2\",\"onchange\":\"forwardEvent s0-0 false 3\",\"oninput\":\"forwardEvent s0-0 false 4\",\"onfocus\":\"onFocus s0-0 false\",\"onblur\":\"onBlur s0-0 false\",\"oninvalid\":\"forwardEvent s0-0 false 5\"}"[39m
       [33mdata-marko-key[39m=[32m"@input s0-0"[39m
       [33mid[39m=[32m"s0-0-textbox"[39m
       [33mplaceholder[39m=[32m"email"[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-a-textarea-element.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-a-textarea-element.expected.txt
@@ -4,7 +4,7 @@
   [36m>[39m
     [36m<textarea[39m
       [33mclass[39m=[32m"textbox__control"[39m
-      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"forwardEvent s0 false 5\",\"onblur\":\"forwardEvent s0 false 6\",\"oninvalid\":\"forwardEvent s0 false 7\"}"[39m
+      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"onFocus s0 false\",\"onblur\":\"onBlur s0 false\",\"oninvalid\":\"forwardEvent s0 false 5\"}"[39m
       [33mdata-marko-key[39m=[32m"@input s0"[39m
       [33mid[39m=[32m"s0-textbox"[39m
     [36m/>[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-default-input-textbox-with-an-id.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-default-input-textbox-with-an-id.expected.txt
@@ -4,7 +4,7 @@
   [36m>[39m
     [36m<input[39m
       [33mclass[39m=[32m"textbox__control"[39m
-      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"forwardEvent s0 false 5\",\"onblur\":\"forwardEvent s0 false 6\",\"oninvalid\":\"forwardEvent s0 false 7\"}"[39m
+      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"onFocus s0 false\",\"onblur\":\"onBlur s0 false\",\"oninvalid\":\"forwardEvent s0 false 5\"}"[39m
       [33mdata-marko-key[39m=[32m"@input s0"[39m
       [33mid[39m=[32m"textbox-id"[39m
       [33mtype[39m=[32m"text"[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-default-input-textbox.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-default-input-textbox.expected.txt
@@ -4,7 +4,7 @@
   [36m>[39m
     [36m<input[39m
       [33mclass[39m=[32m"textbox__control"[39m
-      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"forwardEvent s0 false 5\",\"onblur\":\"forwardEvent s0 false 6\",\"oninvalid\":\"forwardEvent s0 false 7\"}"[39m
+      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"onFocus s0 false\",\"onblur\":\"onBlur s0 false\",\"oninvalid\":\"forwardEvent s0 false 5\"}"[39m
       [33mdata-marko-key[39m=[32m"@input s0"[39m
       [33mid[39m=[32m"s0-textbox"[39m
       [33mtype[39m=[32m"text"[39m

--- a/src/components/ebay-textbox/test/__snapshots__/renders-fluid-input-textbox.expected.txt
+++ b/src/components/ebay-textbox/test/__snapshots__/renders-fluid-input-textbox.expected.txt
@@ -1,10 +1,10 @@
 [36m<DocumentFragment>[39m
   [36m<div[39m
-    [33mclass[39m=[32m"textbox"[39m
+    [33mclass[39m=[32m"textbox textbox--fluid"[39m
   [36m>[39m
     [36m<input[39m
-      [33mclass[39m=[32m"textbox__control textbox__control--fluid"[39m
-      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"forwardEvent s0 false 5\",\"onblur\":\"forwardEvent s0 false 6\",\"oninvalid\":\"forwardEvent s0 false 7\"}"[39m
+      [33mclass[39m=[32m"textbox__control"[39m
+      [33mdata-marko[39m=[32m"{\"onkeydown\":\"forwardEvent s0 false 0\",\"onkeypress\":\"forwardEvent s0 false 1\",\"onkeyup\":\"forwardEvent s0 false 2\",\"onchange\":\"forwardEvent s0 false 3\",\"oninput\":\"forwardEvent s0 false 4\",\"onfocus\":\"onFocus s0 false\",\"onblur\":\"onBlur s0 false\",\"oninvalid\":\"forwardEvent s0 false 5\"}"[39m
       [33mdata-marko-key[39m=[32m"@input s0"[39m
       [33mid[39m=[32m"s0-textbox"[39m
       [33mtype[39m=[32m"text"[39m

--- a/src/components/ebay-textbox/textbox.stories.ts
+++ b/src/components/ebay-textbox/textbox.stories.ts
@@ -8,6 +8,7 @@ import FloatingLabelAutocompleteTemplate from "./examples/floating-label-autocom
 import WithBothIcons from "./examples/both-icons.marko";
 import WithPostfixIcon from "./examples/postfix-icon.marko";
 import WithPrefixIcon from "./examples/prefix-icon.marko";
+import FullyDecoratedTemplate from "./examples/fully-decorated.marko";
 import WithLabelCode from "./examples/external-label.marko?raw";
 import DisabledCode from "./examples/external-label-disabled.marko?raw";
 import FloatingLabelCode from "./examples/floating-label.marko?raw";
@@ -15,6 +16,7 @@ import FloatingLabelAutocompleteCode from "./examples/floating-label-autocomplet
 import WithBothIconsCode from "./examples/both-icons.marko?raw";
 import WithPostfixIconCode from "./examples/postfix-icon.marko?raw";
 import WithPrefixIconCode from "./examples/prefix-icon.marko?raw";
+import FullyDecoratedCode from "./examples/fully-decorated.marko?raw";
 
 const Template = (args) => ({
     input: {
@@ -101,6 +103,22 @@ export default {
         postfixIcon: {
             name: "@postfix-icon",
             description: "An `<ebay-{name}-icon>` to show as the postfix icon.",
+            table: {
+                category: "@attribute tags",
+            },
+        },
+        prefixText: {
+            name: "@prefix-text",
+            description:
+                "Text to show before the input. Can be used alongside prefix-icon.",
+            table: {
+                category: "@attribute tags",
+            },
+        },
+        postfixText: {
+            name: "@postfix-text",
+            description:
+                "Text to show after the input. Can be used alongside postfix-icon.",
             table: {
                 category: "@attribute tags",
             },
@@ -307,6 +325,19 @@ BothIcons.parameters = {
     docs: {
         source: {
             code: WithBothIconsCode,
+        },
+    },
+};
+
+export const FullyDecorated = (args) => ({
+    input: args,
+    component: FullyDecoratedTemplate,
+});
+FullyDecorated.args = {};
+FullyDecorated.parameters = {
+    docs: {
+        source: {
+            code: FullyDecoratedCode,
         },
     },
 };


### PR DESCRIPTION
> [!IMPORTANT]
> - Must be reviewed while linked with eBay/skin#2353

## Description

- Add `@prefix-text` and `@postfix-text`
- Move class names into the parent `textbox`
- Include `focus` and `blur` event handlers, to be removed after full support for `:has`

## Screenshots

<img width="322" alt="image" src="https://github.com/eBay/ebayui-core/assets/26027232/7f23f4cd-2cc6-45ba-9fc8-677ea9f3c9e1">

