### PR TITLE
feat(menu/filter-menu): added keydown events and attributes

### DIFF
--- a/.changeset/strong-zoos-judge.md
+++ b/.changeset/strong-zoos-judge.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+feat(menu/filter-menu): added keydown events and attributes

--- a/src/components/ebay-filter-menu/component.ts
+++ b/src/components/ebay-filter-menu/component.ts
@@ -82,6 +82,13 @@ export default class extends MenuUtils<Input, MenuState> {
                 this._toggleItemChecked(index, ev, itemEl);
             });
         }
+        eventUtils.handleArrowsKeydown(ev, () => {
+            setTimeout(() => {
+                if (this._rovingTabIndex.index !== index) {
+                    this._emitComponentEvent("keydown", ev, { index: this._rovingTabIndex.index });
+                }
+            });
+        });
     }
 
     handleFooterButtonClick(originalEvent: Event) {

--- a/src/components/ebay-filter-menu/filter-menu.stories.ts
+++ b/src/components/ebay-filter-menu/filter-menu.stories.ts
@@ -83,6 +83,18 @@ export default {
                 },
             },
         },
+        onKeydown: {
+            action: "on-keydown",
+            description: "Triggered on keydown",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary:
+                        "{ el, checked, itemChecked, index, originalEvent }",
+                },
+            },
+        },
+
         footerClick: {
             action: "on-footer-click",
             description: "Triggered on footer clicked",

--- a/src/components/ebay-filter-menu/index.marko
+++ b/src/components/ebay-filter-menu/index.marko
@@ -1,5 +1,4 @@
-import { processHtmlAttributes } from "../../common/html-attributes"
-
+import { processHtmlAttributes } from "../../common/html-attributes";
 $ const {
     variant,
     footer,
@@ -13,25 +12,34 @@ $ const {
     formMethod,
     items,
     type,
+    ariaLabel,
+    ariaLabelledby,
     ...htmlInput
 } = input;
-
 $ var isRadio = type === "radio";
-$ var prefixName = isRadio ? 'radio' : 'checkbox';
+$ var prefixName = isRadio ? "radio" : "checkbox";
 $ var baseClass = classPrefix || "filter-menu";
 $ var isForm = variant === "form";
 <span
     ...processHtmlAttributes(htmlInput)
     key="container"
     class=[classPrefix ? `${baseClass}__menu` : baseClass, inputClass]
-    style=style>
+    style=style
+>
     <${isForm && "form"}
         name=formName
         action=formAction
         method=formMethod
-        onSubmit("handleFormSubmit")>
-        <div key="menu" class=`${baseClass}__items` role=(!isForm && "menu")>
-            <for|item, i| of=(items || [])>
+        onSubmit("handleFormSubmit")
+    >
+        <div
+            key="menu"
+            class=`${baseClass}__items`
+            role=!isForm && "menu"
+            aria-label=ariaLabel
+            aria-labelledby=ariaLabelledby
+        >
+            <for|item, i| of=items || []>
                 $ const {
                     class: itemClass,
                     disabled,
@@ -45,20 +53,28 @@ $ var isForm = variant === "form";
                     class=[`${baseClass}__item`, itemClass]
                     role=(isRadio ? "menuitemradio" : "menuitemcheckbox")
                     aria-checked=String(isChecked)
-                    aria-disabled=(disabled && "true")
-                    for=(isForm && component.elId(`${prefixName}-${i}`))
+                    aria-disabled=disabled && "true"
+                    for=isForm && component.elId(`${prefixName}-${i}`)
                     onClick("handleItemClick", i)
-                    onKeydown("handleItemKeydown", i)>
+                    onKeydown("handleItemKeydown", i)
+                >
                     <if(isForm)>
-                        <if (isRadio)>
-                            <ebay-radio id:scoped=`${prefixName}-${i}` checked=isChecked on-change("handleRadioClick", i)/>
+                        <if(isRadio)>
+                            <ebay-radio
+                                id:scoped=`${prefixName}-${i}`
+                                checked=isChecked
+                                on-change("handleRadioClick", i)
+                            />
                         </if>
                         <else>
-                            <ebay-checkbox id:scoped=`${prefixName}-${i}` checked=isChecked/>
+                            <ebay-checkbox
+                                id:scoped=`${prefixName}-${i}`
+                                checked=isChecked
+                            />
                         </else>
                     </if>
                     <else>
-                        <if (isRadio)>
+                        <if(isRadio)>
                             <span class=`${baseClass}__radio`>
                                 <if(isChecked)>
                                     <ebay-radio-checked-18-icon/>
@@ -90,22 +106,20 @@ $ var isForm = variant === "form";
                 type=(isForm ? "submit" : "button")
                 aria-label=a11yFooterText
                 class=`${baseClass}__footer`
-                onClick(!isForm && "handleFooterButtonClick")>
+                onClick(!isForm && "handleFooterButtonClick")
+            >
                 ${footerText}
             </button>
         </if>
         <else-if(footer)>
-            $ const {
-                renderBody,
-                a11yFooterText,
-                ...htmlFooter
-            } = footer;
+            $ const { renderBody, a11yFooterText, ...htmlFooter } = footer;
             <button
                 ...processHtmlAttributes(htmlFooter)
                 type=(isForm ? "submit" : "button")
                 aria-label=a11yFooterText
                 class=`${baseClass}__footer`
-                onClick(!isForm && "handleFooterButtonClick")>
+                onClick(!isForm && "handleFooterButtonClick")
+            >
                 <${renderBody}/>
             </button>
         </else-if>

--- a/src/components/ebay-filter-menu/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-filter-menu/test/__snapshots__/test.server.js.snap
@@ -622,6 +622,216 @@ exports[`filter-menu > renders disabled item 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
+exports[`filter-menu > renders with aria-label 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"filter-menu"[39m
+    [33mtext[39m=[32m"Button"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33maria-label[39m=[32m"test"[39m
+      [33mclass[39m=[32m"filter-menu__items"[39m
+      [33mrole[39m=[32m"menu"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-checkbox-unchecked-18"[39m
+                [33mviewBox[39m=[32m"0 0 18 18"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M6.4 17h5.2c1.137 0 1.929 0 2.546-.051.605-.05.953-.142 1.216-.276a3 3 0 0 0 1.311-1.311c.134-.263.226-.611.276-1.216.05-.617.051-1.41.051-2.546V6.4c0-1.137 0-1.929-.051-2.546-.05-.605-.142-.953-.276-1.216a3 3 0 0 0-1.311-1.311c-.263-.134-.611-.226-1.216-.276C13.529 1.001 12.736 1 11.6 1H6.4c-1.137 0-1.929 0-2.546.051-.605.05-.953.142-1.216.276a3 3 0 0 0-1.311 1.311c-.134.263-.226.611-.276 1.216C1.001 4.471 1 5.264 1 6.4v5.2c0 1.137 0 1.929.051 2.546.05.605.142.953.276 1.216a3 3 0 0 0 1.311 1.311c.263.134.611.226 1.216.276.617.05 1.41.051 2.546.051ZM.436 15.816C0 14.96 0 13.84 0 11.6V6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.04 0 4.16 0 6.4 0h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C18 3.04 18 4.16 18 6.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C14.96 18 13.84 18 11.6 18H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 1[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 2[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 3[0m
+        [36m</span>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<button[39m
+      [33maria-label[39m=[32m"a11y text for footer button"[39m
+      [33mclass[39m=[32m"filter-menu__footer"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [0mApply[0m
+    [36m</button>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m"
+`;
+
+exports[`filter-menu > renders with aria-labelledby 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"filter-menu"[39m
+    [33mtext[39m=[32m"Button"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33maria-labelledby[39m=[32m"test"[39m
+      [33mclass[39m=[32m"filter-menu__items"[39m
+      [33mrole[39m=[32m"menu"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<defs>[39m
+              [36m<symbol[39m
+                [33mid[39m=[32m"icon-checkbox-unchecked-18"[39m
+                [33mviewBox[39m=[32m"0 0 18 18"[39m
+              [36m>[39m
+                [36m<path[39m
+                  [33md[39m=[32m"M6.4 17h5.2c1.137 0 1.929 0 2.546-.051.605-.05.953-.142 1.216-.276a3 3 0 0 0 1.311-1.311c.134-.263.226-.611.276-1.216.05-.617.051-1.41.051-2.546V6.4c0-1.137 0-1.929-.051-2.546-.05-.605-.142-.953-.276-1.216a3 3 0 0 0-1.311-1.311c-.263-.134-.611-.226-1.216-.276C13.529 1.001 12.736 1 11.6 1H6.4c-1.137 0-1.929 0-2.546.051-.605.05-.953.142-1.216.276a3 3 0 0 0-1.311 1.311c-.134.263-.226.611-.276 1.216C1.001 4.471 1 5.264 1 6.4v5.2c0 1.137 0 1.929.051 2.546.05.605.142.953.276 1.216a3 3 0 0 0 1.311 1.311c.263.134.611.226 1.216.276.617.05 1.41.051 2.546.051ZM.436 15.816C0 14.96 0 13.84 0 11.6V6.4c0-2.24 0-3.36.436-4.216A4 4 0 0 1 2.184.436C3.04 0 4.16 0 6.4 0h5.2c2.24 0 3.36 0 4.216.436a4 4 0 0 1 1.748 1.748C18 3.04 18 4.16 18 6.4v5.2c0 2.24 0 3.36-.436 4.216a4 4 0 0 1-1.748 1.748C14.96 18 13.84 18 11.6 18H6.4c-2.24 0-3.36 0-4.216-.436a4 4 0 0 1-1.748-1.748Z"[39m
+                [36m/>[39m
+              [36m</symbol>[39m
+            [36m</defs>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 1[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 2[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33maria-checked[39m=[32m"false"[39m
+        [33mclass[39m=[32m"filter-menu__item"[39m
+        [33mrole[39m=[32m"menuitemcheckbox"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__checkbox"[39m
+        [36m>[39m
+          [36m<svg[39m
+            [33maria-hidden[39m=[32m"true"[39m
+            [33mclass[39m=[32m"icon icon--18"[39m
+            [33mfocusable[39m=[32m"false"[39m
+          [36m>[39m
+            [36m<use[39m
+              [33mhref[39m=[32m"#icon-checkbox-unchecked-18"[39m
+            [36m/>[39m
+          [36m</svg>[39m
+        [36m</span>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"filter-menu__text"[39m
+        [36m>[39m
+          [0mitem 3[0m
+        [36m</span>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<button[39m
+      [33maria-label[39m=[32m"a11y text for footer button"[39m
+      [33mclass[39m=[32m"filter-menu__footer"[39m
+      [33mtype[39m=[32m"button"[39m
+    [36m>[39m
+      [0mApply[0m
+    [36m</button>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m"
+`;
+
 exports[`filter-menu > renders with footer render body 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -16,6 +16,7 @@ let component;
 
 describe("given the menu is in the default state", () => {
     const firstItemText = items[0].renderBody;
+    const secondItemText = items[1].renderBody;
     let footerButton, firstItem, secondItem;
 
     beforeEach(async () => {
@@ -169,6 +170,50 @@ describe("given the menu is in the default state", () => {
             expect(eventArg).has.property("checked").to.deep.equal(["item 4"]);
             expect(eventArg).has.property("currentChecked").to.equal(true);
             expect(eventArg).has.property("index").to.equal(3);
+        });
+    });
+
+    describe("when the down key is pressed from an item", () => {
+        beforeEach(async () => {
+            await pressKey(component.getByText(firstItemText), {
+                key: "ArrowDown",
+                keyCode: 40,
+            });
+        });
+
+        it("then it emits the marko keydown event", () => {
+            const keydownEvents = component.emitted("keydown");
+            expect(keydownEvents).to.have.property("length", 1);
+            expect(keydownEvents[0][0].index).to.equal(1);
+        });
+    });
+
+    describe("when the up key is pressed from the first item", () => {
+        beforeEach(async () => {
+            await pressKey(component.getByText(firstItemText), {
+                key: "ArrowUp",
+                keyCode: 38,
+            });
+        });
+
+        it("then it does not emit the marko keydown event", () => {
+            const keydownEvents = component.emitted("keydown");
+            expect(keydownEvents).to.have.property("length", 0);
+        });
+    });
+
+    describe("when the up key is pressed from the second item", () => {
+        beforeEach(async () => {
+            await pressKey(component.getByText(secondItemText), {
+                key: "ArrowUp",
+                keyCode: 38,
+            });
+        });
+
+        it("then it emits the marko keydown event", () => {
+            const keydownEvents = component.emitted("keydown");
+            expect(keydownEvents).to.have.property("length", 1);
+            expect(keydownEvents[0][0].index).to.equal(0);
         });
     });
 });

--- a/src/components/ebay-filter-menu/test/test.server.js
+++ b/src/components/ebay-filter-menu/test/test.server.js
@@ -15,6 +15,14 @@ describe("filter-menu", () => {
         await htmlSnap(Standard);
     });
 
+    it("renders with aria-label", async () => {
+        await htmlSnap(Standard, { ariaLabel: "test" });
+    });
+
+    it("renders with aria-labelledby", async () => {
+        await htmlSnap(Standard, { ariaLabelledby: "test" });
+    });
+
     it(`renders checked item`, async () => {
         items[1] = Object.assign({ checked: true }, items[1]);
         await htmlSnap(Standard);

--- a/src/components/ebay-menu/component.ts
+++ b/src/components/ebay-menu/component.ts
@@ -110,6 +110,18 @@ export default class extends MenuUtils<Input, MenuState> {
         eventUtils.handleActionKeydown(originalEvent, () =>
             this.toggleItemChecked(index, originalEvent, itemEl),
         );
+
+        eventUtils.handleArrowsKeydown(originalEvent, () => {
+            setTimeout(() => {
+                if (index !== this.rovingTabindex.index) {
+                    this.emitComponentEvent({
+                        eventType: "keydown",
+                        originalEvent,
+                        index: this.rovingTabindex.index,
+                    });
+                }
+            });
+        });
     }
 
     handleItemKeypress({ key }: KeyboardEvent) {

--- a/src/components/ebay-menu/index.marko
+++ b/src/components/ebay-menu/index.marko
@@ -8,6 +8,8 @@ $ const {
     reverse,
     fixWidth,
     items,
+    ariaLabel,
+    ariaLabelledby,
     ...htmlInput
 } = input;
 
@@ -31,6 +33,8 @@ $ var separatorMap = component.getSeparatorMap(input);
         role="menu"
         class=`${baseClass}__items`
         key="menu"
+        aria-label=ariaLabel
+        aria-labelledby=ariaLabelledby
         id:scoped="menu">
         <for|item, index| of=(component.items)>
             $ const {

--- a/src/components/ebay-menu/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-menu/test/__snapshots__/test.server.js.snap
@@ -318,6 +318,164 @@ exports[`menu > renders basic version 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
+exports[`menu > renders with aria-label 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"menu"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33maria-label[39m=[32m"test"[39m
+      [33mclass[39m=[32m"menu__items"[39m
+      [33mid[39m=[32m"s0-menu"[39m
+      [33mrole[39m=[32m"menu"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitem"[39m
+      [36m>[39m
+        [36m<span>[39m
+          [0mitem 1 that has very long text[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--16"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-16"[39m
+              [33mviewBox[39m=[32m"0 0 16 16"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33mclip-rule[39m=[32m"evenodd"[39m
+                [33md[39m=[32m"M13.707 5.707a1 1 0 0 0-1.414-1.414L6 10.586 3.707 8.293a1 1 0 0 0-1.414 1.414l3 3a1 1 0 0 0 1.414 0l7-7Z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-tick-16"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitem"[39m
+      [36m>[39m
+        [36m<span>[39m
+          [0mitem 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--16"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-tick-16"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitem"[39m
+      [36m>[39m
+        [36m<span>[39m
+          [0mitem 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--16"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-tick-16"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m"
+`;
+
+exports[`menu > renders with aria-labelledby 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33maria-labelled-by[39m=[32m"test"[39m
+    [33mclass[39m=[32m"menu"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"menu__items"[39m
+      [33mid[39m=[32m"s0-menu"[39m
+      [33mrole[39m=[32m"menu"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitem"[39m
+      [36m>[39m
+        [36m<span>[39m
+          [0mitem 1 that has very long text[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--16"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<defs>[39m
+            [36m<symbol[39m
+              [33mid[39m=[32m"icon-tick-16"[39m
+              [33mviewBox[39m=[32m"0 0 16 16"[39m
+            [36m>[39m
+              [36m<path[39m
+                [33mclip-rule[39m=[32m"evenodd"[39m
+                [33md[39m=[32m"M13.707 5.707a1 1 0 0 0-1.414-1.414L6 10.586 3.707 8.293a1 1 0 0 0-1.414 1.414l3 3a1 1 0 0 0 1.414 0l7-7Z"[39m
+                [33mfill-rule[39m=[32m"evenodd"[39m
+              [36m/>[39m
+            [36m</symbol>[39m
+          [36m</defs>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-tick-16"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitem"[39m
+      [36m>[39m
+        [36m<span>[39m
+          [0mitem 2[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--16"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-tick-16"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"menu__item"[39m
+        [33mrole[39m=[32m"menuitem"[39m
+      [36m>[39m
+        [36m<span>[39m
+          [0mitem 3[0m
+        [36m</span>[39m
+        [36m<svg[39m
+          [33maria-hidden[39m=[32m"true"[39m
+          [33mclass[39m=[32m"icon icon--16"[39m
+          [33mfocusable[39m=[32m"false"[39m
+        [36m>[39m
+          [36m<use[39m
+            [33mhref[39m=[32m"#icon-tick-16"[39m
+          [36m/>[39m
+        [36m</svg>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m"
+`;
+
 exports[`menu > renders with badged version 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -108,6 +108,7 @@ describe("typeahead functionality", () => {
 
 describe("given the menu is in the default state", () => {
     const firstItemText = Default.args.items[0].renderBody;
+    const secondItemText = Default.args.items[1].renderBody;
 
     beforeEach(async () => {
         component = await render(Default);
@@ -139,6 +140,50 @@ describe("given the menu is in the default state", () => {
 
         it("then it emits the marko keydown event", () => {
             expect(component.emitted("keydown")).to.have.property("length", 1);
+        });
+    });
+
+    describe("when the down key is pressed from an item", () => {
+        beforeEach(async () => {
+            await pressKey(component.getByText(firstItemText), {
+                key: "ArrowDown",
+                keyCode: 40,
+            });
+        });
+
+        it("then it emits the marko keydown event", () => {
+            const keydownEvents = component.emitted("keydown");
+            expect(keydownEvents).to.have.property("length", 1);
+            expect(keydownEvents[0][0].index).to.equal(1);
+        });
+    });
+
+    describe("when the up key is pressed from the first item", () => {
+        beforeEach(async () => {
+            await pressKey(component.getByText(firstItemText), {
+                key: "ArrowUp",
+                keyCode: 38,
+            });
+        });
+
+        it("then it does not emit the marko keydown event", () => {
+            const keydownEvents = component.emitted("keydown");
+            expect(keydownEvents).to.have.property("length", 0);
+        });
+    });
+
+    describe("when the up key is pressed from the second item", () => {
+        beforeEach(async () => {
+            await pressKey(component.getByText(secondItemText), {
+                key: "ArrowUp",
+                keyCode: 38,
+            });
+        });
+
+        it("then it emits the marko keydown event", () => {
+            const keydownEvents = component.emitted("keydown");
+            expect(keydownEvents).to.have.property("length", 1);
+            expect(keydownEvents[0][0].index).to.equal(0);
         });
     });
 });

--- a/src/components/ebay-menu/test/test.server.js
+++ b/src/components/ebay-menu/test/test.server.js
@@ -13,6 +13,14 @@ describe("menu", () => {
         await htmlSnap(Default);
     });
 
+    it("renders with aria-label", async () => {
+        await htmlSnap(Default, { ariaLabel: "test" });
+    });
+
+    it("renders with aria-labelledby", async () => {
+        await htmlSnap(Default, { ariaLabelledBy: "test" });
+    });
+
     it("renders with reverse=true", async () => {
         await htmlSnap(Default, { reverse: true });
     });


### PR DESCRIPTION

## Description

* Added keydown events to menu and filter-menu (note, I had to add a setTimeout so that the roving tabindex changed. I did try it in other ways, but this seemed the cleanest method. 
* Added ariaLabel and ariaLablledby to role=menu element
* note: this is only for menu and filter-menu. I did not add these to the button variants because it did not seem necessary for this. 

## References
https://github.com/eBay/ebayui-core/issues/2240