### PR TITLE
fix(line-chart): updated deprecated token for tooltip bg

### DIFF
--- a/.changeset/yellow-laws-watch.md
+++ b/.changeset/yellow-laws-watch.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(line-chart): updated deprecated token for tooltip bg

--- a/src/common/charts/shared.ts
+++ b/src/common/charts/shared.ts
@@ -5,7 +5,7 @@ export const chartFontFamily = '"Market Sans", Arial, sans-serif',
     legendColor = "var(--color-data-viz-legend)",
     legendInactiveColor = "var(--color-data-viz-legend-inactive)",
     legendHoverColor = "var(--color-data-viz-legend-hover)",
-    tooltipBackgroundColor = "var(--color-neutral-0)",
+    tooltipBackgroundColor = "var(--color-background-primary)",
     tooltipShadows =
         "drop-shadow(0 2px 7px var(--color-data-viz-tooltip-shadow-primary)) drop-shadow(0 5px 7px var(--color-data-viz-tooltip-shadow-secondary))",
     lineChartPrimaryColor = "var(--color-data-viz-line-chart-primary)",


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

<!--- What are the changes? -->
The tooltip background color makes the text unreadable due to using a deprecated token. This PR simply updates the token used to a semantic one.
## Context

<!--- Why did you make these changes, and why in this particular way? -->
Resolves #2255 

## Screenshots

<!-- Upload screenshots if appropriate. -->
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/45e75459-44db-461f-bc54-4e927fc89341">
