### PR TITLE
fix: logic for collapse-on-select was backwards

### DIFF
--- a/.changeset/hungry-stingrays-chew.md
+++ b/.changeset/hungry-stingrays-chew.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Fix collapseOnSelect

--- a/src/components/ebay-listbox-button/component.ts
+++ b/src/components/ebay-listbox-button/component.ts
@@ -52,7 +52,7 @@ class ListboxButton extends Marko.Component<Input, State> {
     }
 
     handleListboxChange(event: ChangeEvent) {
-        if (this.input.collapseOnSelect === false) {
+        if (this.input.collapseOnSelect !== false) {
             this._expander.expanded = false;
         }
         const selectedIndex = event.index;

--- a/src/components/ebay-listbox-button/test/test.browser.js
+++ b/src/components/ebay-listbox-button/test/test.browser.js
@@ -157,6 +157,13 @@ describe("given the listbox is in an expanded state", () => {
                 .has.property("selected")
                 .and.is.deep.equal([options[1].value]);
         });
+
+        it("then it has collapsed the listbox", () => {
+            expect(component.getByRole("button")).toHaveAttribute(
+                "aria-expanded",
+                "false",
+            );
+        });
     });
 
     describe("when the down arrow key is pressed", () => {


### PR DESCRIPTION
- Fixes #2314 

## Description

- 😬 I got some logic backwards while refactoring in #2304
