### PR TITLE
fix(ebay-carousel): fix width calculation for last pill when font not loaded (#2344)

### DIFF
--- a/.changeset/strong-grapes-work.md
+++ b/.changeset/strong-grapes-work.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+fix(ebay-carousel): fix width calculation for last pill when font not loaded (#2344)

--- a/src/components/ebay-carousel/README.md
+++ b/src/components/ebay-carousel/README.md
@@ -7,13 +7,13 @@
     </span>
 </h1>
 
-Descrete or Continuious carousel component. Can show items as a slide or various widths.
+Discrete or Continuous carousel component. Can show items as a slide or various widths.
 
 ## Examples and Documentation
 
-- [Storybook](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-carousel)
-- [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/navigation-disclosure-ebay-carousel)
-- [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-carousel/examples)
+-   [Storybook](https://ebay.github.io/ebayui-core/?path=/story/navigation-disclosure-ebay-carousel)
+-   [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/navigation-disclosure-ebay-carousel)
+-   [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-carousel/examples)
 
 ## Preserving tabindex for focusable elements
 
@@ -22,4 +22,4 @@ In order to preserve the tabindex on an item, pass `data-carousel-tabindex="-1"`
 
 ## Reduced motion
 
-The carousel doesnot autoplay by respecting the `prefers-reduced-motion` media query. Toggle your reduced motion settings to view autoplay example with the default behavior and reduced motion behavior.
+The carousel does not autoplay by respecting the `prefers-reduced-motion` media query. Toggle your reduced motion settings to view autoplay example with the default behavior and reduced motion behavior.

--- a/src/components/ebay-carousel/component.ts
+++ b/src/components/ebay-carousel/component.ts
@@ -531,7 +531,7 @@ class Carousel extends Marko.Component<Input, State> {
                     if (!config.scrollTransitioning) {
                         this.handleScroll(this.listEl.scrollLeft);
                     }
-                }),
+                })
             );
         } else {
             this.subscribeTo(this.listEl).on("transitionend", ({ target }) => {
@@ -540,8 +540,13 @@ class Carousel extends Marko.Component<Input, State> {
                 }
             });
         }
-
         this.onRenderLegacy();
+
+        document.fonts.ready.then(() => {
+            this.cleanupAsync();
+            this.onRenderLegacy();
+        });
+
     }
 
     onUpdate() {


### PR DESCRIPTION
### **Description**

This PR addresses the issue where the [last pill in the `ebay-carousel`](https://www.ebay.com/mye/myebay/watchlist) is partially hidden due to incorrect width calculation. The issue occurs because the width is calculated before the correct font (Market Sans) finishes loading, causing the fallback font (Arial) to be used during calculations.  

The changes ensure the component waits for the font to be fully loaded before performing width calculations. This prevents rendering issues and ensures the correct width is applied.

---

### **Context**

The bug was reproduced on production. However, since this is a rendering issue caused by width calculations happening before the font is loaded, it is nearly impossible to reliably test locally.  

These changes introduce logic to:
- Wait for the fonts to be ready.
- Perform cleanup after the font is loaded.
- Render the component correctly with the appropriate dimensions.

This approach ensures stability and resolves the issue effectively.

---

### **References**

- Issue: [#2344](https://github.com/eBay/ebayui-core/issues/2344)

---

### **Screenshots**
Before: 
![image](https://github.com/user-attachments/assets/4e653deb-f010-4632-b0ad-8b4746cbe9e2)

Screenshot not provided after the fix due to the nature of the rendering issue. The problem was reproduced in production, but it is difficult to capture accurately for testing locally.

---

### **Checklist**
- [x] Bug has been reproduced and verified.
- [x] Visual regression testing has been completed (if applicable).
- [x] Changes have been tested with all supported browsers.
- [x] Changes align with the eBay UI guidelines.