### PR TITLE
fix(menu-button): allow single item

### DIFF
--- a/.changeset/beige-sloths-begin.md
+++ b/.changeset/beige-sloths-begin.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Menu button single item fix

--- a/src/common/menu-utils/index.ts
+++ b/src/common/menu-utils/index.ts
@@ -8,7 +8,7 @@ export interface MenuItem extends Omit<Marko.Input<"button">, `on${string}`> {
 }
 
 export interface BaseMenuInput {
-    items?: Marko.RepeatableAttrTag<MenuItem>;
+    items?: Marko.RepeatableAttrTag<MenuItem> | [Marko.AttrTag<MenuItem>];
     type?: string;
 }
 
@@ -59,9 +59,7 @@ export class MenuUtils<
             from items to pass correct indexes to state
             Any other component that doesn't have separator should pass through
         */
-        this.items = ((input.items as Marko.AttrTag<MenuItem>[]) || []).filter(
-            (item) => !item.separator,
-        );
+        this.items = [...(input.items || [])].filter((item) => !item.separator);
         this.type = input.type;
         if (this.isRadio()) {
             return {
@@ -110,7 +108,7 @@ export class MenuUtils<
 
     getSeparatorMap(input: Input) {
         let separatorCount = 0;
-        return ((input.items as MenuItem[]) || []).reduce(
+        return [...(input.items || [])].reduce(
             (map, item, index) => {
                 if (item.separator) {
                     map[index - separatorCount] = true;


### PR DESCRIPTION
- Resolves #2241 

## Description

- When `marko-tag.json` doesn't process `@item` (i. e. somebody passes `@items` or we remove it in the future), a single item will be passed instead that has `[Symbol.iterator]` attached but not array methods like `.map` or `.filter`.
- TypeScript support for Marko behaves strangely with transformations from `marko-tag.json`, so an additional type intersection is required.
