### PR TITLE
fix(line-chart): adds es module interoperability to prevent tooltip.default from being undefined

### DIFF
--- a/.changeset/nasty-crabs-tan.md
+++ b/.changeset/nasty-crabs-tan.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Adds esModuleInterop flag in tsconfig to avoid importing undefined default property for line-chart tooltip module

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     ],
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
         "incremental": true,
         "lib": ["dom", "ESNext"],
         "module": "CommonJS",


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

<!--- What are the changes? -->
This PR adds `esModuleInterop` to the `tsconfig` for this project. This change alleviates the issue with the tooltip import from #2270 
## Context

<!--- Why did you make these changes, and why in this particular way? -->
https://github.com/eBay/ebayui-core/issues/2270

## Screenshots

<!-- Upload screenshots if appropriate. -->
After testing fix in `search_node`:
![image](https://github.com/user-attachments/assets/c4a39989-e2b6-4205-bc8c-cc58cca63a45)
