### PR TITLE
fix(combobox): updated to default filtering behavior

### DIFF
--- a/.changeset/polite-starfishes-wink.md
+++ b/.changeset/polite-starfishes-wink.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+fix(combobox): updated to default filtering behavior

--- a/.changeset/rich-coins-invent.md
+++ b/.changeset/rich-coins-invent.md
@@ -1,5 +1,5 @@
 ---
-"@ebay/ebayui-core": minor
+"@ebay/ebayui-core": patch
 ---
 
 fix(combobox): updated to default filtering behavior

--- a/src/components/ebay-combobox/combobox.stories.ts
+++ b/src/components/ebay-combobox/combobox.stories.ts
@@ -59,6 +59,11 @@ export default {
             type: "boolean",
             control: { type: "boolean" },
             description: "Filters listbox options based on user input",
+            table: {
+                defaultValue: {
+                    summary: "false",
+                },
+            },
         },
         "floating-label": {
             control: { type: "text" },

--- a/src/components/ebay-combobox/component.ts
+++ b/src/components/ebay-combobox/component.ts
@@ -102,7 +102,7 @@ export default class Combobox extends Marko.Component<Input, State> {
         if (this.listSelection === "automatic") {
             const selected = this._getVisibleOptions()[ev.detail.toIndex];
             // Set textbox value to selected, don't update state since it messes up active descendant
-            (this.getEl("combobox") as HTMLInputElement).value = selected.text;
+            (this.getEl("combobox") as HTMLInputElement).value = selected?.text;
         }
     }
 
@@ -350,7 +350,7 @@ export default class Combobox extends Marko.Component<Input, State> {
     _getVisibleOptions() {
         if (
             this.autocomplete === "none" ||
-            (this.input.viewAllOptions ?? true)
+            (this.input.viewAllOptions ?? false)
         ) {
             return [...(this.input.options ?? [])];
         }

--- a/src/components/ebay-combobox/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-combobox/test/__snapshots__/test.server.js.snap
@@ -727,24 +727,6 @@ exports[`combobox > renders with second item selected 1`] = `
         [33mtabindex[39m=[32m"-1"[39m
       [36m>[39m
         [36m<span>[39m
-          [0mAugust Campaign[0m
-        [36m</span>[39m
-      [36m</div>[39m
-      [36m<div[39m
-        [33mclass[39m=[32m"combobox__option"[39m
-        [33mrole[39m=[32m"option"[39m
-        [33mtabindex[39m=[32m"-1"[39m
-      [36m>[39m
-        [36m<span>[39m
-          [0m4th of July Sale (paused)[0m
-        [36m</span>[39m
-      [36m</div>[39m
-      [36m<div[39m
-        [33mclass[39m=[32m"combobox__option"[39m
-        [33mrole[39m=[32m"option"[39m
-        [33mtabindex[39m=[32m"-1"[39m
-      [36m>[39m
-        [36m<span>[39m
           [0mBasic Offer[0m
         [36m</span>[39m
       [36m</div>[39m

--- a/src/components/ebay-combobox/test/test.browser.js
+++ b/src/components/ebay-combobox/test/test.browser.js
@@ -186,10 +186,11 @@ describe("given the combobox with 3 items", () => {
     }
 });
 
-describe("given the combobox with 3 items and 2 selected", () => {
+describe("given the combobox with 3 items and 2 selected and view all options", () => {
     beforeEach(async () => {
         component = await render(Isolated, {
             value: Isolated.args.options[1].text,
+            viewAllOptions: true,
         });
     });
 


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

Fixes #2343

<!--- What are the changes? -->

## Context

- Updated the combobox default filtering behaviour to always filter options. To view all options `viewAllOptions` flag needs to be set to `false`
- Updated the tests to reflect the behavior. 

