### PR TITLE
fix(3d-viewer): install three peer dep

### DIFF
--- a/.changeset/tall-walls-buy.md
+++ b/.changeset/tall-walls-buy.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Install three as a peer dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
                 "makeup-roving-tabindex": "~0.7.3",
                 "makeup-screenreader-trap": "~0.5.3",
                 "makeup-typeahead": "^0.3.3",
-                "shaka-player": "4.12.5"
+                "shaka-player": "4.12.5",
+                "three": "^0.163.0"
             },
             "devDependencies": {
                 "@babel/cli": "^7.26.4",
@@ -15490,8 +15491,7 @@
             "version": "0.163.0",
             "resolved": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
             "integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/through": {
             "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
         "makeup-roving-tabindex": "~0.7.3",
         "makeup-screenreader-trap": "~0.5.3",
         "makeup-typeahead": "^0.3.3",
-        "shaka-player": "4.12.5"
+        "shaka-player": "4.12.5",
+        "three": "^0.163.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.26.4",


### PR DESCRIPTION
Looks like `three` is marked as a `peerDependency` of `@google/model-viewer`, which means that it will be included by NPM but not by yarn (as far as I understand). This adds it as a direct dependency so that yarn also works out of the box, without installing `three`.