### PR TITLE
fix(ebay-combobox): floating label type

### DIFF
--- a/.changeset/sharp-bees-grin.md
+++ b/.changeset/sharp-bees-grin.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+TS fix for combobox

--- a/src/components/ebay-combobox/component.ts
+++ b/src/components/ebay-combobox/component.ts
@@ -4,7 +4,7 @@ import Expander from "makeup-expander";
 import { scroll } from "../../common/element-scroll";
 import * as eventUtils from "../../common/event-utils";
 import safeRegex from "../../common/build-safe-regex";
-import type { AttrClass } from "marko/tags-html";
+import type { AttrClass, AttrString } from "marko/tags-html";
 import type { WithNormalizedProps } from "../../global";
 
 export interface ComboboxOption {
@@ -26,7 +26,7 @@ interface ComboboxInput extends Omit<Marko.Input<"input">, `on${string}`> {
     fluid?: boolean;
     autocomplete?: "list" | "none";
     "list-selection"?: "manual" | "automatic";
-    "floating-label"?: boolean;
+    "floating-label"?: AttrString;
     "view-all-options"?: boolean;
     button?: Marko.Input<"button"> &
         Marko.AttrTag<{


### PR DESCRIPTION
## Description
The `floating-label` property in the combobox component is currently set as a boolean value, but it should be defined as a string instead.
