### PR TITLE
feat(accordion): update expansion icon

### DIFF
--- a/.changeset/clean-guests-check.md
+++ b/.changeset/clean-guests-check.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat(accordion): update expansion icon

--- a/src/components/ebay-accordion/README.md
+++ b/src/components/ebay-accordion/README.md
@@ -3,7 +3,7 @@
         ebay-accordion
     </span>
     <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
-        DS v1.0.0
+        DS v1.1
     </span>
 </h1>
 

--- a/src/components/ebay-accordion/component.ts
+++ b/src/components/ebay-accordion/component.ts
@@ -7,7 +7,7 @@ export interface AccordionInput extends Omit<Marko.Input<"ul">, `on${string}`> {
     "auto-collapse"?: AttrBoolean;
     "a11y-role-description"?: AttrString;
     details?: Marko.AttrTag<
-        Omit<DetailsInput, "size" | "alignment" | "layout" | `on${string}`>
+        Omit<DetailsInput, "size" | "alignment" | `on${string}`>
     >;
     "on-toggle"?: (event: { originalEvent: Event; open: boolean }) => void;
     "on-click"?: (event: { originalEvent: MouseEvent }) => void;

--- a/src/components/ebay-accordion/index.marko
+++ b/src/components/ebay-accordion/index.marko
@@ -24,7 +24,6 @@ $ (input as any).toJSON = noop;
             <ebay-details
                 ...item
                 open= item.open || (autoCollapse && index === state.index)
-                layout="accordion"
                 on-toggle("handleToggle", index)
                 on-click("emit", "click")
             >

--- a/src/components/ebay-accordion/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-accordion/test/__snapshots__/test.server.js.snap
@@ -24,40 +24,21 @@ exports[`accordion > renders accordion with auto-collapse true 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<defs>[39m
                 [36m<symbol[39m
-                  [33mid[39m=[32m"icon-add-16"[39m
+                  [33mid[39m=[32m"icon-chevron-down-16"[39m
                   [33mviewBox[39m=[32m"0 0 16 16"[39m
                 [36m>[39m
                   [36m<path[39m
-                    [33md[39m=[32m"M14 7H9V2a1 1 0 0 0-2 0v5H2a1 1 0 0 0 0 2h5v5a1 1 0 1 0 2 0V9h5a1 1 0 1 0 0-2Z"[39m
+                    [33md[39m=[32m"M8.707 12.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 1.414-1.414L8 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414l-6 6Z"[39m
                   [36m/>[39m
                 [36m</symbol>[39m
               [36m</defs>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<defs>[39m
-                [36m<symbol[39m
-                  [33mid[39m=[32m"icon-remove-16"[39m
-                  [33mviewBox[39m=[32m"0 0 16 16"[39m
-                [36m>[39m
-                  [36m<path[39m
-                    [33md[39m=[32m"M13 7H3a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2Z"[39m
-                  [36m/>[39m
-                [36m</symbol>[39m
-              [36m</defs>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -89,20 +70,11 @@ exports[`accordion > renders accordion with auto-collapse true 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -134,20 +106,11 @@ exports[`accordion > renders accordion with auto-collapse true 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -189,40 +152,21 @@ exports[`accordion > renders accordion with large size 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<defs>[39m
                 [36m<symbol[39m
-                  [33mid[39m=[32m"icon-add-16"[39m
+                  [33mid[39m=[32m"icon-chevron-down-16"[39m
                   [33mviewBox[39m=[32m"0 0 16 16"[39m
                 [36m>[39m
                   [36m<path[39m
-                    [33md[39m=[32m"M14 7H9V2a1 1 0 0 0-2 0v5H2a1 1 0 0 0 0 2h5v5a1 1 0 1 0 2 0V9h5a1 1 0 1 0 0-2Z"[39m
+                    [33md[39m=[32m"M8.707 12.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 1.414-1.414L8 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414l-6 6Z"[39m
                   [36m/>[39m
                 [36m</symbol>[39m
               [36m</defs>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<defs>[39m
-                [36m<symbol[39m
-                  [33mid[39m=[32m"icon-remove-16"[39m
-                  [33mviewBox[39m=[32m"0 0 16 16"[39m
-                [36m>[39m
-                  [36m<path[39m
-                    [33md[39m=[32m"M13 7H3a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2Z"[39m
-                  [36m/>[39m
-                [36m</symbol>[39m
-              [36m</defs>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -254,20 +198,11 @@ exports[`accordion > renders accordion with large size 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -299,20 +234,11 @@ exports[`accordion > renders accordion with large size 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -354,40 +280,21 @@ exports[`accordion > renders accordion with localized role description 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<defs>[39m
                 [36m<symbol[39m
-                  [33mid[39m=[32m"icon-add-16"[39m
+                  [33mid[39m=[32m"icon-chevron-down-16"[39m
                   [33mviewBox[39m=[32m"0 0 16 16"[39m
                 [36m>[39m
                   [36m<path[39m
-                    [33md[39m=[32m"M14 7H9V2a1 1 0 0 0-2 0v5H2a1 1 0 0 0 0 2h5v5a1 1 0 1 0 2 0V9h5a1 1 0 1 0 0-2Z"[39m
+                    [33md[39m=[32m"M8.707 12.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 1.414-1.414L8 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414l-6 6Z"[39m
                   [36m/>[39m
                 [36m</symbol>[39m
               [36m</defs>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<defs>[39m
-                [36m<symbol[39m
-                  [33mid[39m=[32m"icon-remove-16"[39m
-                  [33mviewBox[39m=[32m"0 0 16 16"[39m
-                [36m>[39m
-                  [36m<path[39m
-                    [33md[39m=[32m"M13 7H3a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2Z"[39m
-                  [36m/>[39m
-                [36m</symbol>[39m
-              [36m</defs>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -419,20 +326,11 @@ exports[`accordion > renders accordion with localized role description 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -464,20 +362,11 @@ exports[`accordion > renders accordion with localized role description 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -519,40 +408,21 @@ exports[`accordion > renders default accordion 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<defs>[39m
                 [36m<symbol[39m
-                  [33mid[39m=[32m"icon-add-16"[39m
+                  [33mid[39m=[32m"icon-chevron-down-16"[39m
                   [33mviewBox[39m=[32m"0 0 16 16"[39m
                 [36m>[39m
                   [36m<path[39m
-                    [33md[39m=[32m"M14 7H9V2a1 1 0 0 0-2 0v5H2a1 1 0 0 0 0 2h5v5a1 1 0 1 0 2 0V9h5a1 1 0 1 0 0-2Z"[39m
+                    [33md[39m=[32m"M8.707 12.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 1.414-1.414L8 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414l-6 6Z"[39m
                   [36m/>[39m
                 [36m</symbol>[39m
               [36m</defs>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<defs>[39m
-                [36m<symbol[39m
-                  [33mid[39m=[32m"icon-remove-16"[39m
-                  [33mviewBox[39m=[32m"0 0 16 16"[39m
-                [36m>[39m
-                  [36m<path[39m
-                    [33md[39m=[32m"M13 7H3a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2Z"[39m
-                  [36m/>[39m
-                [36m</symbol>[39m
-              [36m</defs>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -584,20 +454,11 @@ exports[`accordion > renders default accordion 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m
@@ -629,20 +490,11 @@ exports[`accordion > renders default accordion 1`] = `
           [36m>[39m
             [36m<svg[39m
               [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__expand icon icon--16"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
               [33mfocusable[39m=[32m"false"[39m
             [36m>[39m
               [36m<use[39m
-                [33mhref[39m=[32m"#icon-add-16"[39m
-              [36m/>[39m
-            [36m</svg>[39m
-            [36m<svg[39m
-              [33maria-hidden[39m=[32m"true"[39m
-              [33mclass[39m=[32m"details__collapse icon icon--16"[39m
-              [33mfocusable[39m=[32m"false"[39m
-            [36m>[39m
-              [36m<use[39m
-                [33mhref[39m=[32m"#icon-remove-16"[39m
+                [33mhref[39m=[32m"#icon-chevron-down-16"[39m
               [36m/>[39m
             [36m</svg>[39m
           [36m</span>[39m

--- a/src/components/ebay-details/component-browser.ts
+++ b/src/components/ebay-details/component-browser.ts
@@ -5,7 +5,6 @@ export interface DetailsInput
     summary?: Marko.AttrTag<Marko.Input<"span">>;
     size?: "regular" | "small";
     alignment?: "regular" | "center";
-    layout?: "regular" | "accordion";
     as?: keyof Marko.NativeTags;
     "on-toggle"?: (event: { originalEvent: Event; open: boolean }) => void;
     "on-click"?: (event: { originalEvent: MouseEvent }) => void;

--- a/src/components/ebay-details/index.marko
+++ b/src/components/ebay-details/index.marko
@@ -9,7 +9,6 @@ $ const {
     size,
     summary,
     renderBody,
-    layout,
     as: inputAs,
     ...htmlInput
 } = input;
@@ -31,17 +30,11 @@ $ (input as any).toJSON = noop;
         ]>
             <span class="details__label"><${summary.renderBody}/></span>
             <span class="details__icon" hidden>
-                <if(layout === "accordion")>
-                    <ebay-add-16-icon class="details__expand"/>
-                    <ebay-remove-16-icon class="details__collapse"/>
-                </if>
-                <else>
-                    <ebay-chevron-down-16-icon/>
-                </else>
+                <ebay-chevron-down-16-icon/>
             </span>
         </summary>
     </if>
-    <${inputAs || "div"} class=layout === "accordion" && "details__content">
+    <${inputAs || "div"} class="details__content">
         <${renderBody}/>
     </>
 </details>

--- a/src/components/ebay-details/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-details/test/__snapshots__/test.server.js.snap
@@ -11,7 +11,8 @@ exports[`details > passes through additional html attributes 1`] = `
   type="number"
 >
   <div
-    data-marko-key="7 s0"
+    class="details__content"
+    data-marko-key="5 s0"
   />
 </details>
 `;
@@ -27,7 +28,8 @@ exports[`details > passes through additional html attributes 2`] = `
   type="number"
 >
   <div
-    data-marko-key="7 s0"
+    class="details__content"
+    data-marko-key="5 s0"
   />
 </details>
 `;
@@ -54,11 +56,11 @@ exports[`details > renders as div version 1`] = `
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
           [33mclass[39m=[32m"icon icon--16"[39m
-          [33mdata-marko-key[39m=[32m"@svg s0-6-0"[39m
+          [33mdata-marko-key[39m=[32m"@svg s0-4-0"[39m
           [33mfocusable[39m=[32m"false"[39m
         [36m>[39m
           [36m<defs[39m
-            [33mdata-marko-key[39m=[32m"@defs s0-6-0"[39m
+            [33mdata-marko-key[39m=[32m"@defs s0-4-0"[39m
           [36m>[39m
             [36m<symbol[39m
               [33mid[39m=[32m"icon-chevron-down-16"[39m
@@ -76,7 +78,8 @@ exports[`details > renders as div version 1`] = `
       [36m</span>[39m
     [36m</summary>[39m
     [36m<div[39m
-      [33mdata-marko-key[39m=[32m"7 s0"[39m
+      [33mclass[39m=[32m"details__content"[39m
+      [33mdata-marko-key[39m=[32m"5 s0"[39m
     [36m>[39m
       [0mbody content[0m
     [36m</div>[39m
@@ -106,11 +109,11 @@ exports[`details > renders basic version 1`] = `
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
           [33mclass[39m=[32m"icon icon--16"[39m
-          [33mdata-marko-key[39m=[32m"@svg s0-6-0"[39m
+          [33mdata-marko-key[39m=[32m"@svg s0-4-0"[39m
           [33mfocusable[39m=[32m"false"[39m
         [36m>[39m
           [36m<defs[39m
-            [33mdata-marko-key[39m=[32m"@defs s0-6-0"[39m
+            [33mdata-marko-key[39m=[32m"@defs s0-4-0"[39m
           [36m>[39m
             [36m<symbol[39m
               [33mid[39m=[32m"icon-chevron-down-16"[39m
@@ -128,7 +131,8 @@ exports[`details > renders basic version 1`] = `
       [36m</span>[39m
     [36m</summary>[39m
     [36m<div[39m
-      [33mdata-marko-key[39m=[32m"7 s0"[39m
+      [33mclass[39m=[32m"details__content"[39m
+      [33mdata-marko-key[39m=[32m"5 s0"[39m
     [36m>[39m
       [0mbody content[0m
     [36m</div>[39m
@@ -158,11 +162,11 @@ exports[`details > renders center version 1`] = `
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
           [33mclass[39m=[32m"icon icon--16"[39m
-          [33mdata-marko-key[39m=[32m"@svg s0-6-0"[39m
+          [33mdata-marko-key[39m=[32m"@svg s0-4-0"[39m
           [33mfocusable[39m=[32m"false"[39m
         [36m>[39m
           [36m<defs[39m
-            [33mdata-marko-key[39m=[32m"@defs s0-6-0"[39m
+            [33mdata-marko-key[39m=[32m"@defs s0-4-0"[39m
           [36m>[39m
             [36m<symbol[39m
               [33mid[39m=[32m"icon-chevron-down-16"[39m
@@ -180,7 +184,8 @@ exports[`details > renders center version 1`] = `
       [36m</span>[39m
     [36m</summary>[39m
     [36m<div[39m
-      [33mdata-marko-key[39m=[32m"7 s0"[39m
+      [33mclass[39m=[32m"details__content"[39m
+      [33mdata-marko-key[39m=[32m"5 s0"[39m
     [36m>[39m
       [0mbody content[0m
     [36m</div>[39m
@@ -210,11 +215,11 @@ exports[`details > renders in open state 1`] = `
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
           [33mclass[39m=[32m"icon icon--16"[39m
-          [33mdata-marko-key[39m=[32m"@svg s0-6-0"[39m
+          [33mdata-marko-key[39m=[32m"@svg s0-4-0"[39m
           [33mfocusable[39m=[32m"false"[39m
         [36m>[39m
           [36m<defs[39m
-            [33mdata-marko-key[39m=[32m"@defs s0-6-0"[39m
+            [33mdata-marko-key[39m=[32m"@defs s0-4-0"[39m
           [36m>[39m
             [36m<symbol[39m
               [33mid[39m=[32m"icon-chevron-down-16"[39m
@@ -232,7 +237,8 @@ exports[`details > renders in open state 1`] = `
       [36m</span>[39m
     [36m</summary>[39m
     [36m<div[39m
-      [33mdata-marko-key[39m=[32m"7 s0"[39m
+      [33mclass[39m=[32m"details__content"[39m
+      [33mdata-marko-key[39m=[32m"5 s0"[39m
     [36m>[39m
       [0mbody content[0m
     [36m</div>[39m
@@ -262,11 +268,11 @@ exports[`details > renders small version 1`] = `
         [36m<svg[39m
           [33maria-hidden[39m=[32m"true"[39m
           [33mclass[39m=[32m"icon icon--16"[39m
-          [33mdata-marko-key[39m=[32m"@svg s0-6-0"[39m
+          [33mdata-marko-key[39m=[32m"@svg s0-4-0"[39m
           [33mfocusable[39m=[32m"false"[39m
         [36m>[39m
           [36m<defs[39m
-            [33mdata-marko-key[39m=[32m"@defs s0-6-0"[39m
+            [33mdata-marko-key[39m=[32m"@defs s0-4-0"[39m
           [36m>[39m
             [36m<symbol[39m
               [33mid[39m=[32m"icon-chevron-down-16"[39m
@@ -284,7 +290,8 @@ exports[`details > renders small version 1`] = `
       [36m</span>[39m
     [36m</summary>[39m
     [36m<div[39m
-      [33mdata-marko-key[39m=[32m"7 s0"[39m
+      [33mclass[39m=[32m"details__content"[39m
+      [33mdata-marko-key[39m=[32m"5 s0"[39m
     [36m>[39m
       [0mbody content[0m
     [36m</div>[39m


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

Fixes #2450

## Context

- Updated details code to use chevron all the time.
- Removed internal `layout` option on details with less dependencies. This decision adds the css class `details__content` which wan't there earlier.
- Note: Once skin is updated, the color of the chevron will change to `--color-foreground-secondary`.


## Screenshots

**Before**
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/b4c9381c-4ca2-4fe7-8ea4-281a78ab7308" />

**After**
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/19fccdbc-a821-4f60-a35e-d1a0e98c2141" />

