### PR TITLE
fix(combobox): added viewAllOptions control

### DIFF
--- a/.changeset/mighty-buckets-tan.md
+++ b/.changeset/mighty-buckets-tan.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+fix(combobox): added viewAllOptions control

--- a/src/components/ebay-combobox/combobox.stories.ts
+++ b/src/components/ebay-combobox/combobox.stories.ts
@@ -55,6 +55,11 @@ export default {
             description:
                 "default is `automatic`; available values are `automatic`, `manual`. If set to automatic will automatically fill in the input with the currently highlighted item when using the up/down keys.",
         },
+        viewAllOptions: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description: "Filters listbox options based on user input",
+        },
         "floating-label": {
             control: { type: "text" },
             description:

--- a/src/components/ebay-combobox/component.ts
+++ b/src/components/ebay-combobox/component.ts
@@ -27,7 +27,7 @@ interface ComboboxInput extends Omit<Marko.Input<"input">, `on${string}`> {
     autocomplete?: "list" | "none";
     "list-selection"?: "manual" | "automatic";
     "floating-label"?: boolean;
-    viewAllOptions?: boolean;
+    "view-all-options"?: boolean;
     button?: Marko.Input<"button"> & Marko.AttrTag<{
         htmlAttributes?: Record<string, unknown>;
         renderBody?: Marko.Body;

--- a/src/components/ebay-combobox/component.ts
+++ b/src/components/ebay-combobox/component.ts
@@ -27,6 +27,7 @@ interface ComboboxInput extends Omit<Marko.Input<"input">, `on${string}`> {
     autocomplete?: "list" | "none";
     "list-selection"?: "manual" | "automatic";
     "floating-label"?: boolean;
+    "viewAllOptions"?: boolean;
     button?: Marko.Input<"button"> & Marko.AttrTag<{
         htmlAttributes?: Record<string, unknown>;
         renderBody?: Marko.Body;
@@ -117,14 +118,7 @@ export default class Combobox extends Marko.Component<Input, State> {
     }
 
     handleExpand() {
-        if (this.state.viewAllOptions) {
-            this.setSelectedView();
-        } else {
-            this.state.viewAllOptions = true;
-            this.once("update", () => {
-                this.setSelectedView();
-            });
-        }
+        this.setSelectedView();
         this.emit("expand");
     }
 
@@ -179,7 +173,6 @@ export default class Combobox extends Marko.Component<Input, State> {
                 // We force the expander open just in case.
                 this.expand();
             });
-            this.state.viewAllOptions = false;
 
             this._emitComboboxEvent("input-change");
         });
@@ -233,7 +226,7 @@ export default class Combobox extends Marko.Component<Input, State> {
         this.lastValue = input.value;
         this.state = {
             currentValue: this.lastValue,
-            viewAllOptions: (this.state && this.state.viewAllOptions) || true,
+            viewAllOptions:  input.viewAllOptions ?? true,
         };
         if (this.expander) {
             this.expandedChange = input.expanded !== this.expanded;

--- a/src/components/ebay-combobox/component.ts
+++ b/src/components/ebay-combobox/component.ts
@@ -27,7 +27,7 @@ interface ComboboxInput extends Omit<Marko.Input<"input">, `on${string}`> {
     autocomplete?: "list" | "none";
     "list-selection"?: "manual" | "automatic";
     "floating-label"?: boolean;
-    "viewAllOptions"?: boolean;
+    viewAllOptions?: boolean;
     button?: Marko.Input<"button"> & Marko.AttrTag<{
         htmlAttributes?: Record<string, unknown>;
         renderBody?: Marko.Body;
@@ -50,7 +50,6 @@ export interface Input extends WithNormalizedProps<ComboboxInput> {}
 
 interface State {
     currentValue: Input["value"];
-    viewAllOptions: boolean;
 }
 
 export default class Combobox extends Marko.Component<Input, State> {
@@ -226,7 +225,6 @@ export default class Combobox extends Marko.Component<Input, State> {
         this.lastValue = input.value;
         this.state = {
             currentValue: this.lastValue,
-            viewAllOptions:  input.viewAllOptions ?? true,
         };
         if (this.expander) {
             this.expandedChange = input.expanded !== this.expanded;
@@ -349,7 +347,10 @@ export default class Combobox extends Marko.Component<Input, State> {
     }
 
     _getVisibleOptions() {
-        if (this.autocomplete === "none" || this.state.viewAllOptions) {
+        if (
+            this.autocomplete === "none" ||
+            (this.input.viewAllOptions ?? true)
+        ) {
             return [...(this.input.options ?? [])];
         }
 

--- a/src/components/ebay-combobox/test/test.browser.js
+++ b/src/components/ebay-combobox/test/test.browser.js
@@ -239,6 +239,34 @@ describe("given the combobox with 3 items and 2 selected", () => {
     }
 });
 
+describe("given the combobox with 6 items and view all options false", () => {
+    beforeEach(async () => {
+        component = await render(Isolated, {
+            value: Isolated.args.options[2].text,
+            viewAllOptions: false,
+        });
+    });
+
+    describe("when the input receives focus", () => {
+        beforeEach(async () => {
+            await fireEvent.focus(component.getByRole("combobox"));
+        });
+
+        it("then it should expand the combobox", () => {
+            expect(component.getByRole("combobox")).toHaveAttribute(
+                "aria-expanded",
+                "true",
+            );
+        });
+
+        it("then should show filtered options with first one active", () => {
+            const options = component.getAllByRole("option");
+            expect(options.length).to.equal(4);
+            expect(options[0]).toHaveClass("combobox__option--active");
+        });
+    });
+});
+
 describe("given the combobox with 3 items set to manual selection", () => {
     beforeEach(async () => {
         component = await render(Isolated, {


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

Fixes #2284 

<!--- What are the changes? -->
- Exposed `viewAllOptions` configuration to opt to desired behaviour. 
- By default, if not set it lists all the options and does not filter options with selected text. 

## Screenshots
**view all options set to `true`**
<!-- Upload screenshots if appropriate. -->
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/ee510e00-51e4-4562-9295-7068e2f32944">

**view all options set to `false`**
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/d9350920-eac3-499c-a701-1c6ce643e357">
