### PR TITLE
fix(carousel): removed flickering

### DIFF
--- a/.changeset/curly-lions-agree.md
+++ b/.changeset/curly-lions-agree.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(carousel): removed flickering from controlled

--- a/src/components/ebay-carousel/component.ts
+++ b/src/components/ebay-carousel/component.ts
@@ -61,8 +61,8 @@ interface State {
         scrollTransitioning?: boolean;
     };
     items: (Item & {
-        left: number;
-        right: number;
+        left?: number;
+        right?: number;
     })[];
     index: number;
     slideWidth: number;
@@ -129,7 +129,7 @@ class Carousel extends Marko.Component<Input, State> {
 
             while (high - low > 1) {
                 const mid = Math.floor((low + high) / 2);
-                if (scrollLeft > items[mid * itemsPerSlide].left) {
+                if (scrollLeft > items[mid * itemsPerSlide].left!) {
                     low = mid;
                 } else {
                     high = mid;
@@ -137,10 +137,10 @@ class Carousel extends Marko.Component<Input, State> {
             }
 
             const deltaLow = Math.abs(
-                scrollLeft - items[low * itemsPerSlide].left,
+                scrollLeft - items[low * itemsPerSlide].left!,
             );
             const deltaHigh = Math.abs(
-                scrollLeft - items[high * itemsPerSlide].left,
+                scrollLeft - items[high * itemsPerSlide].left!,
             );
             closest = this.normalizeIndex(
                 state,
@@ -161,14 +161,14 @@ class Carousel extends Marko.Component<Input, State> {
         if (!items.length) {
             return 0;
         }
-        return Math.min(items[index].left, this.getMaxOffset(state)) || 0;
+        return Math.min(items[index].left!, this.getMaxOffset(state)) || 0;
     }
 
     getMaxOffset({ items, slideWidth }: State) {
         if (!items.length) {
             return 0;
         }
-        return Math.max(items[items.length - 1].right - slideWidth, 0) || 0;
+        return Math.max(items[items.length - 1].right! - slideWidth, 0) || 0;
     }
 
     getSlide({ index, itemsPerSlide }: State, i: number = index) {
@@ -218,10 +218,10 @@ class Carousel extends Marko.Component<Input, State> {
 
             if (delta === LEFT && !itemsPerSlide) {
                 // If going left without items per slide, go as far left as possible while keeping this item fully in view.
-                const targetOffset = item.right - slideWidth;
+                const targetOffset = item.right! - slideWidth;
                 do {
                     item = items[--i];
-                } while (item && item.left >= targetOffset);
+                } while (item && item.left! >= targetOffset);
                 i += 1;
             }
         }
@@ -284,7 +284,7 @@ class Carousel extends Marko.Component<Input, State> {
             item.fullyVisible =
                 item.left === undefined ||
                 (item.left - offset >= -0.01 &&
-                    item.right - offset <= slideWidth + 0.01);
+                    item.right! - offset <= slideWidth + 0.01);
         });
 
         const data = Object.assign({}, state, {
@@ -494,8 +494,6 @@ class Carousel extends Marko.Component<Input, State> {
                 key: item.key || i.toString(),
                 style: item.style,
                 renderBody: item.renderBody,
-                left: 0,
-                right: 0,
             };
         });
 

--- a/src/components/ebay-carousel/examples/discrete-controlled.marko
+++ b/src/components/ebay-carousel/examples/discrete-controlled.marko
@@ -1,0 +1,54 @@
+export interface Input {
+    items: number;
+    index: number;
+    itemsPerSlide: number;
+    gap: number;
+    a11yPreviousText: string;
+    a11yNextText: string;
+}
+
+export interface State {
+    index?: number;
+}
+
+class {
+    onCreate() {
+        this.state = {
+            index: 0
+        }
+    }
+    onMove({visibleIndexes}) {
+        this.state.index = visibleIndexes[0];
+    }
+}
+
+<style>
+    .demo2-card {
+        color: #cdf4fd;
+        background: #a1208b;
+        font-size: 36px;
+        font-weight: bold;
+        height: 330px;
+        line-height: 330px;
+        text-align: center;
+    }
+</style>
+
+<ebay-carousel
+    ...input
+    index=state.index
+    itemsPerSlide=(input.itemsPerSlide || 2)
+    on-next("emit", "next")
+    on-previous("emit", "previous")
+    on-move("onMove")>
+    <@item style={ width: 400 } class="demo2-card">Card 1</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 2</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 3</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 4</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 5</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 6</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 7</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 8</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 9</@item>
+    <@item style={ width: 400 } class="demo2-card">Card 10</@item>
+</ebay-carousel>


### PR DESCRIPTION
## Description
* Before typescript was introduced, the left/right offsets for each items could be initially undefined. This was to verify that the component was being re-rendered. After typescript, the offsets were set to 0. There was a check to verify if the carousel is animating which would specifically check for `undefined`. Since these were always set, that check would never pass. 
* We need an initial value of null/undefined. The problem with setting 0, is that 0 could be a possible offset and cannot be used to check if there is a re-render.
* One more issue: there are some comparison checks. If you do any number `>` or `<` to `undefined`, it evaluates as false. This is not the case if its 0. Unfortunately, the code was written expecting those checks to evaluate as false. 

## Context
* I added undefined as the default value. 
* I added `!` to the undefined values to allow typescript to pass compilation. 
* I also added an example of how to do controlled carousel. 

## References
https://github.com/eBay/ebayui-core/issues/2206