### PR TITLE
docs(lightbox-dialog): add expanded to storybook

### DIFF
--- a/.changeset/healthy-waves-collect.md
+++ b/.changeset/healthy-waves-collect.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Edit lightbox dialog documentation

--- a/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.ts
+++ b/src/components/ebay-lightbox-dialog/lightbox-dialog.stories.ts
@@ -33,6 +33,11 @@ export default {
             control: { type: "boolean" },
             description: "Whether dialog is open.",
         },
+        expanded: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description: "Whether dialog is expanded.",
+        },
         focus: {
             control: { type: "text" },
             description:


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Add expanded state to storybook

## Context

- `expanded` was missing from sb but included in ts

## Screenshots

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/94b1b169-5020-4568-8abe-7962cf856d37">
