### PR TITLE
chore: revered combobox view all options state code

### DIFF
--- a/.changeset/gentle-foxes-push.md
+++ b/.changeset/gentle-foxes-push.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+fix(combobox): reverted removing of view all options


### PR DESCRIPTION
## Description
From a previous PR, we had viewAllOptions state variable removed. This should not have been done and only should have been done as changing input. This change does that 
We can discusss to remove viewAllOptions next major

## References
https://github.com/eBay/ebayui-core/issues/2284