### PR TITLE
fix(ebay-icon): bugfixes for icons

### DIFF
--- a/.changeset/pink-pans-applaud.md
+++ b/.changeset/pink-pans-applaud.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+icon: fixed legacy program badge, added color to filled icons, fixed fit icons

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "@commitlint/cli": "^19",
                 "@commitlint/config-conventional": "^19",
                 "@ebay/browserslist-config": "^2.9.0",
-                "@ebay/skin": "~18.0.0",
+                "@ebay/skin": "~18.0.5",
                 "@google/model-viewer": "3.5.0",
                 "@lasso/marko-taglib": "^2.0.6",
                 "@marko/compiler": "^5.37.4",
@@ -107,7 +107,7 @@
                 "wdio-chromedriver-service": "^8"
             },
             "peerDependencies": {
-                "@ebay/skin": "~18.0.0",
+                "@ebay/skin": "~18.0.5",
                 "marko": ">= ^4.27.0 || >= ^5.31.12"
             }
         },
@@ -3110,12 +3110,12 @@
             "dev": true
         },
         "node_modules/@ebay/skin": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/@ebay/skin/-/skin-18.0.0.tgz",
-            "integrity": "sha512-m+DY9DHNNBy1/HPSiEJqseYnBHhGAMXfGScHegjNr8Q5yqktnUFFD7GdpKBW/a4R9u5fptCGZ9vD8WEeR90x0w==",
+            "version": "18.0.5",
+            "resolved": "https://registry.npmjs.org/@ebay/skin/-/skin-18.0.5.tgz",
+            "integrity": "sha512-ZpvL1jSDGCKKNAcTbQOA0AEVElEnKAs+MZ8Po+n7pVxvqpPe8oxqBNO5mjAIDauI0Ncp+/PP+JtdulPM5yFnZg==",
             "dev": true,
             "dependencies": {
-                "postcss": "^8.4.38",
+                "postcss": "^8.4.39",
                 "postcss-mixins": "^10.0.1",
                 "postcss-nested": "^6.0.1",
                 "postcss-simple-vars": "^7.0.1"
@@ -31277,9 +31277,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.38",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+            "version": "8.4.39",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+            "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
             "dev": true,
             "funding": [
                 {
@@ -31297,7 +31297,7 @@
             ],
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.0.1",
                 "source-map-js": "^1.2.0"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "@commitlint/cli": "^19",
         "@commitlint/config-conventional": "^19",
         "@ebay/browserslist-config": "^2.9.0",
-        "@ebay/skin": "~18.0.0",
+        "@ebay/skin": "~18.0.5",
         "@google/model-viewer": "3.5.0",
         "@lasso/marko-taglib": "^2.0.6",
         "@marko/compiler": "^5.37.4",
@@ -146,7 +146,7 @@
         "wdio-chromedriver-service": "^8"
     },
     "peerDependencies": {
-        "@ebay/skin": "~18.0.0",
+        "@ebay/skin": "~18.0.5",
         "marko": ">= ^4.27.0 || >= ^5.31.12"
     },
     "dependencies": {

--- a/scripts/import-svg.js
+++ b/scripts/import-svg.js
@@ -50,9 +50,18 @@ const iconSizes = [
     "24-colored",
     "30-colored",
     "32-colored",
+    "48-colored",
     "64-colored",
 ];
-const sizeMatcher = new RegExp(`-(${iconSizes.join("|")})$`);
+
+const skipExamples = [
+    "star-dynamic",
+    "eek-arrow",
+    "eek-range-arrow",
+    "avatar-signed-out",
+];
+
+const sizeMatcher = new RegExp(`-(${iconSizes.join("|")})(?:-fit)?$`);
 
 const htmlMinifierOptions = {
     keepClosingSlash: true,
@@ -220,6 +229,9 @@ function generateExamples(type, iconMap) {
     const file = fs.readFileSync(exampleFile, "utf-8");
     const exampleHTML = [];
     for (const name of iconMap) {
+        if (skipExamples.indexOf(name) > -1) {
+            continue;
+        }
         const postfixName = type === "icon" ? "-icon" : "";
         const iconName = `ebay-${name}${postfixName}`;
         exampleHTML.push(`    div

--- a/src/components/ebay-icon/examples/all.marko
+++ b/src/components/ebay-icon/examples/all.marko
@@ -356,12 +356,6 @@ div.icon-examples
 
     div
         span.icon
-            ebay-avatar-signed-out-icon
-        span.text
-            -- ebay-avatar-signed-out-icon
-
-    div
-        span.icon
             ebay-background-removal-24-icon
         span.text
             -- ebay-background-removal-24-icon
@@ -1307,18 +1301,6 @@ div.icon-examples
             ebay-ebay-refurbished-24-icon
         span.text
             -- ebay-ebay-refurbished-24-icon
-
-    div
-        span.icon
-            ebay-eek-arrow-icon
-        span.text
-            -- ebay-eek-arrow-icon
-
-    div
-        span.icon
-            ebay-eek-range-arrow-icon
-        span.text
-            -- ebay-eek-range-arrow-icon
 
     div
         span.icon
@@ -3635,12 +3617,6 @@ div.icon-examples
             ebay-split-view-filled-24-icon
         span.text
             -- ebay-split-view-filled-24-icon
-
-    div
-        span.icon
-            ebay-star-dynamic-icon
-        span.text
-            -- ebay-star-dynamic-icon
 
     div
         span.icon

--- a/src/components/ebay-icon/icons/ebay-legacy-authenticity-guarantee-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-authenticity-guarantee-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-authenticity-guarantee-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-authenticity-guarantee-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-click-to-call-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-click-to-call-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-click-to-call-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-click-to-call-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-escrow-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-escrow-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-escrow-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-escrow-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-free-warranty-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-free-warranty-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-free-warranty-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-free-warranty-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-chf-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-chf-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-money-back-guarantee-chf-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-money-back-guarantee-chf-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-eu-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-eu-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-money-back-guarantee-eu-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-money-back-guarantee-eu-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-uk-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-uk-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-money-back-guarantee-uk-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-money-back-guarantee-uk-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-us-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-us-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-money-back-guarantee-us-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-money-back-guarantee-us-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-zl-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-money-back-guarantee-zl-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-money-back-guarantee-zl-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-money-back-guarantee-zl-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-legacy-top-rated-seller-48-colored-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-legacy-top-rated-seller-48-colored-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="legacy-top-rated-seller-48-colored" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="legacy-top-rated-seller-48-colored" _size="48-colored" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-trend-down-16-fit-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-trend-down-16-fit-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="trend-down-16-fit" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="trend-down-16-fit" _size="16" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/icons/ebay-trend-up-16-fit-icon/index.marko
+++ b/src/components/ebay-icon/icons/ebay-trend-up-16-fit-icon/index.marko
@@ -2,4 +2,4 @@ import { symbol } from "./symbol";
 
 import type { Input as IconInput } from "../../component-browser"
 export type Input = Omit<IconInput, `_${string}`>;
-<ebay-icon ...input _name="trend-up-16-fit" _size="" _type="icon" _themes=symbol/>
+<ebay-icon ...input _name="trend-up-16-fit" _size="16" _type="icon" _themes=symbol/>

--- a/src/components/ebay-icon/index.marko
+++ b/src/components/ebay-icon/index.marko
@@ -16,13 +16,24 @@ $ const {
 } = input;
 $ (input as any).toJSON = noop;
 static function getIconClass(type: string, name: string, size?: string) {
+    var colorMap:{[index: string]: string} =  {
+        "confirmation-filled-16": "confirmation-filled",
+        "confirmation-filled-24": "confirmation-filled",
+        "incormation-filled-16": "incormation-filled",
+        "incormation-filled-24": "incormation-filled",
+        "attention-filled-16": "attention-filled",
+        "attention-filled-24": "attention-filled",
+    };
+
+    var extraClass = !!colorMap[name] ? ` icon--${colorMap[name]}` : "";
+
     if (size) {
-        return `icon icon--${size}`;
+        return `icon icon--${size}${extraClass}`;
     } else if (type === "icon") {
-        return `icon icon--${name}`;
+        return `icon icon--${name}${extraClass}`;
     } else {
         var dashedName = name.replace(type, `${type}-`);
-        return `${type} ${dashedName}`;
+        return `${type} ${dashedName}${extraClass}`;
     }
 }
 $ var noTitle = a11yVariant === "label";

--- a/src/components/ebay-listbox-button/test/__snapshots__/renders-with-error.expected.txt
+++ b/src/components/ebay-listbox-button/test/__snapshots__/renders-with-error.expected.txt
@@ -140,7 +140,7 @@
     [36m>[39m
       [36m<svg[39m
         [33maria-hidden[39m=[32m"true"[39m
-        [33mclass[39m=[32m"icon icon--16"[39m
+        [33mclass[39m=[32m"icon icon--16 icon--attention-filled"[39m
         [33mdata-marko-key[39m=[32m"@svg s0-3-0"[39m
         [33mfocusable[39m=[32m"false"[39m
       [36m>[39m


### PR DESCRIPTION
## Description
* Fixed program badges sizes
* Fixed filled icons to have color set by default
* Fixed fit icons to be correctly sized
* Removed several incorrectly sized icons from docs (such as EEK icons and avatar icons which are custom implemtations)

## Screenshots
<img width="709" alt="Screenshot 2024-07-12 at 9 32 58 AM" src="https://github.com/user-attachments/assets/9a1ddee2-3d5f-4dcb-af4b-618701be0c35">
<img width="707" alt="Screenshot 2024-07-12 at 9 33 12 AM" src="https://github.com/user-attachments/assets/3ce396b3-5c16-4e58-a251-d9e83b6c45fa">
<img width="508" alt="Screenshot 2024-07-12 at 9 33 21 AM" src="https://github.com/user-attachments/assets/6b33c38e-0f5d-4933-8475-da449f824dd1">

## References
https://github.com/eBay/ebayui-core/issues/2215