### PR TITLE
fix(ebay-table): update row-header attribute, removed aria-pressed

### DIFF
--- a/.changeset/poor-mirrors-float.md
+++ b/.changeset/poor-mirrors-float.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+fix(ebay-table): update row-header attribute, removed aria-pressed

--- a/src/components/ebay-table/component.ts
+++ b/src/components/ebay-table/component.ts
@@ -3,13 +3,10 @@ import { WithNormalizedProps } from "../../global";
 import { CheckboxEvent } from "../ebay-checkbox/component-browser";
 
 export type TableSort = "asc" | "desc" | "none";
+
 export interface TableHeader extends Omit<Marko.Input<"th">, `on${string}`> {
-    "column-type"?:
-        | "normal"
-        | "numeric"
-        | "row-header"
-        | "layout"
-        | "icon-action";
+    "column-type"?: "normal" | "numeric" | "layout" | "icon-action";
+    "row-header"?: boolean;
     name?: string;
     sort?: TableSort | boolean;
     href?: AttrString;

--- a/src/components/ebay-table/examples/default.marko
+++ b/src/components/ebay-table/examples/default.marko
@@ -1,7 +1,7 @@
 import data from "./data.json";
 
 <ebay-table ...input>
-    <@header column-type="row-header">
+    <@header row-header>
         Seller
     </@header>
     <@header>Item</@header>

--- a/src/components/ebay-table/examples/selection.marko
+++ b/src/components/ebay-table/examples/selection.marko
@@ -1,7 +1,7 @@
 import data from "./data.json";
 
 <ebay-table mode="selection" on-select("emit", "select") ...input>
-    <@header column-type="row-header">
+    <@header row-header>
         Seller
     </@header>
     <@header>Item</@header>

--- a/src/components/ebay-table/examples/sort-client-side.marko
+++ b/src/components/ebay-table/examples/sort-client-side.marko
@@ -36,7 +36,7 @@ class {
     }
 }
 <ebay-table on-sort("onSort") ...input>
-    <@header name="sellerCol" column-type="row-header">
+    <@header name="sellerCol" row-header>
         Seller
     </@header>
     <@header name="itemCol">

--- a/src/components/ebay-table/examples/sort-with-link.marko
+++ b/src/components/ebay-table/examples/sort-with-link.marko
@@ -2,7 +2,7 @@ import data from "./data.json";
 
 <ebay-table ...input>
     <@header
-        column-type="row-header"
+        row-header
         sort=("asc" as const)
         href="https://www.ebay.com"
     >

--- a/src/components/ebay-table/examples/sort.marko
+++ b/src/components/ebay-table/examples/sort.marko
@@ -16,7 +16,7 @@ class {
 <ebay-table on-sort("onSort") ...input>
     <@header
         name="sellerCol"
-        column-type="row-header"
+        row-header
         sort=(state.sorted.sellerCol || "none")
     >
         Seller

--- a/src/components/ebay-table/examples/with-actions.marko
+++ b/src/components/ebay-table/examples/with-actions.marko
@@ -1,7 +1,7 @@
 import data from "./data.json";
 
 <ebay-table ...input>
-    <@header column-type="row-header">
+    <@header row-header>
         Seller
     </@header>
     <@header>Item</@header>

--- a/src/components/ebay-table/index.marko
+++ b/src/components/ebay-table/index.marko
@@ -41,6 +41,7 @@ $ const {
                 <for|header, headerIndex| of=headers>
                     $ const {
                         columnType = "normal",
+                        rowHeader,
                         class: thClass,
                         name = `${headerIndex}`,
                         sort,
@@ -73,9 +74,7 @@ $ const {
                             sortEleAttr = { href };
                         } else if (sortOrder) {
                             sortEleAttr = {
-                                type: "button",
-                                "aria-pressed":
-                                    sortOrder !== "none" ? "true" : "false",
+                                type: "button"
                             };
                         }
                         <${href ? "a" : sortOrder ? "button" : null}
@@ -136,7 +135,7 @@ $ const {
                                     ) &&
                                     `table-cell--${header.columnType}`,
                             ];
-                            <${header.columnType === "row-header" ? "th" : "td"}
+                            <${header.rowHeader ? "th" : "td"}
                                 ...processHtmlAttributes(tdInput)
                                 class=[cellBaseClass, tdClass]
                             >

--- a/src/components/ebay-table/marko-tag.json
+++ b/src/components/ebay-table/marko-tag.json
@@ -19,8 +19,9 @@
         },
         "@html-attributes": "expression",
         "@column-type": {
-            "enum": ["normal", "numeric", "row-header", "layout", "icon-action"]
-        }
+            "enum": ["normal", "numeric", "layout", "icon-action"]
+        },
+        "@row-header": "boolean"
     },
     "@row <row>[]": {
         "attribute-groups": ["html-attributes"],

--- a/src/components/ebay-table/table.stories.ts
+++ b/src/components/ebay-table/table.stories.ts
@@ -47,6 +47,14 @@ export default {
                 category: "@attribute tags",
             },
         },
