### PR TITLE
fix(line-chart): adds outside input to allow for renders in modal

### DIFF
--- a/.changeset/tasty-dancers-do.md
+++ b/.changeset/tasty-dancers-do.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(line-chart): adds outside input to allow for renders in modal

--- a/src/components/ebay-line-chart/component.ts
+++ b/src/components/ebay-line-chart/component.ts
@@ -40,6 +40,7 @@ interface LineChartInput
     "cdn-highcharts-accessibility"?: string;
     version?: string;
     series: SeriesLineOptions | SeriesLineOptions[];
+    outside?: boolean;
     trend?: "positive" | "negative" | "neutral";
 }
 
@@ -321,7 +322,7 @@ class LineChart extends Marko.Component<Input> {
             backgroundColor: tooltipBackgroundColor, // sets tooltip background color
             borderWidth: 0, // hide the default border stroke
             borderRadius: 10, // set the border radius of the tooltip
-            outside: true, // used to render the tooltip outside of the main SVG element
+            outside: component.input.outside || true, // used to render the tooltip outside of the main SVG element
             shadow: false, // hide the default shadow as it conflicts with designs
             crosshair: {
                 dashStyle: "Solid", // makes a yaxis cross hair appear over the hovered xAxis data points

--- a/src/components/ebay-line-chart/index.marko
+++ b/src/components/ebay-line-chart/index.marko
@@ -9,6 +9,7 @@ $ const {
     yAxisLabels,
     xAxisPositioner,
     yAxisPositioner,
+    outside,
     trend,
     ...htmlInput
 } = input;

--- a/src/components/ebay-line-chart/line-chart.stories.ts
+++ b/src/components/ebay-line-chart/line-chart.stories.ts
@@ -90,6 +90,15 @@ export default {
             type: { name: "string", require: false },
             description: "Highcharts version to load from CDN",
         },
+        outside: {
+            type: { name: "boolean", require: false },
+            description: "Defaults to `true`, if set to false the tooltip will render inside the chart container. Set to `false` when rendering in a modal.",
+            table: {
+                defaultValue: {
+                    summary: "true",
+                },
+            },
+        }
     },
 };
 

--- a/src/components/ebay-line-chart/marko-tag.json
+++ b/src/components/ebay-line-chart/marko-tag.json
@@ -19,5 +19,6 @@
     "@xAxisPositioner": "function",
     "@yAxisLabels": "array",
     "@yAxisPositioner": "function",
+    "@outside": "boolean",
     "@trend": "boolean"
 }


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

<!--- What are the changes? -->
Adds `outside` input onto `ebay-line-chart`.
## Context

<!--- Why did you make these changes, and why in this particular way? -->
Prior to this PR, the `outside` highcharts configuration hardcoded to `true` would cause the tooltip to render relative to the whole page rather than to the modal window or chart render. Allowing clients to set this value allows proper rendering of the tooltip + chart in a modal window.
## References

<!-- Include links to JIRA, Github, etc. if appropriate. -->
https://github.com/eBay/ebayui-core/issues/2271

## Screenshots

<!-- Upload screenshots if appropriate. -->
![image](https://github.com/user-attachments/assets/43539de1-b5e2-4e05-969f-a88c178ca28a)
