### PR TITLE
fix(vite/storybook): resolved runtime error for dynamic imports

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -40,6 +40,12 @@ export default {
         const { mergeConfig } = await import("vite");
         return mergeConfig(config, {
             plugins: [rawMarkdown],
+            optimizeDeps: {
+                // Pre-bundle @storybook/addon-docs/blocks to avoid runtime errors
+                // This is needed because MDX documentation requires these blocks to be available
+                // during dynamic imports
+                include: ['@storybook/addon-docs/blocks']
+            }
         });
     },
 };


### PR DESCRIPTION
#### Description:
The current Vite configuration requires an update to prevent runtime errors when using MDX documentation within Storybook. Specifically, the `@storybook/addon-docs/blocks` module needs to be pre-bundled for compatibility during dynamic imports. This update adds the necessary adjustments to the `optimizeDeps` section of the Vite configuration.

#### Steps to Reproduce:
1. Attempt to use MDX documentation in Storybook.
2. Observe runtime errors related to missing pre-bundled dependencies.

#### Proposed Solution:
Integrate the following changes into the Vite configuration:
```javascript
const { mergeConfig } = await import("vite");
return mergeConfig(config, {
    plugins: [rawMarkdown],
    optimizeDeps: {
        // Pre-bundle @storybook/addon-docs/blocks to avoid runtime errors
        // This is needed because MDX documentation requires these blocks to be available
        // during dynamic imports
        include: ['@storybook/addon-docs/blocks']
    }
});
```

#### Acceptance Criteria:
- [x] Storybook loads MDX documentation without runtime errors.
- [x] The Vite configuration changes are compatible with existing workflows.
- [x] Ensure that these changes do not introduce regressions in other parts of the build system.

#### Additional Context:
- This update aligns with the requirement to dynamically import Storybook blocks during MDX rendering.