### PR TITLE
fix(internal): added import to support webpack 4

### DIFF
--- a/.changeset/nasty-dryers-promise.md
+++ b/.changeset/nasty-dryers-promise.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+feat(internal): added support for webpack 4

--- a/src/node_modules/@internal/highcharts/dynamic-legacy-import.js
+++ b/src/node_modules/@internal/highcharts/dynamic-legacy-import.js
@@ -1,0 +1,5 @@
+if (typeof __webpack_require__ !== "undefined") {
+    module.exports = require("./dynamic-import.js");
+} else {
+    module.exports = require("./async-load-with-lasso.js");
+}

--- a/src/node_modules/@internal/highcharts/package.json
+++ b/src/node_modules/@internal/highcharts/package.json
@@ -6,6 +6,6 @@
         }
     },
     "main": "./noop-for-node.js",
-    "browser": "./async-load-with-lasso.js",
+    "browser": "./dynamic-legacy-import.js",
     "types": "index.d.ts"
 }

--- a/src/node_modules/@internal/model-viewer/dynamic-legacy-import.js
+++ b/src/node_modules/@internal/model-viewer/dynamic-legacy-import.js
@@ -1,0 +1,5 @@
+if (typeof __webpack_require__ !== "undefined") {
+    module.exports = require("./dynamic-import.js");
+} else {
+    module.exports = require("./async-load-with-lasso.js");
+}

--- a/src/node_modules/@internal/model-viewer/package.json
+++ b/src/node_modules/@internal/model-viewer/package.json
@@ -6,6 +6,6 @@
         }
     },
     "main": "./noop-for-node.js",
-    "browser": "./async-load-with-lasso.js",
+    "browser": "./dynamic-legacy-import.js",
     "types": "index.d.ts"
 }

--- a/src/node_modules/@internal/shaka-player/dynamic-legacy-import.js
+++ b/src/node_modules/@internal/shaka-player/dynamic-legacy-import.js
@@ -1,0 +1,5 @@
+if (typeof __webpack_require__ !== "undefined") {
+    module.exports = require("./dynamic-import.js");
+} else {
+    module.exports = require("./async-load-with-lasso.js");
+}

--- a/src/node_modules/@internal/shaka-player/package.json
+++ b/src/node_modules/@internal/shaka-player/package.json
@@ -6,6 +6,6 @@
         }
     },
     "main": "./noop-for-node.js",
-    "browser": "./async-load-with-lasso.js",
+    "browser": "./dynamic-legacy-import.js",
     "types": "index.d.ts"
 }


### PR DESCRIPTION
## Description
* Webpack 4 apps were picking up the `browser` field. Added a check to load `import` on webpack apps.
