### PR TITLE
ebay-video: added ability to input shaka config

### DIFF
--- a/.changeset/weak-lemons-dance.md
+++ b/.changeset/weak-lemons-dance.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+ebay-video: shaka config can now be added as input

--- a/src/components/ebay-video/component.ts
+++ b/src/components/ebay-video/component.ts
@@ -93,7 +93,6 @@ class Video extends Marko.Component<Input, State> {
     declare player: any;
     declare ui: any;
     declare cdnLoader: CDNLoader;
-    declare shakaConfig: any;
 
     isPlaylist(source: Marko.Input<"source"> & { src: string }) {
         const type = source.type && source.type.toLowerCase();
@@ -198,7 +197,7 @@ class Video extends Marko.Component<Input, State> {
         }
     }
 
-    onCreate(input: Input) {
+    onCreate() {
         this.state = {
             volumeSlider: false,
             action: "",
@@ -207,7 +206,6 @@ class Video extends Marko.Component<Input, State> {
             failed: false,
             played: false,
         };
-        this.shakaConfig = input.shakaConfig || {};
         this.cdnLoader = new CDNLoader(this as any, {
             key: "shaka",
             types: ["src", "css"],
@@ -315,7 +313,7 @@ class Video extends Marko.Component<Input, State> {
 
         // eslint-disable-next-line no-undef,new-cap
         this.player = new shaka.Player(this.video);
-        this.player.configure(this.shakaConfig);
+        this.player.configure(this.input.shakaConfig);
         this._attach();
 
         this._loadSrc();

--- a/src/components/ebay-video/component.ts
+++ b/src/components/ebay-video/component.ts
@@ -93,6 +93,7 @@ class Video extends Marko.Component<Input, State> {
     declare player: any;
     declare ui: any;
     declare cdnLoader: CDNLoader;
+    declare shakaConfig: any;
 
     isPlaylist(source: Marko.Input<"source"> & { src: string }) {
         const type = source.type && source.type.toLowerCase();
@@ -197,7 +198,7 @@ class Video extends Marko.Component<Input, State> {
         }
     }
 
-    onCreate() {
+    onCreate(input: Input) {
         this.state = {
             volumeSlider: false,
             action: "",
@@ -206,7 +207,7 @@ class Video extends Marko.Component<Input, State> {
             failed: false,
             played: false,
         };
-
+        this.shakaConfig = input.shakaConfig || {};
         this.cdnLoader = new CDNLoader(this as any, {
             key: "shaka",
             types: ["src", "css"],
@@ -314,6 +315,7 @@ class Video extends Marko.Component<Input, State> {
 
         // eslint-disable-next-line no-undef,new-cap
         this.player = new shaka.Player(this.video);
+        this.player.configure(this.shakaConfig);
         this._attach();
 
         this._loadSrc();

--- a/src/components/ebay-video/component.ts
+++ b/src/components/ebay-video/component.ts
@@ -73,6 +73,7 @@ interface VideoInput extends Omit<Marko.Input<"video">, `on${string}`> {
     "on-pause"?: (event: PlayPauseEvent) => void;
     "on-volume-change"?: (event: VolumeEvent) => void;
     "on-load-error"?: (err: Error) => void;
+    "shaka-config"?: any;
 }
 
 export interface Input extends WithNormalizedProps<VideoInput> {}
@@ -314,7 +315,7 @@ class Video extends Marko.Component<Input, State> {
 
         // eslint-disable-next-line no-undef,new-cap
         this.player = new shaka.Player(this.video);
-        this.player.configure(this.input.shakaConfig);
+        this.player.configure(this.input.shakaConfig || {});
         this._attach();
 
         this._loadSrc();

--- a/src/components/ebay-video/component.ts
+++ b/src/components/ebay-video/component.ts
@@ -206,6 +206,7 @@ class Video extends Marko.Component<Input, State> {
             failed: false,
             played: false,
         };
+
         this.cdnLoader = new CDNLoader(this as any, {
             key: "shaka",
             types: ["src", "css"],

--- a/src/components/ebay-video/video.stories.ts
+++ b/src/components/ebay-video/video.stories.ts
@@ -233,12 +233,7 @@ Standard.args = {
             src: "https://ir.ebaystatic.com/cr/v/c1/ebayui/video/v1/playlist.mpd",
             type: "dash",
         },
-    ],
-    shakaConfig: {
-        streaming: {
-            lowLatencyMode: true,
-        }
-    }
+    ]
 };
 Standard.parameters = {
     docs: {

--- a/src/components/ebay-video/video.stories.ts
+++ b/src/components/ebay-video/video.stories.ts
@@ -91,7 +91,7 @@ export default {
         },
         shakaConfig: {
             description:
-                "The Shaka player configuration object. This allows users to control Shaka player.",
+                "The Shaka player [configuration object](https://shaka-player-demo.appspot.com/docs/api/tutorial-config.html). This allows users to control Shaka player.",
             control: { type: "object" },
         },
 

--- a/src/components/ebay-video/video.stories.ts
+++ b/src/components/ebay-video/video.stories.ts
@@ -89,6 +89,11 @@ export default {
             description:
                 "True/False to keep or remove volume slider. Default is False",
         },
+        shakaConfig: {
+            description:
+                "The Shaka player configuration object. This allows users to control Shaka player.",
+            control: { type: "object" },
+        },
 
         source: {
             name: "@source",
@@ -229,6 +234,11 @@ Standard.args = {
             type: "dash",
         },
     ],
+    shakaConfig: {
+        streaming: {
+            lowLatencyMode: true,
+        }
+    }
 };
 Standard.parameters = {
     docs: {
@@ -253,6 +263,11 @@ ios.args = {
             type: "dash",
         },
     ],
+    shakaConfig: {
+        streaming: {
+            lowLatencyMode: true,
+        }
+    }
 };
 
 ios.parameters = {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

<!--- What are the changes? -->
This PR allows the component to read from input.shakaConfig onCreate, and configure shaka with that config once shaka has successfully loaded.

## Context

<!--- Why did you make these changes, and why in this particular way? -->
Currently <ebay-video> doesn't have the functionality to allow inputting Shaka configuration.
This creates an issue where the host of the component would see a bunch of warnings in the console if it tries to play videos of DASH (HLS) type because shaka is not configured correctly for this.
This PR allows users of the component to input shaka config in order to fix this

### Warnings:
<img width="733" alt="Screenshot 2024-10-28 at 6 01 11 PM" src="https://github.com/user-attachments/assets/dd6968be-9c5f-4e2e-b9db-284bdadd6612">
<img width="2066" alt="Screenshot 2024-10-28 at 6 01 39 PM" src="https://github.com/user-attachments/assets/02d2b4fe-0814-4a9c-97f5-f29c7437729f">

### Usage after fix this:
<img width="665" alt="Screenshot 2024-10-28 at 6 02 35 PM" src="https://github.com/user-attachments/assets/1f50a1ae-aa05-4b95-b152-335614a6a8a0">
<img width="834" alt="Screenshot 2024-10-28 at 6 02 22 PM" src="https://github.com/user-attachments/assets/455488ac-c656-4313-8e76-633a2b2cd2db">

### Storybook update:
<img width="2423" alt="Screenshot 2024-10-29 at 3 55 27 PM" src="https://github.com/user-attachments/assets/50117490-404d-4913-ba30-a4e152bbc720">


## References

<!-- Include links to JIRA, Github, etc. if appropriate. -->
ebay-video HLS streaming issue: https://github.com/eBay/ebayui-core/issues/2307

