### PR TITLE
fix: add locale for ebay-video controls/buttons

### DIFF
--- a/.changeset/great-ants-watch.md
+++ b/.changeset/great-ants-watch.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Added localization for ebay-video component

--- a/src/components/ebay-video/component.ts
+++ b/src/components/ebay-video/component.ts
@@ -273,6 +273,13 @@ class Video extends Marko.Component<Input, State> {
             this.input.reportText || "",
         );
 
+        if (document?.documentElement?.lang) {
+            this.ui
+                .getControls()
+                .getLocalization()
+                .changeLocale([document.documentElement.lang]);
+        }
+
         // eslint-disable-next-line no-undef,new-cap
         shaka.ui.Controls.registerElement(
             "report",


### PR DESCRIPTION
## Description
Added localization for ebay-video component

## Context
https://github.com/eBay/ebayui-core/issues/2323 

## References
This change was requested form the accessibility team [STRFRNT-5398](https://jirap.corp.ebay.com/browse/STRFRNT-5398) and [STRFRNT-5391](https://jirap.corp.ebay.com/browse/STRFRNT-5391)

## Screenshots
Thumbnail play button
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/3b9a4c69-d7af-476a-a807-4a2d981bc4f7">

Video play arrow
<img width="1648" alt="image" src="https://github.com/user-attachments/assets/3a52f1be-98c6-4163-ba42-e76f1701d1f4">

Volume up button
<img width="1687" alt="image" src="https://github.com/user-attachments/assets/e054d7eb-2298-4401-8bf3-f8ed64c4eb42">

Report button
<img width="746" alt="image" src="https://github.com/user-attachments/assets/df7040c1-89b4-4808-b04a-f30df97fe429">

Fullscreen 
<img width="1697" alt="image" src="https://github.com/user-attachments/assets/0e5a626a-1938-4e2a-8f9c-4ce49777ab72">

Seekbar
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/eb83fb33-7a83-4b1e-bf1f-dfe7eb522104">


