### PR TITLE
feat(textbox): added check to show prefix label only if floating is not set

### DIFF
--- a/.changeset/gold-walls-think.md
+++ b/.changeset/gold-walls-think.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat(textbox): added check to show prefix label only if floating is not set

--- a/src/components/ebay-textbox/examples/fully-decorated.marko
+++ b/src/components/ebay-textbox/examples/fully-decorated.marko
@@ -10,6 +10,7 @@
     on-invalid("emit", "invalid")
     on-floating-label-init("emit", "floating-label-init")
     on-button-click("emit", "button-click")
+    ...input
 >
     <@prefix-icon>
         <ebay-mail-24-icon/>

--- a/src/components/ebay-textbox/index.marko
+++ b/src/components/ebay-textbox/index.marko
@@ -37,6 +37,9 @@ $ var displayIcon = Boolean(!multiline && hasIcon);
 $ var prefixId = prefixText && component.getElId("prefix");
 $ var postfixId = postfixText && component.getElId("postfix");
 $ var defaultTag = fluid ? "div" : "span";
+// Since prefix doesn't work with floating label, we need to disable it
+// In floating label static, where its always floated, we allow prefix
+$ var disablePrefix = !!floatingLabel && !floatingLabelStatic;
 
 <${floatingLabel && defaultTag} class=["floating-label", isLarge && "floating-label--large", opaqueLabel && "floating-label--opaque"]>
     <if(floatingLabel)>
@@ -62,10 +65,10 @@ $ var defaultTag = fluid ? "div" : "span";
             fluid && "textbox--fluid",
             inputClass,
         ]>
-        <if(displayIcon && prefixIcon)>
+        <if(displayIcon && prefixIcon && !disablePrefix)>
             <${prefixIcon}/>
         </if>
-        <if(prefixText)>
+        <if(prefixText && !disablePrefix)>
             <span id=prefixId ...prefixText>
                 <${prefixText} />
             </span>

--- a/src/components/ebay-textbox/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-textbox/test/__snapshots__/test.server.js.snap
@@ -292,6 +292,33 @@ exports[`ebay-textbox > renders a textarea element with prefix icon 1`] = `
 [36m</DocumentFragment>[39m"
 `;
 
+exports[`ebay-textbox > renders a textbox element with floating label and without prefix icon 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<span[39m
+    [33mclass[39m=[32m"floating-label"[39m
+  [36m>[39m
+    [36m<label[39m
+      [33mclass[39m=[32m"floating-label__label"[39m
+      [33mfor[39m=[32m"s0-0-textbox"[39m
+    [36m>[39m
+      [0mtest label[0m
+    [36m</label>[39m
+    [36m<span[39m
+      [33mclass[39m=[32m"textbox"[39m
+    [36m>[39m
+      [36m<input[39m
+        [33mclass[39m=[32m"textbox__control"[39m
+        [33mdata-marko[39m=[32m"{\\"onkeydown\\":\\"forwardEvent s0-0 false 0\\",\\"onkeypress\\":\\"forwardEvent s0-0 false 1\\",\\"onkeyup\\":\\"forwardEvent s0-0 false 2\\",\\"onchange\\":\\"forwardEvent s0-0 false 3\\",\\"oninput\\":\\"forwardEvent s0-0 false 4\\",\\"onfocus\\":\\"onFocus s0-0 false\\",\\"onblur\\":\\"onBlur s0-0 false\\",\\"oninvalid\\":\\"forwardEvent s0-0 false 5\\"}"[39m
+        [33mdata-marko-key[39m=[32m"@input s0-0"[39m
+        [33mid[39m=[32m"s0-0-textbox"[39m
+        [33mplaceholder[39m=[32m"email"[39m
+        [33mtype[39m=[32m"text"[39m
+      [36m/>[39m
+    [36m</span>[39m
+  [36m</span>[39m
+[36m</DocumentFragment>[39m"
+`;
+
 exports[`ebay-textbox > renders an input textbox with inline floating label 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<span[39m

--- a/src/components/ebay-textbox/test/test.server.js
+++ b/src/components/ebay-textbox/test/test.server.js
@@ -49,6 +49,10 @@ describe("ebay-textbox", () => {
         await htmlSnap(PrefixIcon);
     });
 
+    it("renders a textbox element with floating label and without prefix icon", async () => {
+        await htmlSnap(PrefixIcon, { floatingLabel: "test label" });
+    });
+
     it("renders a textarea element with postfix icon", async () => {
         await htmlSnap(PostfixIcon);
     });

--- a/src/components/ebay-textbox/textbox.stories.ts
+++ b/src/components/ebay-textbox/textbox.stories.ts
@@ -97,14 +97,14 @@ export default {
         },
         prefixIcon: {
             name: "@prefix-icon",
-            description: "An `<ebay-{name}-icon>` to show as the prefix icon.",
+            description: "An `<ebay-{name}-icon>` to show as the prefix icon. Cannot be used with floating-label.",
             table: {
                 category: "@attribute tags",
             },
         },
         postfixIcon: {
             name: "@postfix-icon",
-            description: "An `<ebay-{name}-icon>` to show as the postfix icon.",
+            description: "An `<ebay-{name}-icon>` to show as the postfix icon. Cannot be used with floating-label.",
             table: {
                 category: "@attribute tags",
             },


### PR DESCRIPTION
## Description
* Since prefix label cannot be used with floating label (because there are overrides), we have disabled it for now. 
* For static floating label, we enable it (since it will always be floated and not overlap, such as in phone textbox. 

## References
#2373
