### PR TITLE
feat(avatar): added image position option

### DIFF
--- a/.changeset/clever-rivers-compete.md
+++ b/.changeset/clever-rivers-compete.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat(avatar): added image position option

--- a/src/components/ebay-avatar/avatar.stories.ts
+++ b/src/components/ebay-avatar/avatar.stories.ts
@@ -64,6 +64,11 @@ export default {
             description:
                 'The label to describe the users state as well as their user name. Usually in the format of "Signed in as Bob" or "Signed out"',
         },
+        knownAspectRatio: {
+            control: { type: "number" },
+            description:
+                "Optional, as aspect ratio will be calculated when the image loads on the client. This can be passed to help prevent a flash of incorrectly styled content before the image loads",
+        },
     },
 };
 

--- a/src/components/ebay-avatar/avatar.stories.ts
+++ b/src/components/ebay-avatar/avatar.stories.ts
@@ -7,6 +7,9 @@ import avatar from "./index.marko";
 import Readme from "./README.md";
 import imageTemplate from "./examples/image.marko";
 import imageTemplateCode from "./examples/image.marko?raw";
+import autoImageTemplate from "./examples/with-auto-placement.marko";
+import autoImageTemplateCode from "./examples/with-auto-placement.marko?raw";
+
 import { Story } from "@storybook/marko";
 import type { Input } from "./index.marko";
 
@@ -37,12 +40,7 @@ export default {
                 "magenta",
                 "pink",
             ],
-            table: {
-                defaultValue: {
-                    summary: "teal",
-                },
-            },
-            type: { category: "Options" },
+            type: "select",
             description:
                 "The color to color the background. This can be only used in the non icon/image case. This is used simply as an override to the username hash",
         },
@@ -53,14 +51,23 @@ export default {
                     summary: "48",
                 },
             },