+        rowHeader: {
+            name: "row-header",
+            control: { type: "boolean" },
+            description: "If true, the cell will be rendered as a row header",
+            table: {
+                category: "@header attribute tags",
+            },
+        },
         row: {
             name: "@row",
             description: "row attribute tags",
@@ -68,12 +76,14 @@ export default {
             options: [
                 "normal",
                 "numeric",
-                "row-header",
                 "layout",
                 "icon-action",
             ],
             table: {
                 category: "@header attribute tags",
+                defaultValue: {
+                    summary: "normal",
+                },
             },
         },
         href: {

--- a/src/components/ebay-table/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-table/test/__snapshots__/test.server.js.snap
@@ -15,7 +15,6 @@ exports[`ebay-table > renders ColumnSorting 1`] = `
             [33mclass[39m=[32m"table-cell"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"true"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mSeller[0m
@@ -45,7 +44,6 @@ exports[`ebay-table > renders ColumnSorting 1`] = `
             [33mclass[39m=[32m"table-cell"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"false"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mItem[0m
@@ -75,7 +73,6 @@ exports[`ebay-table > renders ColumnSorting 1`] = `
             [33mclass[39m=[32m"table-cell"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"false"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mStatus[0m
@@ -95,7 +92,6 @@ exports[`ebay-table > renders ColumnSorting 1`] = `
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"false"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mList Price[0m
@@ -115,7 +111,6 @@ exports[`ebay-table > renders ColumnSorting 1`] = `
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"false"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mQuantity Available[0m
@@ -135,7 +130,6 @@ exports[`ebay-table > renders ColumnSorting 1`] = `
             [33mclass[39m=[32m"table-cell"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"false"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mOrders[0m
@@ -155,7 +149,6 @@ exports[`ebay-table > renders ColumnSorting 1`] = `
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"false"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mWatchers[0m
@@ -173,7 +166,17 @@ exports[`ebay-table > renders ColumnSorting 1`] = `
           [36m</th>[39m
           [36m<th[39m
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
-         ..."
+          [36m>[39m
+            [36m<button[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mProtection[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [..."
 `;
 
 exports[`ebay-table > renders ColumnSortingClientSide 1`] = `
@@ -205,7 +208,6 @@ exports[`ebay-table > renders ColumnSortingClientSide 1`] = `
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"false"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mList Price[0m
@@ -235,7 +237,6 @@ exports[`ebay-table > renders ColumnSortingClientSide 1`] = `
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
           [36m>[39m
             [36m<button[39m
-              [33maria-pressed[39m=[32m"false"[39m
               [33mtype[39m=[32m"button"[39m
             [36m>[39m
               [0mQuantity Available[0m
@@ -374,7 +375,11 @@ exports[`ebay-table > renders ColumnSortingClientSide 1`] = `
           [36m>[39m
             [36m<a[39m
               [33mhref[39m=[32m"https://ebay.com"[39m
-            ..."
+            [36m>[39m
+              [0m00-10542-89507[0m
+            [36m</a>[39m
+          [36m</td>[39m
+        ..."
 `;
 
 exports[`ebay-table > renders ColumnSortingWithLink 1`] = `

--- a/src/components/ebay-table/test/sort/test.browser.js
+++ b/src/components/ebay-table/test/sort/test.browser.js
@@ -26,7 +26,6 @@ describe("given sortable table with Seller column is sorted in ascending order (
         it("then proper sort event should be emitted", async () => {
             expect(sellerColumn).toMatchInlineSnapshot(`
               <button
-                aria-pressed="true"
                 type="button"
               >
                 
@@ -68,7 +67,6 @@ describe("given sortable table with Seller column is sorted in ascending order (
             it("then proper sort event should be emitted", async () => {
                 expect(sellerColumn).toMatchInlineSnapshot(`
                   <button
-                    aria-pressed="false"
                     type="button"
                   >
                     


### PR DESCRIPTION
## Description

Replaced `column-type` of `row-header` with a boolean `row-header` in the `ebay-table` component. Updated the relevant Marko and JSON files to reflect this change. Removed incorrectly used `aria-pressed`.

## Context

This change was made to simplify the handling of row headers and improve ARIA accessibility. The boolean `row-header` is more intuitive and aligns better with accessibility standards.

## References

- resolves #2313, resolves #2382 
- Prior PR: [#2355](https://github.com/eBay/ebayui-core/pull/2355)

## Tests

- [x]  Updated