### PR TITLE
feat(combobox): remove default chevron icon

### DIFF
--- a/.changeset/rotten-geckos-sniff.md
+++ b/.changeset/rotten-geckos-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Remove chevron from combobox

--- a/src/components/ebay-chips-combobox/index.marko
+++ b/src/components/ebay-chips-combobox/index.marko
@@ -45,7 +45,6 @@ $ const options = [...option || []].map((o) => o.text)
         onCollapse("emit", "collapse")
         disabled=disabled
         dropdown-element=() => component.getEl("root")
-        chevron-size="large"
         ...comboboxInput
         autocomplete="list"
     >

--- a/src/components/ebay-chips-combobox/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-chips-combobox/test/__snapshots__/test.server.js.snap
@@ -21,25 +21,6 @@ exports[`ebay-chips-combobox > renders default 1`] = `
           [33mrole[39m=[32m"combobox"[39m
           [33mtype[39m=[32m"text"[39m
         [36m/>[39m
-        [36m<svg[39m
-          [33maria-hidden[39m=[32m"true"[39m
-          [33mclass[39m=[32m"icon icon--16"[39m
-          [33mfocusable[39m=[32m"false"[39m
-        [36m>[39m
-          [36m<defs>[39m
-            [36m<symbol[39m
-              [33mid[39m=[32m"icon-chevron-down-16"[39m
-              [33mviewBox[39m=[32m"0 0 16 16"[39m
-            [36m>[39m
-              [36m<path[39m
-                [33md[39m=[32m"M8.707 12.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 1.414-1.414L8 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414l-6 6Z"[39m
-              [36m/>[39m
-            [36m</symbol>[39m
-          [36m</defs>[39m
-          [36m<use[39m
-            [33mhref[39m=[32m"#icon-chevron-down-16"[39m
-          [36m/>[39m
-        [36m</svg>[39m
       [36m</span>[39m
       [36m<div[39m
         [33mclass[39m=[32m"combobox__listbox"[39m
@@ -197,25 +178,6 @@ exports[`ebay-chips-combobox > renders with chips already selected 1`] = `
           [33mrole[39m=[32m"combobox"[39m
           [33mtype[39m=[32m"text"[39m
         [36m/>[39m
-        [36m<svg[39m
-          [33maria-hidden[39m=[32m"true"[39m
-          [33mclass[39m=[32m"icon icon--16"[39m
-          [33mfocusable[39m=[32m"false"[39m
-        [36m>[39m
-          [36m<defs>[39m
-            [36m<symbol[39m
-              [33mid[39m=[32m"icon-chevron-down-16"[39m
-              [33mviewBox[39m=[32m"0 0 16 16"[39m
-            [36m>[39m
-              [36m<path[39m
-                [33md[39m=[32m"M8.707 12.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 1.414-1.414L8 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414l-6 6Z"[39m
-              [36m/>[39m
-            [36m</symbol>[39m
-          [36m</defs>[39m
-          [36m<use[39m
-            [33mhref[39m=[32m"#icon-chevron-down-16"[39m
-          [36m/>[39m
-        [36m</svg>[39m
       [36m</span>[39m
       [36m<div[39m
         [33mclass[39m=[32m"combobox__listbox"[39m

--- a/src/components/ebay-combobox/combobox.stories.ts
+++ b/src/components/ebay-combobox/combobox.stories.ts
@@ -8,6 +8,8 @@ import Combobox from "./index.marko";
 import type { Input } from "./component";
 import SearchFilteringTemplate from "./examples/search-filtering.marko";
 import SearchFilteringTemplateCode from "./examples/search-filtering.marko?raw";
+import ActionableButtonTemplate from "./examples/actionable-button.marko";
+import ActionableButtonTemplateCode from "./examples/actionable-button.marko?raw";
 import { Story } from "@storybook/marko";
 
 const Template: Story<Input> = (args) => ({
@@ -221,4 +223,9 @@ Isolated.parameters = {
 export const SearchFiltering = buildExtensionTemplate(
     SearchFilteringTemplate,
     SearchFilteringTemplateCode,
+);
+
+export const ActionableButton = buildExtensionTemplate(
+    ActionableButtonTemplate,
+    ActionableButtonTemplateCode,
 );

--- a/src/components/ebay-combobox/component.ts
+++ b/src/components/ebay-combobox/component.ts
@@ -34,12 +34,11 @@ interface ComboboxInput extends Omit<Marko.HTML.Input, `on${string}`> {
             renderBody?: Marko.Body;
         }>;
     options?: Marko.AttrTag<ComboboxOption>;
-    "chevron-size"?: "large";
     /**
      * For internal use only. Used when combobox container changes.
      * @returns The dropdown element to be used for the combobox
      */
-    "dropdown-element"?:  () => HTMLElement;
+    "dropdown-element"?: () => HTMLElement;
     "on-focus"?: (event: ComboboxEvent) => void;
     "on-button-click"?: (event: { originalEvent: MouseEvent }) => void;
     "on-expand"?: () => void;
@@ -233,13 +232,12 @@ export default class Combobox extends Marko.Component<Input, State> {
             input.listSelection === "manual" ? "manual" : "automatic";
         this.lastValue = input.value;
         this.state = {
-            currentValue: this.lastValue
+            currentValue: this.lastValue,
         };
         if (this.expander) {
             this.expandedChange = input.expanded !== this.expanded;
             if (this.expandedChange) {
                 this.expander.expanded = input.expanded;
-
             }
         }
         this.expanded = input.expanded;
@@ -317,7 +315,10 @@ export default class Combobox extends Marko.Component<Input, State> {
             }
         }
 
-        this.dropdownUtil = new DropdownUtil(this.input.dropdownElement?.() ?? this.getEl("combobox"), this.getEl("listbox"))
+        this.dropdownUtil = new DropdownUtil(
+            this.input.dropdownElement?.() ?? this.getEl("combobox"),
+            this.getEl("listbox"),
+        );
         if (this.isExpanded()) {
             this.dropdownUtil.show();
         }
@@ -325,7 +326,6 @@ export default class Combobox extends Marko.Component<Input, State> {
         if (this.input.floatingLabel) {
             this._setupFloatingLabel();
         }
-
     }
 
     _cleanupMakeup() {
@@ -363,9 +363,7 @@ export default class Combobox extends Marko.Component<Input, State> {
     }
 
     _getVisibleOptions() {
-        if (
-            this.autocomplete === "none"
-        ) {
+        if (this.autocomplete === "none") {
             return [...(this.input.options ?? [])];
         }
 

--- a/src/components/ebay-combobox/examples/actionable-button.marko
+++ b/src/components/ebay-combobox/examples/actionable-button.marko
@@ -1,17 +1,30 @@
+import type { ComboboxEvent } from "../component";
 class {
-    toggle() {
-        console.log(this.getComponent<any>("combobox").isExpanded());
+    declare state: {
+        value: string;
+    }
+    onCreate() {
+        this.state = {
+            value: "Basic Offer 22"
+        }
+    }
+    handleClear() {
+        this.state.value=""
+    }
+    handleSelect(e: ComboboxEvent) {
+        this.state.value = e.selectedOption?.text || "";
     }
 }
 
 <ebay-combobox
     key="combobox"
     name="example2text"
-    value="Basic Offer 22"
+    value=state.value
     autocomplete="list"
-    on-button-click("toggle")>
+    on-button-click("handleClear")
+    on-select("handleSelect")>
     <@button aria-label="Toggle autocomplete">
-        <ebay-chevron-down-12-icon/>
+        <ebay-clear-16-icon/>
     </@button>
     <@option text="August Campaign"/>
     <@option text="4th of July Sale (paused)"/>

--- a/src/components/ebay-combobox/index.marko
+++ b/src/components/ebay-combobox/index.marko
@@ -14,7 +14,6 @@ $ const {
     listSelection,
     expanded,
     fluid,
-    chevronSize,
     ...htmlInput
 } = input;
 
@@ -77,28 +76,20 @@ $ var id = inputId || component.getElId("input");
             onKeydown("handleComboboxKeyDown")
             onKeyup("handleComboboxKeyUp")
         >
-        <${hasButton ? "button" : null}
-            ...processHtmlAttributes(htmlButton)
-            onClick("handleButtonClick")
-            key="actionable"
-            class=[
-                "icon-btn",
-                "icon-btn--transparent",
-                buttonClass,
-            ]
-        >
-            <if(buttonRenderBody)>
+        <if(hasButton)>
+            <button
+                ...processHtmlAttributes(htmlButton)
+                onClick("handleButtonClick")
+                key="actionable"
+                class=[
+                    "icon-btn",
+                    "icon-btn--transparent",
+                    buttonClass,
+                ]
+            >
                 <${buttonRenderBody}/>
-            </if>
-            <else>
-                <if(chevronSize === "large")>
-                    <ebay-chevron-down-16-icon/>
-                </if>
-                <else>
-                    <ebay-chevron-down-12-icon/>
-                </else>
-            </else>
-        </>
+            </button>
+        </if>
     </span>
     <if(component._hasVisibleOptions())>
         <div key="listbox" role="listbox" class="combobox__listbox">

--- a/src/components/ebay-combobox/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-combobox/test/__snapshots__/test.server.js.snap
@@ -35,29 +35,6 @@ exports[`combobox > passes through additional html attributes 2`] = `
       role="combobox"
       type="text"
     />
-    <!--F#f_@actionable-->
-    <svg
-      aria-hidden="true"
-      class="icon icon--12"
-      focusable="false"
-    >
-      <defs>
-        <symbol
-          id="icon-chevron-down-12"
-          viewBox="0 0 12 12"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"
-            fill-rule="evenodd"
-          />
-        </symbol>
-      </defs>
-      <use
-        href="#icon-chevron-down-12"
-      />
-    </svg>
-    <!--F/-->
   </span>
   <div
     class="combobox__listbox"
@@ -139,27 +116,6 @@ exports[`combobox > renders basic version 1`] = `
         [33mrole[39m=[32m"combobox"[39m
         [33mtype[39m=[32m"text"[39m
       [36m/>[39m
-      [36m<svg[39m
-        [33maria-hidden[39m=[32m"true"[39m
-        [33mclass[39m=[32m"icon icon--12"[39m
-        [33mfocusable[39m=[32m"false"[39m
-      [36m>[39m
-        [36m<defs>[39m
-          [36m<symbol[39m
-            [33mid[39m=[32m"icon-chevron-down-12"[39m
-            [33mviewBox[39m=[32m"0 0 12 12"[39m
-          [36m>[39m
-            [36m<path[39m
-              [33mclip-rule[39m=[32m"evenodd"[39m
-              [33md[39m=[32m"M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"[39m
-              [33mfill-rule[39m=[32m"evenodd"[39m
-            [36m/>[39m
-          [36m</symbol>[39m
-        [36m</defs>[39m
-        [36m<use[39m
-          [33mhref[39m=[32m"#icon-chevron-down-12"[39m
-        [36m/>[39m
-      [36m</svg>[39m
     [36m</span>[39m
     [36m<div[39m
       [33mclass[39m=[32m"combobox__listbox"[39m
@@ -242,27 +198,6 @@ exports[`combobox > renders empty 1`] = `
         [33mrole[39m=[32m"combobox"[39m
         [33mtype[39m=[32m"text"[39m
       [36m/>[39m
-      [36m<svg[39m
-        [33maria-hidden[39m=[32m"true"[39m
-        [33mclass[39m=[32m"icon icon--12"[39m
-        [33mfocusable[39m=[32m"false"[39m
-      [36m>[39m
-        [36m<defs>[39m
-          [36m<symbol[39m
-            [33mid[39m=[32m"icon-chevron-down-12"[39m
-            [33mviewBox[39m=[32m"0 0 12 12"[39m
-          [36m>[39m
-            [36m<path[39m
-              [33mclip-rule[39m=[32m"evenodd"[39m
-              [33md[39m=[32m"M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"[39m
-              [33mfill-rule[39m=[32m"evenodd"[39m
-            [36m/>[39m
-          [36m</symbol>[39m
-        [36m</defs>[39m
-        [36m<use[39m
-          [33mhref[39m=[32m"#icon-chevron-down-12"[39m
-        [36m/>[39m
-      [36m</svg>[39m
     [36m</span>[39m
   [36m</span>[39m
 [36m</DocumentFragment>[39m"
@@ -373,27 +308,6 @@ exports[`combobox > renders with borderless enabled 1`] = `
         [33mrole[39m=[32m"combobox"[39m
         [33mtype[39m=[32m"text"[39m
       [36m/>[39m
-      [36m<svg[39m
-        [33maria-hidden[39m=[32m"true"[39m
-        [33mclass[39m=[32m"icon icon--12"[39m
-        [33mfocusable[39m=[32m"false"[39m
-      [36m>[39m
-        [36m<defs>[39m
-          [36m<symbol[39m
-            [33mid[39m=[32m"icon-chevron-down-12"[39m
-            [33mviewBox[39m=[32m"0 0 12 12"[39m
-          [36m>[39m
-            [36m<path[39m
-              [33mclip-rule[39m=[32m"evenodd"[39m
-              [33md[39m=[32m"M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"[39m
-              [33mfill-rule[39m=[32m"evenodd"[39m
-            [36m/>[39m
-          [36m</symbol>[39m
-        [36m</defs>[39m
-        [36m<use[39m
-          [33mhref[39m=[32m"#icon-chevron-down-12"[39m
-        [36m/>[39m
-      [36m</svg>[39m
     [36m</span>[39m
     [36m<div[39m
       [33mclass[39m=[32m"combobox__listbox"[39m
@@ -479,29 +393,7 @@ exports[`combobox > renders with default actionable button 1`] = `
       [36m<button[39m
         [33maria-label[39m=[32m"Actionable Button"[39m
         [33mclass[39m=[32m"icon-btn icon-btn--transparent"[39m
-      [36m>[39m
-        [36m<svg[39m
-          [33maria-hidden[39m=[32m"true"[39m
-          [33mclass[39m=[32m"icon icon--12"[39m
-          [33mfocusable[39m=[32m"false"[39m
-        [36m>[39m
-          [36m<defs>[39m
-            [36m<symbol[39m
-              [33mid[39m=[32m"icon-chevron-down-12"[39m
-              [33mviewBox[39m=[32m"0 0 12 12"[39m
-            [36m>[39m
-              [36m<path[39m
-                [33mclip-rule[39m=[32m"evenodd"[39m
-                [33md[39m=[32m"M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"[39m
-                [33mfill-rule[39m=[32m"evenodd"[39m
-              [36m/>[39m
-            [36m</symbol>[39m
-          [36m</defs>[39m
-          [36m<use[39m
-            [33mhref[39m=[32m"#icon-chevron-down-12"[39m
-          [36m/>[39m
-        [36m</svg>[39m
-      [36m</button>[39m
+      [36m/>[39m
     [36m</span>[39m
     [36m<div[39m
       [33mclass[39m=[32m"combobox__listbox"[39m
@@ -591,27 +483,6 @@ exports[`combobox > renders with floating label 1`] = `
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m""[39m
       [36m/>[39m
-      [36m<svg[39m
-        [33maria-hidden[39m=[32m"true"[39m
-        [33mclass[39m=[32m"icon icon--12"[39m
-        [33mfocusable[39m=[32m"false"[39m
-      [36m>[39m
-        [36m<defs>[39m
-          [36m<symbol[39m
-            [33mid[39m=[32m"icon-chevron-down-12"[39m
-            [33mviewBox[39m=[32m"0 0 12 12"[39m
-          [36m>[39m
-            [36m<path[39m
-              [33mclip-rule[39m=[32m"evenodd"[39m
-              [33md[39m=[32m"M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"[39m
-              [33mfill-rule[39m=[32m"evenodd"[39m
-            [36m/>[39m
-          [36m</symbol>[39m
-        [36m</defs>[39m
-        [36m<use[39m
-          [33mhref[39m=[32m"#icon-chevron-down-12"[39m
-        [36m/>[39m
-      [36m</svg>[39m
     [36m</span>[39m
     [36m<div[39m
       [33mclass[39m=[32m"combobox__listbox"[39m
@@ -695,27 +566,6 @@ exports[`combobox > renders with second item selected 1`] = `
         [33mtype[39m=[32m"text"[39m
         [33mvalue[39m=[32m"Basic Offer"[39m
       [36m/>[39m
-      [36m<svg[39m
-        [33maria-hidden[39m=[32m"true"[39m
-        [33mclass[39m=[32m"icon icon--12"[39m
-        [33mfocusable[39m=[32m"false"[39m
-      [36m>[39m
-        [36m<defs>[39m
-          [36m<symbol[39m
-            [33mid[39m=[32m"icon-chevron-down-12"[39m
-            [33mviewBox[39m=[32m"0 0 12 12"[39m
-          [36m>[39m
-            [36m<path[39m
-              [33mclip-rule[39m=[32m"evenodd"[39m
-              [33md[39m=[32m"M1.808 4.188a.625.625 0 0 1 .884 0L6 7.495l3.308-3.307a.625.625 0 1 1 .884.885l-3.75 3.749a.625.625 0 0 1-.884 0l-3.75-3.749a.626.626 0 0 1 0-.885Z"[39m
-              [33mfill-rule[39m=[32m"evenodd"[39m
-            [36m/>[39m
-          [36m</symbol>[39m
-        [36m</defs>[39m
-        [36m<use[39m
-          [33mhref[39m=[32m"#icon-chevron-down-12"[39m
-        [36m/>[39m
-      [36m</svg>[39m
     [36m</span>[39m
     [36m<div[39m
       [33mclass[39m=[32m"combobox__listbox"[39m


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Removes chevron from examples for combobox and chips-combobox to reduce confusion on it being an input and not a dropdown
- Add actionable button example to storybook

## Context

<!--- Why did you make these changes, and why in this particular way? -->

## References

<!-- Include links to JIRA, Github, etc. if appropriate. -->

## Screenshots

<img width="269" alt="image" src="https://github.com/user-attachments/assets/5c19fc8b-7922-45e2-ae73-886e3d94345d" />