-            type: { category: "Options" },
-
+            type: "select",
             description:
                 "The pixel size of the avatar. Can only be specific sizes",
         },
         username: {
             description:
                 "The username to display. If there is no body, then this will deternmine what the content is. If there is no username passed, then user is signed out. Based on the username, the icon will change colors and show the first letter if there is no user profile pic.",
+        },
+        imagePlacement: {
+            options: ["cover", "fit", "auto"],
+            table: {
+                defaultValue: {
+                    summary: "cover",
+                },
+            },
+            type: "select",
+            description: "The way the image is placed in the avatar. Covers fills the enite area, and fit ties to show the whole picture. Auto picks between cover and fit based on the image aspect ratio (3:4, 4:3, 1:1 use cover, everything else uses fit)",
         },
         a11yText: {
             control: { type: "text" },
@@ -74,6 +81,7 @@ export const Default = Template.bind({});
 Default.args = {
     a11yText: "Signed in - as Elizabeth",
     username: "Elizabeth",
+    color: "teal",
 };
 
 Default.parameters = {
@@ -92,6 +100,17 @@ export const WithImage = buildExtensionTemplate(
         username: "Doggy",
     },
 );
+
+export const WithAutoPlacement = buildExtensionTemplate(
+    autoImageTemplate,
+    autoImageTemplateCode,
+    {
+        imagePlacement: "auto",
+        a11yText: "Signed in - as Doggy",
+        username: "Doggy",
+    },
+);
+
 
 export const SignedOut = Template.bind({});
 SignedOut.args = {

--- a/src/components/ebay-avatar/avatar.stories.ts
+++ b/src/components/ebay-avatar/avatar.stories.ts
@@ -59,16 +59,6 @@ export default {
             description:
                 "The username to display. If there is no body, then this will deternmine what the content is. If there is no username passed, then user is signed out. Based on the username, the icon will change colors and show the first letter if there is no user profile pic.",
         },
-        imagePlacement: {
-            options: ["cover", "fit", "auto"],
-            table: {
-                defaultValue: {
-                    summary: "cover",
-                },
-            },
-            type: "select",
-            description: "The way the image is placed in the avatar. Covers fills the enite area, and fit ties to show the whole picture. Auto picks between cover and fit based on the image aspect ratio (3:4, 4:3, 1:1 use cover, everything else uses fit)",
-        },
         a11yText: {
             control: { type: "text" },
             description:
@@ -105,12 +95,10 @@ export const WithAutoPlacement = buildExtensionTemplate(
     autoImageTemplate,
     autoImageTemplateCode,
     {
-        imagePlacement: "auto",
         a11yText: "Signed in - as Doggy",
         username: "Doggy",
     },
 );
-
 
 export const SignedOut = Template.bind({});
 SignedOut.args = {

--- a/src/components/ebay-avatar/component.ts
+++ b/src/components/ebay-avatar/component.ts
@@ -1,11 +1,9 @@
 import type { WithNormalizedProps } from "../../global";
-import type {
-    AttrString,
-} from "marko/tags-html";
+import type { AttrString } from "marko/tags-html";
 
 type Size = 32 | 40 | 48 | 56 | 64 | 96 | 128;
 
-type ImagePlacement = "cover" | "fit" | "auto";
+type ImagePlacement = "cover" | "fit";
 
 interface State {
     imagePlacement: ImagePlacement;
@@ -13,18 +11,11 @@ interface State {
 
 interface AvatarInput extends Omit<Marko.HTML.Div, `on${string}`> {
     username?: string;
-    "image-placement"?: ImagePlacement;
     color?: string;
     "a11y-text"?: AttrString;
     size?: Size | `${Size}`;
     img?: Marko.AttrTag<Omit<Marko.HTML.Img, `on${string}`>>;
 }
-
-const coverApsectRatios = [
-    0.75, // 3:4
-    1.33, // 4:3
-    1, // 1:1
-];
 
 export interface Input extends WithNormalizedProps<AvatarInput> {}
 
@@ -34,30 +25,13 @@ class Avatar extends Marko.Component<Input, State> {
             imagePlacement: "cover",
         };
     }
-    onMount() {
-        if (this.input.img && this.input.imagePlacement === "auto") {
-            const image = this.getEl("img") as HTMLImageElement;
-            image.onload = () => {
-                const width = image.naturalWidth;
-                const height = image.naturalHeight;
-                const aspectRatio = Math.round((width / height) * 100) / 100;
-                console.log(aspectRatio);
-                if (coverApsectRatios.includes(aspectRatio)) {
-                    this.state.imagePlacement = "cover";
-                } else {
-                    this.state.imagePlacement = "fit";
-                }
-            };
+    handleImageLoad(_event: Event, el: HTMLImageElement) {
+        const aspectRatio = el.naturalWidth / el.naturalHeight;
+        if (aspectRatio < 3 / 4 || aspectRatio > 4 / 3) {
+            this.state.imagePlacement = "fit";
+        } else {
+            this.state.imagePlacement = "cover";
         }
-    }
-    onInput(input: Input) {
-        let imagePlacement = input.imagePlacement || "cover";
-        if (input.imagePlacement === "auto") {
-            imagePlacement = "cover";
-        }
-        this.state = {
-            imagePlacement,
-        };
     }
 }
 

--- a/src/components/ebay-avatar/component.ts
+++ b/src/components/ebay-avatar/component.ts
@@ -15,14 +15,20 @@ interface AvatarInput extends Omit<Marko.HTML.Div, `on${string}`> {
     "a11y-text"?: AttrString;
     size?: Size | `${Size}`;
     img?: Marko.AttrTag<Omit<Marko.HTML.Img, `on${string}`>>;
+    "known-aspect-ratio"?: number;
 }
 
 export interface Input extends WithNormalizedProps<AvatarInput> {}
 
 class Avatar extends Marko.Component<Input, State> {
-    onCreate() {
+    onCreate(input: Input) {
         this.state = {
-            imagePlacement: "cover",
+            imagePlacement:
+                input.knownAspectRatio &&
+                (input.knownAspectRatio < 3 / 4 ||
+                    input.knownAspectRatio > 4 / 3)
+                    ? "fit"
+                    : "cover",
         };
     }
     handleImageLoad(_event: Event, el: HTMLImageElement) {

--- a/src/components/ebay-avatar/component.ts
+++ b/src/components/ebay-avatar/component.ts
@@ -1,0 +1,64 @@
+import type { WithNormalizedProps } from "../../global";
+import type {
+    AttrString,
+} from "marko/tags-html";
+
+type Size = 32 | 40 | 48 | 56 | 64 | 96 | 128;
+
+type ImagePlacement = "cover" | "fit" | "auto";
+
+interface State {
+    imagePlacement: ImagePlacement;
+}
+
+interface AvatarInput extends Omit<Marko.HTML.Div, `on${string}`> {
+    username?: string;
+    "image-placement"?: ImagePlacement;
+    color?: string;
+    "a11y-text"?: AttrString;
+    size?: Size | `${Size}`;
+    img?: Marko.AttrTag<Omit<Marko.HTML.Img, `on${string}`>>;
+}
+
+const coverApsectRatios = [
+    0.75, // 3:4
+    1.33, // 4:3
+    1, // 1:1
+];
+
+export interface Input extends WithNormalizedProps<AvatarInput> {}
+
+class Avatar extends Marko.Component<Input, State> {
+    onCreate() {
+        this.state = {
+            imagePlacement: "cover",
+        };
+    }
+    onMount() {
+        if (this.input.img && this.input.imagePlacement === "auto") {
+            const image = this.getEl("img") as HTMLImageElement;
+            image.onload = () => {
+                const width = image.naturalWidth;
+                const height = image.naturalHeight;
+                const aspectRatio = Math.round((width / height) * 100) / 100;
+                console.log(aspectRatio);
+                if (coverApsectRatios.includes(aspectRatio)) {
+                    this.state.imagePlacement = "cover";
+                } else {
+                    this.state.imagePlacement = "fit";
+                }
+            };
+        }
+    }
+    onInput(input: Input) {
+        let imagePlacement = input.imagePlacement || "cover";
+        if (input.imagePlacement === "auto") {
+            imagePlacement = "cover";
+        }
+        this.state = {
+            imagePlacement,
+        };
+    }
+}
+
+export default Avatar;

--- a/src/components/ebay-avatar/examples/default.marko
+++ b/src/components/ebay-avatar/examples/default.marko
@@ -1,1 +1,1 @@
-<ebay-avatar a11yText="Signed in as Elizabeth" username="Elizabeth"></ebay-avatar>
+<ebay-avatar a11yText="Signed in as Elizabeth" color="teal" username="Elizabeth"></ebay-avatar>

--- a/src/components/ebay-avatar/examples/with-auto-placement.marko
+++ b/src/components/ebay-avatar/examples/with-auto-placement.marko
@@ -1,0 +1,24 @@
+<div>
+    <ebay-avatar a11yText="Signed in as Doggy" image-placement="auto" ...input>
+        <@img
+            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile2.png"
+            alt="my photo"
+        />
+    </ebay-avatar>
+</div>
+<div>
+    <ebay-avatar a11yText="Signed in as Doggy" image-placement="auto" ...input>
+        <@img
+            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile3.png"
+            alt="my photo"
+        />
+    </ebay-avatar>
+</div>
+<div>
+    <ebay-avatar a11yText="Signed in as Doggy" image-placement="auto" ...input>
+        <@img
+            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile4.png"
+            alt="my photo"
+        />
+    </ebay-avatar>
+</div>

--- a/src/components/ebay-avatar/examples/with-auto-placement.marko
+++ b/src/components/ebay-avatar/examples/with-auto-placement.marko
@@ -1,5 +1,5 @@
 <div>
-    <ebay-avatar a11yText="Signed in as Doggy" image-placement="auto" ...input>
+    <ebay-avatar a11yText="Signed in as Doggy" ...input>
         <@img
             src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile2.png"
             alt="my photo"
@@ -7,7 +7,7 @@
     </ebay-avatar>
 </div>
 <div>
-    <ebay-avatar a11yText="Signed in as Doggy" image-placement="auto" ...input>
+    <ebay-avatar a11yText="Signed in as Doggy" ...input>
         <@img
             src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile3.png"
             alt="my photo"
@@ -15,7 +15,7 @@
     </ebay-avatar>
 </div>
 <div>
-    <ebay-avatar a11yText="Signed in as Doggy" image-placement="auto" ...input>
+    <ebay-avatar a11yText="Signed in as Doggy" ...input>
         <@img
             src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile4.png"
             alt="my photo"

--- a/src/components/ebay-avatar/index.marko
+++ b/src/components/ebay-avatar/index.marko
@@ -4,7 +4,6 @@ import { getColorForText } from "./util";
 $ const {
     a11yText,
     class: inputClass,
-    imagePlacement = "cover",
     size,
     color,
     img,
@@ -26,7 +25,7 @@ $ const {
     ]
 >
     <if(img)>
-        <img key="img" ...img>
+        <img onLoad("handleImageLoad") ...img>
     </if>
 
     <else-if(renderBody)>

--- a/src/components/ebay-avatar/index.marko
+++ b/src/components/ebay-avatar/index.marko
@@ -1,23 +1,10 @@
 import { processHtmlAttributes } from "../../common/html-attributes";
 import { getColorForText } from "./util";
-import type { WithNormalizedProps } from "../../global";
-import type { AttrString } from "marko/tags-html";
-
-static type Size = 32 | 40 | 48 | 56 | 64 | 96 | 128;
-
-static interface AvatarInput extends Omit<Marko.HTML.Div, `on${string}`> {
-    username?: string;
-    color?: string;
-    "a11y-text"?: AttrString;
-    size?: Size | `${Size}`;
-    img?: Marko.AttrTag<Omit<Marko.HTML.Img, `on${string}`>>;
-}
-
-export interface Input extends WithNormalizedProps<AvatarInput> {}
 
 $ const {
     a11yText,
     class: inputClass,
+    imagePlacement = "cover",
     size,
     color,
     img,
@@ -32,13 +19,14 @@ $ const {
     aria-label=a11yText
     class=[
         "avatar",
+        state.imagePlacement === "fit" && "avatar--fit",
         inputClass,
         size && `avatar--${size}`,
-        `avatar--${getColorForText(username, color)}`,
+        color && !img && `avatar--${getColorForText(username, color)}`,
     ]
 >
     <if(img)>
-        <img ...img>
+        <img key="img" ...img>
     </if>
 
     <else-if(renderBody)>

--- a/src/components/ebay-avatar/index.marko
+++ b/src/components/ebay-avatar/index.marko
@@ -21,7 +21,7 @@ $ const {
         state.imagePlacement === "fit" && "avatar--fit",
         inputClass,
         size && `avatar--${size}`,
-        color && !img && `avatar--${getColorForText(username, color)}`,
+        username && !img && `avatar--${getColorForText(username, color)}`,
     ]
 >
     <if(img)>

--- a/src/components/ebay-avatar/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-avatar/test/__snapshots__/test.server.js.snap
@@ -28,18 +28,15 @@ exports[`avatar > renders signed out 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33maria-label[39m=[32m"Signed out"[39m
-    [33mclass[39m=[32m"avatar avatar--teal"[39m
+    [33mclass[39m=[32m"avatar"[39m
     [33mrole[39m=[32m"img"[39m
   [36m>[39m
     [36m<svg[39m
       [33maria-hidden[39m=[32m"true"[39m
       [33mclass[39m=[32m"icon icon--avatar-signed-out"[39m
-      [33mdata-marko-key[39m=[32m"@svg s0-3-0"[39m
       [33mfocusable[39m=[32m"false"[39m
     [36m>[39m
-      [36m<defs[39m
-        [33mdata-marko-key[39m=[32m"@defs s0-3-0"[39m
-      [36m>[39m
+      [36m<defs>[39m
         [36m<symbol[39m
           [33mid[39m=[32m"icon-avatar-signed-out"[39m
           [33mviewBox[39m=[32m"0 0 40 40"[39m
@@ -86,7 +83,7 @@ exports[`avatar > renders with doggy as username 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33maria-label[39m=[32m"Signed in - as Elizabeth"[39m
-    [33mclass[39m=[32m"avatar avatar--magenta"[39m
+    [33mclass[39m=[32m"avatar avatar--teal"[39m
     [33mrole[39m=[32m"img"[39m
   [36m>[39m
     [0mD[0m
@@ -98,7 +95,7 @@ exports[`avatar > renders with image 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33maria-label[39m=[32m"Signed in - as Doggy"[39m
-    [33mclass[39m=[32m"avatar avatar--magenta"[39m
+    [33mclass[39m=[32m"avatar"[39m
     [33mrole[39m=[32m"img"[39m
   [36m>[39m
     [36m<img[39m
@@ -113,7 +110,7 @@ exports[`avatar > renders with robert as username 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33maria-label[39m=[32m"Signed in - as Elizabeth"[39m
-    [33mclass[39m=[32m"avatar avatar--magenta"[39m
+    [33mclass[39m=[32m"avatar avatar--teal"[39m
     [33mrole[39m=[32m"img"[39m
   [36m>[39m
     [0mR[0m
@@ -125,7 +122,7 @@ exports[`avatar > renders with test as usernames 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33maria-label[39m=[32m"Signed in - as Elizabeth"[39m
-    [33mclass[39m=[32m"avatar avatar--green"[39m
+    [33mclass[39m=[32m"avatar avatar--teal"[39m
     [33mrole[39m=[32m"img"[39m
   [36m>[39m
     [0mT[0m


### PR DESCRIPTION
## Description
* Added image position option
* Options are `fit`, `contain` and `auto`. Auto detects aspect ratio and sets fit or contain.

## References
https://github.com/eBay/ebayui-core/issues/2434

## Screenshots
<img width="106" alt="Screenshot 2025-02-14 at 9 24 33 AM" src="https://github.com/user-attachments/assets/3109d652-cc35-4f53-be3e-1a339860628c" />
