### PR TITLE
fix(chips-combobox): arrow function parsing for Marko 4

### DIFF
--- a/.changeset/bright-rabbits-guess.md
+++ b/.changeset/bright-rabbits-guess.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Fix arrow function for Marko 4

--- a/src/components/ebay-chips-combobox/index.marko
+++ b/src/components/ebay-chips-combobox/index.marko
@@ -35,6 +35,10 @@ $ const {
             </for>
         </ul>
     </if>
+    /**
+     * This needs to be extracted because Marko 4 has trouble parsing arrow functions as attribute values
+     */
+    $ const getDropdownEl = () => component.getEl("root") as HTMLElement;
     <ebay-combobox
         class="chips-combobox__combobox"
         onKeydown("handleKeydown")
@@ -42,7 +46,7 @@ $ const {
         onExpand("emit", "expand")
         onCollapse("emit", "collapse")
         disabled=disabled
-        dropdown-element=() => component.getEl("root")
+        dropdown-element=getDropdownEl
         ...comboboxInput
         autocomplete="list"
     >


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Marko 4's parser doesn't understand arrow functions passed as attributes unless they're wrapped in parentheses, so all Marko 4 apps that use `chips-combobox` are broken
- `mtc` strips parentheses from attributes so the most straightforward solution is to extract into a variable