### PR TITLE
fix(dialog): added request animation frame before running keyboardTrap

### DIFF
--- a/.changeset/good-jobs-cheat.md
+++ b/.changeset/good-jobs-cheat.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(dialog): added request animation frame before running keyboardTrap

--- a/src/components/components/ebay-dialog-base/component.ts
+++ b/src/components/components/ebay-dialog-base/component.ts
@@ -246,7 +246,8 @@ class DialogBase extends Marko.Component<Input, State> {
             if (willTrap) {
                 screenReaderTrap.trap(this.el, { useHiddenProperty });
                 if (!useHiddenProperty) {
-                    keyboardTrap.trap(this.windowEl);
+                    // Adding request animation frame because focusables will return that all elements are not visible since dialog is still animating.
+                    requestAnimationFrame(() => keyboardTrap.trap(this.windowEl));
                 }
             }
         };


### PR DESCRIPTION
## Description
The latest focusables change causes some issues with dialog not showing becasue of animation. Calling request animation frame before calling keyboard trap to fix this.

## References
https://github.com/eBay/ebayui-core/issues/2372

