### PR TITLE
fix(ebay-toggle-button): update types for subtitle and icon

### DIFF
--- a/.changeset/clean-birds-cover.md
+++ b/.changeset/clean-birds-cover.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+subtitle and icon types fix for 'ebay-toggle-button'

--- a/src/components/ebay-toggle-button/component.ts
+++ b/src/components/ebay-toggle-button/component.ts
@@ -8,13 +8,13 @@ export interface ToggleButtonEvent {
 interface ToggleButtonInput extends Omit<Marko.Input<"span">, `on${string}`> {
     pressed?: boolean;
     "layout-type"?: string;
-    icon?: Marko.Renderable;
+    icon?: Marko.AttrTag<Marko.Renderable>;
     img?: Marko.AttrTag<{
         src: string;
         alt: string;
         fillPlacement?: string;
     }>;
-    subtitle?: string | Marko.Renderable;
+    subtitle?: string | Marko.AttrTag<Marko.Renderable>;
     renderBody?: Marko.Body;
     "on-toggle"?: (event: ToggleButtonEvent) => void;
 }


### PR DESCRIPTION
fix for: ['ebay-toggle-button-group' shows type errors for <@subtitle> and <@icon> inputs ](https://github.com/eBay/ebayui-core/issues/2247)

## Description

<!--- What are the changes? -->

## Context

<!--- Why did you make these changes, and why in this particular way? -->

## References

<!-- Include links to JIRA, Github, etc. if appropriate. -->

## Screenshots

<!-- Upload screenshots if appropriate. -->
