### PR TITLE
fix(calendar): account for timezones with "today" calculation

### DIFF
--- a/.changeset/two-mirrors-doubt.md
+++ b/.changeset/two-mirrors-doubt.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Use local time in calendar

--- a/src/common/dates/date-utils.ts
+++ b/src/common/dates/date-utils.ts
@@ -40,8 +40,19 @@ export function dateArgToISO(arg: DateConstructor["arguments"]) {
     return /^\d\d\d\d-\d\d-\d\d$/g.test(date) ? date : undefined;
 }
 
+/**
+ * ISO 8601 date format (YYYY-MM-DD) in **UTC** timezone
+ */
 export function toISO(date: Date): DayISO {
     return date.toISOString().slice(0, 10) as DayISO;
+}
+
+/**
+ * ISO 8601 date format (YYYY-MM-DD) in **local** timezone
+ */
+export function toLocalISO(date: Date): DayISO {
+    // This works because Canada uses the YYYY-MM-DD format
+    return date.toLocaleDateString("en-CA") as DayISO;
 }
 
 export function fromISO(iso: DayISO) {

--- a/src/components/ebay-calendar/component.ts
+++ b/src/components/ebay-calendar/component.ts
@@ -6,6 +6,7 @@ import {
     getWeekdayInfo,
     offsetISO,
     toISO,
+    toLocalISO,
     type DayISO,
 } from "../../common/dates/date-utils";
 import { localeDefault } from "../../common/dates";
@@ -67,7 +68,7 @@ class Calendar extends Marko.Component<Input, State> {
     onCreate(input: Input) {
         this.locale = input.locale;
         const { firstDayOfWeek, weekdayLabels } = getWeekdayInfo(input.locale);
-        const todayISO = toISO(new Date());
+        const todayISO = toLocalISO(new Date());
         this.state = {
             focusISO: null,
             baseISO: todayISO,


### PR DESCRIPTION
- Resolves #2244 

## Description

- Use the local timezone instead of UTC for "today"

## Context

- For testing, you can modify timezone in system settings until your date doesn't match the UTC date. In California during the morning, China Standard Time is a day ahead so I used that. 
