### PR TITLE
feat(listbox-button): added postfix-label

### DIFF
--- a/.changeset/shaggy-knives-brake.md
+++ b/.changeset/shaggy-knives-brake.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat(listbox-button): added postfix-label

--- a/src/components/ebay-listbox-button/component.ts
+++ b/src/components/ebay-listbox-button/component.ts
@@ -25,6 +25,7 @@ interface ListboxButtonInput extends Omit<Marko.Input<"div">, `on${string}`> {
     hasError?: boolean;
     "a11y-icon-prefix-text"?: AttrString;
     "prefix-label"?: AttrString;
+    "postfix-label"?: AttrString;
     "collapse-on-select"?: boolean;
     "on-expand"?: () => void;
     "on-collapse"?: () => void;

--- a/src/components/ebay-listbox-button/index.marko
+++ b/src/components/ebay-listbox-button/index.marko
@@ -12,6 +12,7 @@ $ const {
     truncate,
     prefixLabel,
     prefixId,
+    postfixLabel,
     unselectedText = "-",
     floatingLabel,
     collapseOnSelect,
@@ -26,7 +27,9 @@ $ const {
 $ var selectedOption = (options as Option[])[state.selectedIndex];
 $ var selectedText = selectedOption && selectedOption.text;
 $ var selectedIcon = selectedOption && selectedOption.icon;
-$ var a11ySelectedIconText = selectedIcon && selectedOption && selectedOption.text;
+$ var a11ySelectedIconText = (
+    selectedIcon && selectedOption && selectedOption.text
+);
 $ var labelId = prefixId && component.getElId("label");
 $ var displayText = selectedText || unselectedText;
 $ var isForm = variant === "form";
@@ -40,6 +43,11 @@ $ var isForm = variant === "form";
     <else-if(selectedText || alwaysDisplay)>
         <span id=labelId class="btn__text">
             ${displayText}
+            <if(postfixLabel)>
+                <span class="btn__postfix-label">
+                    ${` ${postfixLabel}`}
+                </span>
+            </if>
         </span>
     </else-if>
 </macro>
@@ -67,7 +75,8 @@ $ var isForm = variant === "form";
             truncate && "btn--truncated",
             floatingLabel && "btn--floating-label",
         ]
-        aria-label=a11ySelectedIconText && `${a11yIconPrefixText}: ${a11ySelectedIconText}`
+        aria-label=a11ySelectedIconText &&
+        `${a11yIconPrefixText}: ${a11ySelectedIconText}`
         value=selectedText
         type="button"
         disabled=disabled

--- a/src/components/ebay-listbox-button/marko-tag.json
+++ b/src/components/ebay-listbox-button/marko-tag.json
@@ -16,6 +16,7 @@
     "@prefix-label": "string",
     "@floating-label": "string",
     "@unselected-text": "string",
+    "@postfix-label": "string",
     "@aria-describedby": "string",
     "@list-selection": {
         "enum": ["manual", "auto"]


### PR DESCRIPTION
## Description
* Added postfix-label to listbox
* Wrapped it in a span because the team needs this to override in order to test their gold standard
* No documentation added. This is not a pattern we want to expose

## References
https://github.com/eBay/ebayui-core/issues/2201

## Screenshots
<img width="212" alt="Screenshot 2024-06-25 at 11 45 41 AM" src="https://github.com/eBay/ebayui-core/assets/1755269/8b36a9c6-4aed-4ca0-9ae0-8fca9bde0f70">

<!-- Upload screenshots if appropriate. -->