### PR TITLE
fix(video): Downgrade shaka to prevent autoplay bug

### DIFF
--- a/.changeset/red-ducks-sniff.md
+++ b/.changeset/red-ducks-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Downgrade shaka-player to prevent autoplay bug

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "makeup-roving-tabindex": "~0.7.3",
                 "makeup-screenreader-trap": "~0.5.3",
                 "makeup-typeahead": "^0.3.3",
-                "shaka-player": "^4.13.1"
+                "shaka-player": "4.12.10"
             },
             "devDependencies": {
                 "@babel/cli": "^7.26.4",
@@ -14667,12 +14667,12 @@
             }
         },
         "node_modules/shaka-player": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-4.13.1.tgz",
-            "integrity": "sha512-JUfMVd4aM5lORJSohLTD7dFhMLtu3856eWNxy5mstIuObOpI6A+maLWdehwII6jQYB0Wgp9eMbbk5tHXGQeOhg==",
+            "version": "4.12.10",
+            "resolved": "https://registry.npmjs.org/shaka-player/-/shaka-player-4.12.10.tgz",
+            "integrity": "sha512-5aiiWJ37xqPLQgMMG0/oPImLVLZRXZ7EkqVq6XaWK1Ll0v7sgtvPic19eAbD5LbOjNZu6pAuDv6h+DzVGVtzdw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "eme-encryption-scheme-polyfill": "^2.2.1"
+                "eme-encryption-scheme-polyfill": "^2.1.6"
             },
             "engines": {
                 "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "makeup-roving-tabindex": "~0.7.3",
         "makeup-screenreader-trap": "~0.5.3",
         "makeup-typeahead": "^0.3.3",
-        "shaka-player": "^4.13.1"
+        "shaka-player": "4.12.10"
     },
     "devDependencies": {
         "@babel/cli": "^7.26.4",


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- `shaka-player` introduced a bug in the latest minor version where video autoplays as soon as it is loaded, regardless of autoplay setting. This PR forces an older version until the bug is fixed
