### PR TITLE
fix(event-utils): updated to use key

### DIFF
--- a/.changeset/seven-hounds-hide.md
+++ b/.changeset/seven-hounds-hide.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+fix(event-utils): updated to use key

--- a/src/common/event-utils/index.ts
+++ b/src/common/event-utils/index.ts
@@ -1,13 +1,9 @@
-function checkModifiers(e: KeyboardEvent): boolean {
-    return e.ctrlKey || e.altKey || e.metaKey || e.shiftKey;
-}
-
 function handleKeydown(
     keyCodes: string[],
     e: KeyboardEvent,
     callback: () => any,
 ) {
-    const keyCode = e.key
+    const keyCode = e.key;
     if (keyCodes.indexOf(keyCode) !== -1) {
         callback();
     }
@@ -20,7 +16,7 @@ function handleNotKeydown(
     callback: () => any,
 ) {
     const keyCode = e.key;
-    if (keyCodes.indexOf(keyCode) === -1 && !checkModifiers(e)) {
+    if (keyCodes.indexOf(keyCode) === -1) {
         callback();
     }
 }
@@ -48,7 +44,11 @@ function handleLeftRightArrowsKeydown(e: KeyboardEvent, callback: () => any) {
 }
 
 function handleArrowsKeydown(e: KeyboardEvent, callback: () => any) {
-    handleKeydown(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"], e, callback);
+    handleKeydown(
+        ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"],
+        e,
+        callback,
+    );
 }
 
 // only fire for character input, not modifier/meta keys (enter, escape, backspace, tab, etc.)
@@ -61,7 +61,12 @@ function handleTextInput(e: KeyboardEvent, callback: () => any) {
         "ArrowUp",
         "ArrowDown",
         "ArrowLeft",
-        "ArrowRight"
+        "ArrowRight",
+        "Shift",
+        "Alt",
+        "Meta",
+        "Control",
+        "CapsLock"
     ];
     handleNotKeydown(keys, e, callback);
 }

--- a/src/common/event-utils/index.ts
+++ b/src/common/event-utils/index.ts
@@ -1,9 +1,13 @@
+function checkModifiers(e: KeyboardEvent): boolean {
+    return e.ctrlKey || e.altKey || e.metaKey || e.shiftKey;
+}
+
 function handleKeydown(
-    keyCodes: number[],
+    keyCodes: string[],
     e: KeyboardEvent,
     callback: () => any,
 ) {
-    const keyCode = e.charCode || e.keyCode;
+    const keyCode = e.key
     if (keyCodes.indexOf(keyCode) !== -1) {
         callback();
     }
@@ -11,57 +15,53 @@ function handleKeydown(
 
 // inverse of found keys
 function handleNotKeydown(
-    keyCodes: number[],
+    keyCodes: string[],
     e: KeyboardEvent,
     callback: () => any,
 ) {
-    const keyCode = e.charCode || e.keyCode;
-    if (keyCodes.indexOf(keyCode) === -1) {
+    const keyCode = e.key;
+    if (keyCodes.indexOf(keyCode) === -1 && !checkModifiers(e)) {
         callback();
     }
 }
 
 // enter key
 function handleEnterKeydown(e: KeyboardEvent, callback: () => any) {
-    handleKeydown([13], e, callback);
+    handleKeydown(["Enter"], e, callback);
 }
 
 // space and enter keys
 function handleActionKeydown(e: KeyboardEvent, callback: () => any) {
-    handleKeydown([32, 13], e, callback);
+    handleKeydown(["Enter", " "], e, callback);
 }
 
 function handleEscapeKeydown(e: KeyboardEvent, callback: () => any) {
-    handleKeydown([27], e, callback);
+    handleKeydown(["Escape"], e, callback);
 }
 
 function handleUpDownArrowsKeydown(e: KeyboardEvent, callback: () => any) {
-    handleKeydown([38, 40], e, callback);
+    handleKeydown(["ArrowUp", "ArrowDown"], e, callback);
 }
 
 function handleLeftRightArrowsKeydown(e: KeyboardEvent, callback: () => any) {
-    handleKeydown([37, 39], e, callback);
+    handleKeydown(["ArrowLeft", "ArrowRight"], e, callback);
 }
 
 function handleArrowsKeydown(e: KeyboardEvent, callback: () => any) {
-    handleKeydown([37, 38, 39, 40], e, callback);
+    handleKeydown(["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"], e, callback);
 }
 
 // only fire for character input, not modifier/meta keys (enter, escape, backspace, tab, etc.)
 function handleTextInput(e: KeyboardEvent, callback: () => any) {
     const keys = [
-        9, // tab
-        13, // enter key
-        16, // shift
-        17, // control
-        18, // alt
-        20, // caps lock
-        27, // escape
-        37, // left arrow
-        38, // up arrow
-        39, // right arrow
-        40, // down arrow
-        91, // "meta" key (Mac "command" key)
+        "Tab",
+        "Enter",
+        "Shift",
+        "Escape",
+        "ArrowUp",
+        "ArrowDown",
+        "ArrowLeft",
+        "ArrowRight"
     ];
     handleNotKeydown(keys, e, callback);
 }

--- a/src/common/event-utils/test/test.browser.js
+++ b/src/common/event-utils/test/test.browser.js
@@ -11,58 +11,58 @@ const handleLeftRightArrowsKeydown = eventUtils.handleLeftRightArrowsKeydown;
 const preventDefaultIfHijax = eventUtils.preventDefaultIfHijax;
 
 describe("handleActionKeydown()", () => {
-    [{ keyCode: 13 }, { keyCode: 32 }].forEach((event) => {
-        it(`calls callback for keyCode=${event.keyCode}`, () => {
+    [{ key: " " }, { key: "Enter" }].forEach((event) => {
+        it(`calls callback for key=${event.key}`, () => {
             const callback = vi.fn();
             handleActionKeydown(event, callback);
             expect(callback).toBeCalledTimes(1);
         });
     });
 
-    it("doesn't call callback for other keyCode", () => {
+    it("doesn't call callback for other key", () => {
         const callback = vi.fn();
-        handleActionKeydown({ keyCode: 1 }, callback);
+        handleActionKeydown({ key: "A" }, callback);
         expect(callback).toBeCalledTimes(0);
     });
 });
 
 describe("handleEscapeKeydown()", () => {
-    const escapeKeyCode = 27;
-    it(`calls callback for keyCode=${escapeKeyCode}`, () => {
+    const escapeKey = "Escape";
+    it(`calls callback for key=${escapeKey}`, () => {
         const callback = vi.fn();
-        handleEscapeKeydown({ keyCode: escapeKeyCode }, callback);
+        handleEscapeKeydown({ key: escapeKey }, callback);
         expect(callback).toBeCalledTimes(1);
     });
 });
 
 describe("handleUpDownArrowsKeydown()", () => {
-    [{ keyCode: 38 }, { keyCode: 40 }].forEach((event) => {
-        it(`calls callback for keyCode=${event.keyCode}`, () => {
+    [{ key: "ArrowUp" }, { key: "ArrowDown" }].forEach((event) => {
+        it(`calls callback for key=${event.key}`, () => {
             const callback = vi.fn();
             handleUpDownArrowsKeydown(event, callback);
             expect(callback).toBeCalledTimes(1);
         });
     });
 
-    it("doesn't call callback for other keyCode", () => {
+    it("doesn't call callback for other key", () => {
         const callback = vi.fn();
-        handleUpDownArrowsKeydown({ keyCode: 1 }, callback);
+        handleUpDownArrowsKeydown({ key: "A" }, callback);
         expect(callback).toBeCalledTimes(0);
     });
 });
 
 describe("handleLeftRightArrowsKeydown()", () => {
-    [{ keyCode: 37 }, { keyCode: 39 }].forEach((event) => {
-        it(`calls callback for keyCode=${event.keyCode}`, () => {
+    [{ key: "ArrowLeft" }, { key: "ArrowRight" }].forEach((event) => {
+        it(`calls callback for key=${event.key}`, () => {
             const callback = vi.fn();
             handleLeftRightArrowsKeydown(event, callback);
             expect(callback).toBeCalledTimes(1);
         });
     });
 
-    it("doesn't call callback for other keyCode", () => {
+    it("doesn't call callback for other key", () => {
         const callback = vi.fn();
-        handleLeftRightArrowsKeydown({ keyCode: 1 }, callback);
+        handleLeftRightArrowsKeydown({ key: "A" }, callback);
         expect(callback).toBeCalledTimes(0);
     });
 });

--- a/src/components/ebay-filter-menu-button/test/test.browser.js
+++ b/src/components/ebay-filter-menu-button/test/test.browser.js
@@ -225,7 +225,7 @@ describe("given the menu is in the expanded state", () => {
     describe("when an item is checked via the keyboard", () => {
         beforeEach(async () => {
             await pressKey(firstItem, {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });

--- a/src/components/ebay-filter-menu/test/test.browser.js
+++ b/src/components/ebay-filter-menu/test/test.browser.js
@@ -97,7 +97,7 @@ describe("given the menu is in the default state", () => {
     describe("when an item is checked via the keyboard", () => {
         beforeEach(async () => {
             await pressKey(firstItem, {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });
@@ -312,7 +312,7 @@ describe("given the menu is in the radio state", () => {
     describe("when an item is checked via the keyboard", () => {
         beforeEach(async () => {
             await pressKey(firstItem, {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });
@@ -406,7 +406,7 @@ describe("given the menu item is disabled", () => {
     describe("when the current item is pressed with space", () => {
         beforeEach(async () => {
             await pressKey(firstItem, {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });
@@ -419,7 +419,7 @@ describe("given the menu item is disabled", () => {
     describe("when the second item is pressed with space", () => {
         beforeEach(async () => {
             await pressKey(secondItem, {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });

--- a/src/components/ebay-listbox-button/test/test.browser.js
+++ b/src/components/ebay-listbox-button/test/test.browser.js
@@ -218,7 +218,7 @@ describe("given the listbox is in an expanded state with manual list-selection",
                 keyCode: 40,
             });
             await pressKey(component.getAllByRole("listbox").find(isVisible), {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });

--- a/src/components/ebay-listbox/test/test.browser.js
+++ b/src/components/ebay-listbox/test/test.browser.js
@@ -140,7 +140,7 @@ describe("given the listbox with manual selection", () => {
                 keyCode: 40,
             });
             await pressKey(component.getAllByRole("listbox").find(isVisible), {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });
@@ -205,7 +205,7 @@ describe("given the listbox with disabled option", () => {
                 keyCode: 40,
             });
             await pressKey(component.getAllByRole("listbox").find(isVisible), {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });

--- a/src/components/ebay-menu-button/test/test.browser.js
+++ b/src/components/ebay-menu-button/test/test.browser.js
@@ -265,7 +265,7 @@ describe("given the menu is in the expanded state with radio items", () => {
     describe("when an action button is pressed on an item", () => {
         beforeEach(async () => {
             await pressKey(firstItem, {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });

--- a/src/components/ebay-menu/test/test.browser.js
+++ b/src/components/ebay-menu/test/test.browser.js
@@ -218,7 +218,7 @@ describe("given the menu has radio items", () => {
     describe("when an action button is pressed on an item", () => {
         beforeEach(async () => {
             await pressKey(firstItem, {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });

--- a/src/components/ebay-tabs/test/test.browser.js
+++ b/src/components/ebay-tabs/test/test.browser.js
@@ -84,7 +84,7 @@ describe("given tabs with manual activation", () => {
     describe("when the first heading is activated via keybaord action button", () => {
         beforeEach(async () => {
             await pressKey(component.getAllByRole("tab")[0], {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });
@@ -97,7 +97,7 @@ describe("given tabs with manual activation", () => {
     describe("when the second tab is activated via keyboard action button", () => {
         beforeEach(async () => {
             await pressKey(component.getAllByRole("tab")[1], {
-                key: "(Space character)",
+                key: " ",
                 keyCode: 32,
             });
         });


### PR DESCRIPTION
## Description
* Swapped deprecated event `charCode` and `keyCode` to use `key`

## Context
For tests, I updated `"(Space key)"` to be just `" "`
## References
https://github.com/eBay/ebayui-core/issues/2431