### PR TITLE
fix(date-textbox, calendar): clear behavior with ranges

### DIFF
--- a/.changeset/polite-rocks-exist.md
+++ b/.changeset/polite-rocks-exist.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Fix clearing behavior for calendar and date-textbox

--- a/src/components/ebay-calendar/component.ts
+++ b/src/components/ebay-calendar/component.ts
@@ -388,6 +388,9 @@ class Calendar extends Marko.Component<Input, State> {
                 // We can't display a range, so ensure that no range is highlighted
                 this.state.rangeStart = this.state.rangeEnd = null;
             }
+        } else {
+            // We can't display a range, so ensure that no range is highlighted
+            this.state.rangeStart = this.state.rangeEnd = null;
         }
     }
 

--- a/src/components/ebay-date-textbox/component.ts
+++ b/src/components/ebay-date-textbox/component.ts
@@ -87,7 +87,7 @@ class DateTextbox extends Marko.Component<Input, State> {
         if (input.value !== undefined) {
             this.state.firstSelected = dateArgToISO(input.value);
         }
-        if (input.rangeEnd) {
+        if (input.rangeEnd !== undefined) {
             this.state.secondSelected = dateArgToISO(input.rangeEnd);
         }
         if (!input.range) {

--- a/src/components/ebay-date-textbox/examples/with-clear.marko
+++ b/src/components/ebay-date-textbox/examples/with-clear.marko
@@ -2,19 +2,28 @@ class {
     onCreate() {
         this.state = {
             value: null,
+            rangeEnd: undefined
         };
     }
 
-    handleChange({ selected }) {
-        this.state.value = selected;
+    handleChange({ selected, rangeStart, rangeEnd }) {
+        if (selected) {
+            this.state.value = selected;
+        } else {
+            this.state.value = rangeStart;
+            this.state.rangeEnd = rangeEnd;
+        }
     }
 
     clear() {
         this.state.value = null;
+        if (this.input.range) {
+            this.state.rangeEnd = null;
+        }
     }
 }
 
-<ebay-date-textbox value=state.value onChange("handleChange") ...input/>
+<ebay-date-textbox value=state.value rangeEnd=state.rangeEnd onChange("handleChange") ...input/>
 
 <ebay-button onClick("clear")>
     Clear


### PR DESCRIPTION
- Fixes #2295 

## Description

- Allow clearing date textbox with `range`
- Updated example to work with the changes. This makes the example more complicated, it may even be better to keep the simpler version even though it doesn't work when you toggle range to true.
- This uncovered a bug in `ebay-calendar` with clearing of dates, which I fixed

