### PR TITLE
feat(table): added loading body state

### DIFF
--- a/.changeset/gold-foxes-swim.md
+++ b/.changeset/gold-foxes-swim.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat(table): added loading body state

--- a/src/components/ebay-table/component.ts
+++ b/src/components/ebay-table/component.ts
@@ -1,3 +1,4 @@
+import focusables from "makeup-focusables";
 import { AttrString, AttrTriState } from "marko/tags-html";
 import { WithNormalizedProps } from "../../global";
 import { CheckboxEvent } from "../ebay-checkbox/component-browser";
@@ -24,9 +25,11 @@ export interface TableRow extends Omit<Marko.HTML.TR, `on${string}`> {
 export interface TableInput extends Omit<Marko.HTML.Div, `on${string}`> {
     header: Marko.AttrTag<WithNormalizedProps<TableHeader>>;
     mode?: "none" | "selection";
+    "body-state"?: "loading" | "none";
     "all-selected"?: AttrTriState;
     row?: Marko.AttrTag<TableRow>;
     density?: "compact" | "relaxed" | "none";
+    "a11y-loading-text"?: string;
     "a11y-select-all-text"?: string;
     "a11y-select-row-text"?: string;
     "on-select"?: (event: {
@@ -45,6 +48,9 @@ interface State {
 }
 
 export default class EbayTable extends Marko.Component<Input, State> {
+    declare disabledItems: Map<HTMLElement, boolean>;
+    declare tbody: HTMLElement;
+
     onCreate() {
         this.state = {
             selected: {},
@@ -53,10 +59,20 @@ export default class EbayTable extends Marko.Component<Input, State> {
         };
     }
 
+    onMount() {
+        this.disabledItems = new Map();
+        this.tbody = this.getEl("tbody");
+        this.setLoading();
+    }
+
     onInput(input: Input) {
         this.state.selected = this.getSelectedRowStateFromInput(input);
         this.state.allSelected = this.getAllSelectedState(input);
         this.state.sorted = this.getSortedColStateFromInput(input);
+    }
+
+    onUpdate() {
+        this.setLoading();
     }
 
     getSelectedRowStateFromInput(input: Input) {
@@ -127,6 +143,28 @@ export default class EbayTable extends Marko.Component<Input, State> {
         this.emit("select", {
             selected: this.state.selected,
         });
+    }
+
+    setLoading() {
+        if (this.input.bodyState === "loading") {
+            if (this.tbody) {
+                requestAnimationFrame(() => {
+                    focusables(this.tbody).forEach((focusable: HTMLElement) => {
+                        if (!focusable.getAttribute("disabled")) {
+                            focusable.setAttribute("disabled", "true");
+                            focusable.setAttribute("tabindex", "-1");
+                            this.disabledItems.set(focusable, true);
+                        }
+                    });
+                });
+            }
+        } else {
+            for (const [focusable] of this.disabledItems) {
+                focusable.removeAttribute("disabled");
+                focusable.removeAttribute("tabindex");
+            }
+            this.disabledItems.clear();
+        }
     }
 
     sortColumn(name: string) {

--- a/src/components/ebay-table/component.ts
+++ b/src/components/ebay-table/component.ts
@@ -161,7 +161,19 @@ export default class EbayTable extends Marko.Component<Input, State> {
             if (this.tbody) {
                 this.animationFrame = requestAnimationFrame(() => {
                     focusables(this.tbody).forEach((focusable: HTMLElement) => {
-                        focusable.setAttribute("disabled", "true");
+                        if (focusable.tagName === "A") {
+                            focusable.setAttribute(
+                                "data-href",
+                                focusable.getAttribute("href") || "",
+                            );
+                            focusable.removeAttribute("href");
+                        } else {
+                            focusable.setAttribute("disabled", "true");
+                        }
+                        focusable.setAttribute(
+                            "data-tabindex",
+                            focusable.getAttribute("tabindex") || "",
+                        );
                         focusable.setAttribute("tabindex", "-1");
                         this.disabledItems.add(focusable);
                     });
@@ -169,8 +181,24 @@ export default class EbayTable extends Marko.Component<Input, State> {
             }
         } else {
             for (const [focusable] of this.disabledItems.entries()) {
-                focusable.removeAttribute("disabled");
-                focusable.removeAttribute("tabindex");
+                if (focusable.tagName === "A") {
+                    focusable.setAttribute(
+                        "href",
+                        focusable.getAttribute("data-href") || "",
+                    );
+                    focusable.removeAttribute("data-href");
+                } else {
+                    focusable.setAttribute("disabled", "true");
+                }
+
+                if (focusable.getAttribute("data-tabindex") !== null) {
+                    focusable.setAttribute(
+                        "tabindex",
+                        focusable.getAttribute("tabindex") || "",
+                    );
+                } else {
+                    focusable.removeAttribute("tabindex");
+                }
             }
             this.disabledItems.clear();
         }

--- a/src/components/ebay-table/index.marko
+++ b/src/components/ebay-table/index.marko
@@ -30,9 +30,8 @@ $ const isLoading = bodyState === "loading";
     ]
     role="group"
     tabindex="0"
-    inert=isLoading
 >
-    <table aria-hidden=isLoading && "true">
+    <table aria-hidden=isLoading && "true" inert=isLoading>
         <thead>
             <tr>
                 <if(mode === "selection")>
@@ -164,7 +163,7 @@ $ const isLoading = bodyState === "loading";
             </for>
         </tbody>
     </table>
-    <div role="status">
+    <div role="status" aria-live="polite">
         <if(isLoading)>
             <ebay-progress-bar-expressive a11y-text=a11yLoadingText || "Loading..." />
         </if>

--- a/src/components/ebay-table/index.marko
+++ b/src/components/ebay-table/index.marko
@@ -77,14 +77,18 @@ $ const isLoading = bodyState === "loading";
                     >
                         $ let sortEleAttr = {};
                         $ if (href) {
-                            sortEleAttr = { href };
+                            if (isLoading) {
+                                sortEleAttr = { };
+                            } else {
+                                sortEleAttr = { href };
+                            }
                         } else if (sortOrder) {
                             sortEleAttr = {
-                                type: "button"
+                                type: "button",
+                                disabled: isLoading,
                             };
                         }
                         <${href ? "a" : sortOrder ? "button" : null}
-                            disabled=isLoading
                             ...sortEleAttr
                             on-click(href ? undefined : "sortColumn", name)
                         >

--- a/src/components/ebay-table/index.marko
+++ b/src/components/ebay-table/index.marko
@@ -7,17 +7,22 @@ $ const {
     header: headers,
     row: rows,
     allSelected,
+    a11yLoadingText,
     a11ySelectAllText,
     a11ySelectRowText,
     mode = "none",
+    bodyState = "none",
     ...divInput
 } = input;
+
+$ const isLoading = bodyState === "loading";
 
 <div
     ...processHtmlAttributes(divInput)
     class=[
         "table",
         mode === "selection" && "table--mode-selection",
+        isLoading && "table--loading-state",
         density &&
             validDensity.includes(density) &&
             `table--density-${density}`,
@@ -32,6 +37,7 @@ $ const {
                 <if(mode === "selection")>
                     <th class="table-cell">
                         <ebay-tri-state-checkbox
+                            disabled=isLoading
                             aria-label=(a11ySelectAllText ?? "Select all rows")
                             checked=state.allSelected
                             on-change("headerSelect")
@@ -78,6 +84,7 @@ $ const {
                             };
                         }
                         <${href ? "a" : sortOrder ? "button" : null}
+                            disabled=isLoading
                             ...sortEleAttr
                             on-click(href ? undefined : "sortColumn", name)
                         >
@@ -99,7 +106,7 @@ $ const {
                 </for>
             </tr>
         </thead>
-        <tbody>
+        <tbody key="tbody">
             <for|row, rowIndex| of=rows || []>
                 $ const {
                     cell: cells,
@@ -111,6 +118,7 @@ $ const {
                     <if(mode === "selection")>
                         <th scope="row" class="table__cell">
                             <ebay-checkbox
+                                disabled=isLoading
                                 aria-label=(a11ySelectRowText ?? "Select row")
                                 checked=(state.selected[name])
                                 on-change("rowSelect", name)
@@ -151,4 +159,7 @@ $ const {
             </for>
         </tbody>
     </table>
+    <if(isLoading)>
+        <ebay-progress-bar-expressive a11y-text=a11yLoadingText || "Loading..." />
+    </if>
 </div>

--- a/src/components/ebay-table/index.marko
+++ b/src/components/ebay-table/index.marko
@@ -29,10 +29,10 @@ $ const isLoading = bodyState === "loading";
         divClass,
     ]
     role="group"
-    tabindex=isLoading ? "-1" :"0"
+    tabindex="0"
     inert=isLoading
 >
-    <table>
+    <table aria-hidden=isLoading && "true">
         <thead>
             <tr>
                 <if(mode === "selection")>
@@ -164,7 +164,9 @@ $ const isLoading = bodyState === "loading";
             </for>
         </tbody>
     </table>
-    <if(isLoading)>
-        <ebay-progress-bar-expressive a11y-text=a11yLoadingText || "Loading..." />
-    </if>
+    <div role="status">
+        <if(isLoading)>
+            <ebay-progress-bar-expressive a11y-text=a11yLoadingText || "Loading..." />
+        </if>
+    </div>
 </div>

--- a/src/components/ebay-table/index.marko
+++ b/src/components/ebay-table/index.marko
@@ -163,7 +163,7 @@ $ const isLoading = bodyState === "loading";
             </for>
         </tbody>
     </table>
-    <div role="status" aria-live="polite">
+    <div role="status">
         <if(isLoading)>
             <ebay-progress-bar-expressive a11y-text=a11yLoadingText || "Loading..." />
         </if>

--- a/src/components/ebay-table/index.marko
+++ b/src/components/ebay-table/index.marko
@@ -29,7 +29,8 @@ $ const isLoading = bodyState === "loading";
         divClass,
     ]
     role="group"
-    tabindex="0"
+    tabindex=isLoading ? "-1" :"0"
+    inert=isLoading
 >
     <table>
         <thead>

--- a/src/components/ebay-table/table.stories.ts
+++ b/src/components/ebay-table/table.stories.ts
@@ -35,6 +35,11 @@ export default {
             description: "table mode",
             options: ["selection", "none"],
         },
+        bodyState: {
+            control: { type: "select" },
+            description: "table state",
+            options: ["loading", "none"],
+        },
         allSelected: {
             control: { type: "select" },
             description: "Select all tri-state checkbox state",
@@ -110,6 +115,27 @@ export default {
             description: "cell attribute tags",
             table: {
                 category: "@row attribute tags",
+            },
+        },
+        a11yLoadingText: {
+            description: "Text for progress bar expressive when table is in loading body state",
+            table: {
+                category: "a11y",
+                defaultValue: {
+                    summary: "Loading...",
+                }
+            },
+        },
+        a11ySelectAllText: {
+            description: "Text for selecting all rows. Used with select mode",
+            table: {
+                category: "a11y",
+            },
+        },
+        a11ySelectRowText: {
+            description: "Text for selecting a row. Used with select mode",
+            table: {
+                category: "a11y",
             },
         },
         onSelect: {

--- a/src/components/ebay-table/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-table/test/__snapshots__/test.server.js.snap
@@ -772,6 +772,9 @@ exports[`ebay-table > renders ColumnSortingWithLink 1`] = `
         [36m</tr>[39m
       [36m</tbody>[39m
     [36m</table>[39m
+    [36m<div[39m
+      [33mrole[39m=[32m"status"[39m
+    [36m/>[39m
   [36m</div>[39m
 [36m</DocumentFragment>[39m"
 `;
@@ -1141,6 +1144,9 @@ exports[`ebay-table > renders Default 1`] = `
         [36m</tr>[39m
       [36m</tbody>[39m
     [36m</table>[39m
+    [36m<div[39m
+      [33mrole[39m=[32m"status"[39m
+    [36m/>[39m
   [36m</div>[39m
 [36m</DocumentFragment>[39m"
 `;
@@ -1663,6 +1669,9 @@ exports[`ebay-table > renders TableDensity 1`] = `
         [36m</tr>[39m
       [36m</tbody>[39m
     [36m</table>[39m
+    [36m<div[39m
+      [33mrole[39m=[32m"status"[39m
+    [36m/>[39m
   [36m</div>[39m
 [36m</DocumentFragment>[39m"
 `;
@@ -1852,9 +1861,11 @@ exports[`ebay-table > renders with anchors loading 1`] = `
     [33mclass[39m=[32m"table table--loading-state"[39m
     [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
-    [33mtabindex[39m=[32m"-1"[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [36m<table>[39m
+    [36m<table[39m
+      [33maria-hidden[39m=[32m"true"[39m
+    [36m>[39m
       [36m<thead>[39m
         [36m<tr>[39m
           [36m<th[39m
@@ -2019,8 +2030,7 @@ exports[`ebay-table > renders with anchors loading 1`] = `
             [36m</button>[39m
           [36m</th>[39m
           [36m<th[39m
-            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
-          [36m>..."
+            [33mclass[39m=..."
 `;
 
 exports[`ebay-table > renders with columns client side loading 1`] = `
@@ -2029,9 +2039,11 @@ exports[`ebay-table > renders with columns client side loading 1`] = `
     [33mclass[39m=[32m"table table--loading-state"[39m
     [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
-    [33mtabindex[39m=[32m"-1"[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [36m<table>[39m
+    [36m<table[39m
+      [33maria-hidden[39m=[32m"true"[39m
+    [36m>[39m
       [36m<thead>[39m
         [36m<tr>[39m
           [36m<th[39m
@@ -2219,9 +2231,7 @@ exports[`ebay-table > renders with columns client side loading 1`] = `
           [36m</td>[39m
           [36m<td[39m
             [33mclass[39m=[32m"table-cell"[39m
-          [36m>[39m
-            [36m<a[39m
-              [33mhref[39m=[32..."
+          [36m>[39m..."
 `;
 
 exports[`ebay-table > renders with loading state 1`] = `
@@ -2230,9 +2240,11 @@ exports[`ebay-table > renders with loading state 1`] = `
     [33mclass[39m=[32m"table table--loading-state"[39m
     [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
-    [33mtabindex[39m=[32m"-1"[39m
+    [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
-    [36m<table>[39m
+    [36m<table[39m
+      [33maria-hidden[39m=[32m"true"[39m
+    [36m>[39m
       [36m<thead>[39m
         [36m<tr>[39m
           [36m<th[39m
@@ -2437,7 +2449,5 @@ exports[`ebay-table > renders with loading state 1`] = `
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
           [36m>[39m
             [0m345[0m
-          [36m</td>[39m
-          [36m<td[39m
-            [33mcl..."
+          ..."
 `;

--- a/src/components/ebay-table/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-table/test/__snapshots__/test.server.js.snap
@@ -773,6 +773,7 @@ exports[`ebay-table > renders ColumnSortingWithLink 1`] = `
       [36m</tbody>[39m
     [36m</table>[39m
     [36m<div[39m
+      [33maria-live[39m=[32m"polite"[39m
       [33mrole[39m=[32m"status"[39m
     [36m/>[39m
   [36m</div>[39m
@@ -1145,6 +1146,7 @@ exports[`ebay-table > renders Default 1`] = `
       [36m</tbody>[39m
     [36m</table>[39m
     [36m<div[39m
+      [33maria-live[39m=[32m"polite"[39m
       [33mrole[39m=[32m"status"[39m
     [36m/>[39m
   [36m</div>[39m
@@ -1670,6 +1672,7 @@ exports[`ebay-table > renders TableDensity 1`] = `
       [36m</tbody>[39m
     [36m</table>[39m
     [36m<div[39m
+      [33maria-live[39m=[32m"polite"[39m
       [33mrole[39m=[32m"status"[39m
     [36m/>[39m
   [36m</div>[39m
@@ -1859,12 +1862,12 @@ exports[`ebay-table > renders with anchors loading 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33mclass[39m=[32m"table table--loading-state"[39m
-    [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
     [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
     [36m<table[39m
       [33maria-hidden[39m=[32m"true"[39m
+      [33minert[39m=[32m""[39m
     [36m>[39m
       [36m<thead>[39m
         [36m<tr>[39m
@@ -2030,19 +2033,19 @@ exports[`ebay-table > renders with anchors loading 1`] = `
             [36m</button>[39m
           [36m</th>[39m
           [36m<th[39m
-            [33mclass[39m=..."
+            [33mclass[39..."
 `;
 
 exports[`ebay-table > renders with columns client side loading 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33mclass[39m=[32m"table table--loading-state"[39m
-    [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
     [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
     [36m<table[39m
       [33maria-hidden[39m=[32m"true"[39m
+      [33minert[39m=[32m""[39m
     [36m>[39m
       [36m<thead>[39m
         [36m<tr>[39m
@@ -2231,19 +2234,19 @@ exports[`ebay-table > renders with columns client side loading 1`] = `
           [36m</td>[39m
           [36m<td[39m
             [33mclass[39m=[32m"table-cell"[39m
-          [36m>[39m..."
+          [36m>[3..."
 `;
 
 exports[`ebay-table > renders with loading state 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33mclass[39m=[32m"table table--loading-state"[39m
-    [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
     [33mtabindex[39m=[32m"0"[39m
   [36m>[39m
     [36m<table[39m
       [33maria-hidden[39m=[32m"true"[39m
+      [33minert[39m=[32m""[39m
     [36m>[39m
       [36m<thead>[39m
         [36m<tr>[39m
@@ -2449,5 +2452,5 @@ exports[`ebay-table > renders with loading state 1`] = `
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
           [36m>[39m
             [0m345[0m
-          ..."
+        ..."
 `;

--- a/src/components/ebay-table/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-table/test/__snapshots__/test.server.js.snap
@@ -1846,6 +1846,384 @@ exports[`ebay-table > renders TableWithActions 1`] = `
                 [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-17[3[0]]-3[0] false\\",\\"onkeydown\\":\\"handleKeydown s0-0-17[3[0]]-3[0] false\\",\\"onfocus\\":\\"handleFocus s0-0-17[3[0]]-3[0] false\\",\\"onblur\\":\\"handleBlur s0-0-17[3[0]]-3[0] ..."
 `;
 
+exports[`ebay-table > renders with anchors loading 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"table table--loading-state"[39m
+    [33mrole[39m=[32m"group"[39m
+    [33mtabindex[39m=[32m"0"[39m
+  [36m>[39m
+    [36m<table>[39m
+      [36m<thead>[39m
+        [36m<tr>[39m
+          [36m<th[39m
+            [33maria-sort[39m=[32m"ascending"[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mSeller[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<defs>[39m
+                  [36m<symbol[39m
+                    [33mid[39m=[32m"icon-sort-down-12"[39m
+                    [33mviewBox[39m=[32m"0 0 12 12"[39m
+                  [36m>[39m
+                    [36m<path[39m
+                      [33md[39m=[32m"m6.523 10.789 4.27-4.287a.717.717 0 0 0-.003-1.011.71.71 0 0 0-1.007.003L6.729 8.567V1.715A.713.713 0 0 0 6.017 1a.713.713 0 0 0-.711.715v6.852L2.252 5.494a.71.71 0 0 0-1.232.298.716.716 0 0 0 .229.71l4.27 4.287a.71.71 0 0 0 1.004 0Z"[39m
+                    [36m/>[39m
+                  [36m</symbol>[39m
+                [36m</defs>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-down-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mItem[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<defs>[39m
+                  [36m<symbol[39m
+                    [33mid[39m=[32m"icon-sort-12"[39m
+                    [33mviewBox[39m=[32m"0 0 12 12"[39m
+                  [36m>[39m
+                    [36m<path[39m
+                      [33md[39m=[32m"M2.75 1a.75.75 0 0 1 .75.75v6.527l.69-.775a.75.75 0 1 1 1.12.996L3.32 10.74a.752.752 0 0 1-1.137 0L.188 8.5a.75.75 0 1 1 1.122-.997l.69.774V1.75A.75.75 0 0 1 2.75 1Zm5.06 3.498a.75.75 0 1 1-1.12-.996L8.68 1.26a.752.752 0 0 1 1.137 0L11.81 3.5a.75.75 0 1 1-1.12.997L10 3.723v6.527a.75.75 0 0 1-1.5 0V3.723l-.69.775Z"[39m
+                    [36m/>[39m
+                  [36m</symbol>[39m
+                [36m</defs>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mStatus[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mList Price[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mQuantity Available[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mOrders[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mWatchers[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [36m<button[39..."
+`;
+
+exports[`ebay-table > renders with columns client side loading 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"table table--loading-state"[39m
+    [33mrole[39m=[32m"group"[39m
+    [33mtabindex[39m=[32m"0"[39m
+  [36m>[39m
+    [36m<table>[39m
+      [36m<thead>[39m
+        [36m<tr>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mSeller[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mItem[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mStatus[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mList Price[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<defs>[39m
+                  [36m<symbol[39m
+                    [33mid[39m=[32m"icon-sort-12"[39m
+                    [33mviewBox[39m=[32m"0 0 12 12"[39m
+                  [36m>[39m
+                    [36m<path[39m
+                      [33md[39m=[32m"M2.75 1a.75.75 0 0 1 .75.75v6.527l.69-.775a.75.75 0 1 1 1.12.996L3.32 10.74a.752.752 0 0 1-1.137 0L.188 8.5a.75.75 0 1 1 1.122-.997l.69.774V1.75A.75.75 0 0 1 2.75 1Zm5.06 3.498a.75.75 0 1 1-1.12-.996L8.68 1.26a.752.752 0 0 1 1.137 0L11.81 3.5a.75.75 0 1 1-1.12.997L10 3.723v6.527a.75.75 0 0 1-1.5 0V3.723l-.69.775Z"[39m
+                    [36m/>[39m
+                  [36m</symbol>[39m
+                [36m</defs>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [36m<button[39m
+              [33mdisabled[39m=[32m""[39m
+              [33mtype[39m=[32m"button"[39m
+            [36m>[39m
+              [0mQuantity Available[0m
+              [0m [0m
+              [36m<svg[39m
+                [33maria-hidden[39m=[32m"true"[39m
+                [33mclass[39m=[32m"icon icon--12"[39m
+                [33mfocusable[39m=[32m"false"[39m
+              [36m>[39m
+                [36m<use[39m
+                  [33mhref[39m=[32m"#icon-sort-12"[39m
+                [36m/>[39m
+              [36m</svg>[39m
+            [36m</button>[39m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mOrders[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0mWatchers[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0mProtection[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mShipping[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mDelivery[0m
+          [36m</th>[39m
+        [36m</tr>[39m
+      [36m</thead>[39m
+      [36m<tbody>[39m
+        [36m<tr>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mNintendo[0m
+          [36m</th>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mNintendo Switch Brand New Gaming System with Four Controllers[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<span[39m
+              [33mclass[39m=[32m"signal signal--recent"[39m
+            [36m>[39m
+              [0mReady to Ship[0m
+            [36m</span>[39m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m$287.96[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m300[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<a[39m
+              [33mhref[39m=[32m"https://ebay.com"[39m
+            [36m>[39m
+              [0m00-10542-89507[0m
+            [36m</a>[39m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m95[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m$17.99[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mFREE[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0m4/1 - 4/5[0m
+          [36m</td>[39m
+        [36m</tr>[39m
+        [36m<tr>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mNintendo[0m
+          [36m</th>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mNintendo SNES Brand New Gaming System with Four Controllers[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<span[39m
+              [33mclass[39m=[32m"signal signal--recent"[39m
+            [36m>[39m
+              [0mReady to Ship[0m
+            [36m</span>[39m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m$89.85[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m45[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<a[39m
+              [33mhref[39m=[32m"https://ebay.com"[39m
+         ..."
+`;
+
 exports[`ebay-table > renders with loading state 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m

--- a/src/components/ebay-table/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-table/test/__snapshots__/test.server.js.snap
@@ -1850,8 +1850,9 @@ exports[`ebay-table > renders with anchors loading 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33mclass[39m=[32m"table table--loading-state"[39m
+    [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
-    [33mtabindex[39m=[32m"0"[39m
+    [33mtabindex[39m=[32m"-1"[39m
   [36m>[39m
     [36m<table>[39m
       [36m<thead>[39m
@@ -2019,16 +2020,16 @@ exports[`ebay-table > renders with anchors loading 1`] = `
           [36m</th>[39m
           [36m<th[39m
             [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
-          [36m>[39m
-            [36m<button[39..."
+          [36m>..."
 `;
 
 exports[`ebay-table > renders with columns client side loading 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33mclass[39m=[32m"table table--loading-state"[39m
+    [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
-    [33mtabindex[39m=[32m"0"[39m
+    [33mtabindex[39m=[32m"-1"[39m
   [36m>[39m
     [36m<table>[39m
       [36m<thead>[39m
@@ -2220,16 +2221,16 @@ exports[`ebay-table > renders with columns client side loading 1`] = `
             [33mclass[39m=[32m"table-cell"[39m
           [36m>[39m
             [36m<a[39m
-              [33mhref[39m=[32m"https://ebay.com"[39m
-         ..."
+              [33mhref[39m=[32..."
 `;
 
 exports[`ebay-table > renders with loading state 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
     [33mclass[39m=[32m"table table--loading-state"[39m
+    [33minert[39m=[32m""[39m
     [33mrole[39m=[32m"group"[39m
-    [33mtabindex[39m=[32m"0"[39m
+    [33mtabindex[39m=[32m"-1"[39m
   [36m>[39m
     [36m<table>[39m
       [36m<thead>[39m
@@ -2438,6 +2439,5 @@ exports[`ebay-table > renders with loading state 1`] = `
             [0m345[0m
           [36m</td>[39m
           [36m<td[39m
-            [33mclass[39m=[32m"table-cell"[39m
-  ..."
+            [33mcl..."
 `;

--- a/src/components/ebay-table/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-table/test/__snapshots__/test.server.js.snap
@@ -1758,7 +1758,7 @@ exports[`ebay-table > renders TableWithActions 1`] = `
               [33mclass[39m=[32m"select select--borderless"[39m
             [36m>[39m
               [36m<select[39m
-                [33mid[39m=[32m"s0-0-18[2[0]]-1[0]-select"[39m
+                [33mid[39m=[32m"s0-0-17[2[0]]-1[0]-select"[39m
               [36m>[39m
                 [36m<option[39m
                   [33mtext[39m=[32m"New"[39m
@@ -1819,11 +1819,11 @@ exports[`ebay-table > renders TableWithActions 1`] = `
                   [36m<svg[39m
                     [33maria-hidden[39m=[32m"true"[39m
                     [33mclass[39m=[32m"icon icon--24"[39m
-                    [33mdata-marko-key[39m=[32m"@svg s0-0-18[3[0]]-2[0]-4-0"[39m
+                    [33mdata-marko-key[39m=[32m"@svg s0-0-17[3[0]]-2[0]-4-0"[39m
                     [33mfocusable[39m=[32m"false"[39m
                   [36m>[39m
                     [36m<defs[39m
-                      [33mdata-marko-key[39m=[32m"@defs s0-0-18[3[0]]-2[0]-4-0"[39m
+                      [33mdata-marko-key[39m=[32m"@defs s0-0-17[3[0]]-2[0]-4-0"[39m
                     [36m>[39m
                       [36m<symbol[39m
                         [33mid[39m=[32m"icon-arrow-right-24"[39m
@@ -1843,5 +1843,223 @@ exports[`ebay-table > renders TableWithActions 1`] = `
               [36m<button[39m
                 [33mclass[39m=[32m"icon-btn"[39m
                 [33mdata-ebayui[39m=[32m""[39m
-                [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-18[3[0]]-3[0] false\\",\\"onkeydown\\":\\"handleKeydown s0-0-18[3[0]]-3[0] false\\",\\"onfocus\\":\\"handleFocus s0-0-18[3[0]]-3[0] false\\",\\"onblur\\":\\"handleBlur s0-0-18[3[0]]-3[0] ..."
+                [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-17[3[0]]-3[0] false\\",\\"onkeydown\\":\\"handleKeydown s0-0-17[3[0]]-3[0] false\\",\\"onfocus\\":\\"handleFocus s0-0-17[3[0]]-3[0] false\\",\\"onblur\\":\\"handleBlur s0-0-17[3[0]]-3[0] ..."
+`;
+
+exports[`ebay-table > renders with loading state 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"table table--loading-state"[39m
+    [33mrole[39m=[32m"group"[39m
+    [33mtabindex[39m=[32m"0"[39m
+  [36m>[39m
+    [36m<table>[39m
+      [36m<thead>[39m
+        [36m<tr>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mSeller[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mItem[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mStatus[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0mList Price[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0mQuantity Available[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mOrders[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0mWatchers[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0mProtection[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mShipping[0m
+          [36m</th>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mDelivery[0m
+          [36m</th>[39m
+        [36m</tr>[39m
+      [36m</thead>[39m
+      [36m<tbody>[39m
+        [36m<tr>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mNintendo[0m
+          [36m</th>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mNintendo Switch Brand New Gaming System with Four Controllers[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<span[39m
+              [33mclass[39m=[32m"signal signal--recent"[39m
+            [36m>[39m
+              [0mReady to Ship[0m
+            [36m</span>[39m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m$287.96[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m300[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<a[39m
+              [33mhref[39m=[32m"https://ebay.com"[39m
+            [36m>[39m
+              [0m00-10542-89507[0m
+            [36m</a>[39m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m95[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m$17.99[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mFREE[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0m4/1 - 4/5[0m
+          [36m</td>[39m
+        [36m</tr>[39m
+        [36m<tr>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mNintendo[0m
+          [36m</th>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mNintendo SNES Brand New Gaming System with Four Controllers[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<span[39m
+              [33mclass[39m=[32m"signal signal--recent"[39m
+            [36m>[39m
+              [0mReady to Ship[0m
+            [36m</span>[39m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m$89.85[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m45[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<a[39m
+              [33mhref[39m=[32m"https://ebay.com"[39m
+            [36m>[39m
+              [0m00-10542-89507[0m
+            [36m</a>[39m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m5[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m$18.95[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mFREE[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0m4/11 - 4/15[0m
+          [36m</td>[39m
+        [36m</tr>[39m
+        [36m<tr>[39m
+          [36m<th[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mMicrosoft[0m
+          [36m</th>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [0mMicrosoft XBOX 360 Brand New Gaming System with Four Controllers[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+          [36m>[39m
+            [36m<span[39m
+              [33mclass[39m=[32m"signal signal--time-sensitive"[39m
+            [36m>[39m
+              [0mBackorder[0m
+            [36m</span>[39m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m$499.99[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell table-cell--numeric"[39m
+          [36m>[39m
+            [0m345[0m
+          [36m</td>[39m
+          [36m<td[39m
+            [33mclass[39m=[32m"table-cell"[39m
+  ..."
 `;

--- a/src/components/ebay-table/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-table/test/__snapshots__/test.server.js.snap
@@ -773,7 +773,6 @@ exports[`ebay-table > renders ColumnSortingWithLink 1`] = `
       [36m</tbody>[39m
     [36m</table>[39m
     [36m<div[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mrole[39m=[32m"status"[39m
     [36m/>[39m
   [36m</div>[39m
@@ -1146,7 +1145,6 @@ exports[`ebay-table > renders Default 1`] = `
       [36m</tbody>[39m
     [36m</table>[39m
     [36m<div[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mrole[39m=[32m"status"[39m
     [36m/>[39m
   [36m</div>[39m
@@ -1672,7 +1670,6 @@ exports[`ebay-table > renders TableDensity 1`] = `
       [36m</tbody>[39m
     [36m</table>[39m
     [36m<div[39m
-      [33maria-live[39m=[32m"polite"[39m
       [33mrole[39m=[32m"status"[39m
     [36m/>[39m
   [36m</div>[39m

--- a/src/components/ebay-table/test/loading/test.browser.js
+++ b/src/components/ebay-table/test/loading/test.browser.js
@@ -19,7 +19,10 @@ describe("given table mode selection with loading", () => {
     describe("when first row is rendered", () => {
         it("then tri-state checkbox in header should be disabled", async () => {
             expect(
-                component.getByRole("checkbox", { name: "Select all" }),
+                component.getByRole("checkbox", {
+                    name: "Select all",
+                    hidden: true,
+                }),
             ).toHaveAttribute("disabled", "");
         });
     });
@@ -28,6 +31,7 @@ describe("given table mode selection with loading", () => {
         it("should be disabled", () => {
             const rowCheckboxes = component.getAllByRole("checkbox", {
                 name: "Select row",
+                hidden: true,
             });
             expect(rowCheckboxes).has.length(5);
             for (const [, checkbox] of Object.entries(rowCheckboxes)) {
@@ -46,6 +50,7 @@ describe("given table mode selection with loading", () => {
                 expect(
                     component.getByRole("checkbox", {
                         name: "Select all rows",
+                        hidden: true,
                     }),
                 ).not.toHaveAttribute("disabled");
             });
@@ -53,6 +58,7 @@ describe("given table mode selection with loading", () => {
             it("all row checkboxes should not be disabled", async () => {
                 const rowCheckboxes = component.getAllByRole("checkbox", {
                     name: "Select row",
+                    hidden: true,
                 });
                 expect(rowCheckboxes).has.length(5);
                 for (const [, checkbox] of Object.entries(rowCheckboxes)) {
@@ -71,20 +77,24 @@ describe("given table with actions with loading", () => {
 
     describe("all interactive elements should be disabled and have tabindex -1", () => {
         it("should have all buttons disabled", async () => {
-            component.getAllByRole("button").forEach(async (button) => {
-                await waitFor(() => {
-                    expect(button).toHaveAttribute("disabled", "");
-                    expect(button).toHaveAttribute("tabindex", "-1");
+            component
+                .getAllByRole("button", { hidden: true })
+                .forEach(async (button) => {
+                    await waitFor(() => {
+                        expect(button).toHaveAttribute("disabled", "");
+                        expect(button).toHaveAttribute("tabindex", "-1");
+                    });
                 });
-            });
         });
         it("should have all links disabled", async () => {
-            component.getAllByRole("link").forEach(async (button) => {
-                await waitFor(() => {
-                    expect(button).toHaveAttribute("disabled", "");
-                    expect(button).toHaveAttribute("tabindex", "-1");
+            component
+                .getAllByRole("link", { hidden: true })
+                .forEach(async (button) => {
+                    await waitFor(() => {
+                        expect(button).toHaveAttribute("disabled", "");
+                        expect(button).toHaveAttribute("tabindex", "-1");
+                    });
                 });
-            });
         });
     });
     describe("When table is rerendered without loading", () => {
@@ -94,12 +104,17 @@ describe("given table with actions with loading", () => {
 
         describe("all interactive elements should be enabled", () => {
             it("should have all buttons disabled", async () => {
-                component.getAllByRole("button").forEach(async (button) => {
-                    await waitFor(() => {
-                        expect(button).not.toHaveAttribute("disabled", "");
-                        expect(button).not.toHaveAttribute("tabindex", "-1");
+                component
+                    .getAllByRole("button", { hidden: true })
+                    .forEach(async (button) => {
+                        await waitFor(() => {
+                            expect(button).not.toHaveAttribute("disabled", "");
+                            expect(button).not.toHaveAttribute(
+                                "tabindex",
+                                "-1",
+                            );
+                        });
                     });
-                });
             });
         });
     });
@@ -115,12 +130,14 @@ describe("given table with header actions with loading", () => {
 
     describe("all interactive elements should be disabled and have tabindex -1", () => {
         it("should have all buttons disabled", async () => {
-            component.getAllByRole("button").forEach(async (button) => {
-                await waitFor(() => {
-                    expect(button).toHaveAttribute("disabled", "");
-                    expect(button).toHaveAttribute("tabindex", "-1");
+            component
+                .getAllByRole("button", { hidden: true })
+                .forEach(async (button) => {
+                    await waitFor(() => {
+                        expect(button).toHaveAttribute("disabled", "");
+                        expect(button).toHaveAttribute("tabindex", "-1");
+                    });
                 });
-            });
         });
     });
     describe("When table is rerendered without loading", () => {

--- a/src/components/ebay-table/test/loading/test.browser.js
+++ b/src/components/ebay-table/test/loading/test.browser.js
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
+import { composeStories } from "@storybook/marko";
+import { render, cleanup, waitFor } from "@marko/testing-library";
+import * as stories from "../../table.stories";
+
+const { SelectionModeBasic, TableWithActions, ColumnSortingClientSide } =
+    composeStories(stories);
+
+afterEach(cleanup);
+
+/** @type import("@marko/testing-library").RenderResult */
+
+describe("given table mode selection with loading", () => {
+    let component;
+    beforeEach(async () => {
+        component = await render(SelectionModeBasic, { bodyState: "loading" });
+    });
+
+    describe("when first row is rendered", () => {
+        it("then tri-state checkbox in header should be disabled", async () => {
+            expect(
+                component.getByRole("checkbox", { name: "Select all" }),
+            ).toHaveAttribute("disabled", "");
+        });
+    });
+
+    describe("all rows should have disabled items", () => {
+        it("should be disabled", () => {
+            const rowCheckboxes = component.getAllByRole("checkbox", {
+                name: "Select row",
+            });
+            expect(rowCheckboxes).has.length(5);
+            for (const [, checkbox] of Object.entries(rowCheckboxes)) {
+                expect(checkbox).toHaveAttribute("disabled");
+            }
+        });
+    });
+
+    describe("When table is rerendered without loading", () => {
+        beforeEach(async () => {
+            await component.rerender({ bodyState: "default" });
+        });
+
+        describe("all interactive elements should be enabled", () => {
+            it("then tri-state checkbox in header should not be disabled", async () => {
+                expect(
+                    component.getByRole("checkbox", {
+                        name: "Select all rows",
+                    }),
+                ).not.toHaveAttribute("disabled");
+            });
+
+            it("all row checkboxes should not be disabled", async () => {
+                const rowCheckboxes = component.getAllByRole("checkbox", {
+                    name: "Select row",
+                });
+                expect(rowCheckboxes).has.length(5);
+                for (const [, checkbox] of Object.entries(rowCheckboxes)) {
+                    expect(checkbox).not.toHaveAttribute("disabled");
+                }
+            });
+        });
+    });
+});
+
+describe("given table with actions with loading", () => {
+    let component;
+    beforeEach(async () => {
+        component = await render(TableWithActions, { bodyState: "loading" });
+    });
+
+    describe("all interactive elements should be disabled and have tabindex -1", () => {
+        it("should have all buttons disabled", async () => {
+            component.getAllByRole("button").forEach(async (button) => {
+                await waitFor(() => {
+                    expect(button).toHaveAttribute("disabled", "");
+                    expect(button).toHaveAttribute("tabindex", "-1");
+                });
+            });
+        });
+        it("should have all links disabled", async () => {
+            component.getAllByRole("link").forEach(async (button) => {
+                await waitFor(() => {
+                    expect(button).toHaveAttribute("disabled", "");
+                    expect(button).toHaveAttribute("tabindex", "-1");
+                });
+            });
+        });
+    });
+    describe("When table is rerendered without loading", () => {
+        beforeEach(async () => {
+            await component.rerender({ bodyState: "default" });
+        });
+
+        describe("all interactive elements should be enabled", () => {
+            it("should have all buttons disabled", async () => {
+                component.getAllByRole("button").forEach(async (button) => {
+                    await waitFor(() => {
+                        expect(button).not.toHaveAttribute("disabled", "");
+                        expect(button).not.toHaveAttribute("tabindex", "-1");
+                    });
+                });
+            });
+        });
+    });
+});
+
+describe("given table with header actions with loading", () => {
+    let component;
+    beforeEach(async () => {
+        component = await render(ColumnSortingClientSide, {
+            bodyState: "loading",
+        });
+    });
+
+    describe("all interactive elements should be disabled and have tabindex -1", () => {
+        it("should have all buttons disabled", async () => {
+            component.getAllByRole("button").forEach(async (button) => {
+                await waitFor(() => {
+                    expect(button).toHaveAttribute("disabled", "");
+                    expect(button).toHaveAttribute("tabindex", "-1");
+                });
+            });
+        });
+    });
+    describe("When table is rerendered without loading", () => {
+        beforeEach(async () => {
+            await component.rerender({ bodyState: "default" });
+        });
+
+        describe("all interactive elements should be enabled", () => {
+            it("should have all buttons disabled", async () => {
+                component.getAllByRole("button").forEach(async (button) => {
+                    await waitFor(() => {
+                        expect(button).not.toHaveAttribute("disabled", "");
+                        expect(button).not.toHaveAttribute("tabindex", "-1");
+                    });
+                });
+            });
+        });
+    });
+});

--- a/src/components/ebay-table/test/test.server.js
+++ b/src/components/ebay-table/test/test.server.js
@@ -3,7 +3,8 @@ import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import * as stories from "../table.stories"; // import all stories from the stories file
 
 const htmlSnap = snapshotHTML(__dirname);
-const { Default } = composeStories(stories);
+const { Default, ColumnSorting, ColumnSortingClientSide } =
+    composeStories(stories);
 
 describe("ebay-table", () => {
     for (const [name, story] of Object.entries(composeStories(stories))) {
@@ -14,5 +15,13 @@ describe("ebay-table", () => {
 
     it("renders with loading state", async () => {
         await htmlSnap(Default, { bodyState: "loading" });
+    });
+
+    it("renders with anchors loading", async () => {
+        await htmlSnap(ColumnSorting, { bodyState: "loading" });
+    });
+
+    it("renders with columns client side loading", async () => {
+        await htmlSnap(ColumnSortingClientSide, { bodyState: "loading" });
     });
 });

--- a/src/components/ebay-table/test/test.server.js
+++ b/src/components/ebay-table/test/test.server.js
@@ -3,6 +3,7 @@ import { snapshotHTML } from "../../../common/test-utils/snapshots";
 import * as stories from "../table.stories"; // import all stories from the stories file
 
 const htmlSnap = snapshotHTML(__dirname);
+const { Default } = composeStories(stories);
 
 describe("ebay-table", () => {
     for (const [name, story] of Object.entries(composeStories(stories))) {
@@ -10,4 +11,8 @@ describe("ebay-table", () => {
             await htmlSnap(story);
         });
     }
+
+    it("renders with loading state", async () => {
+        await htmlSnap(Default, { bodyState: "loading" });
+    });
 });


### PR DESCRIPTION
## Description
* Added table loading state. Used `body-state`. Was looking at using mode initially but that can remove `selected` state (can have load + selected`)
* Added `isLoading` variable to disable all interactive elements in template
* Added check in component to check all focusable elements (IE elements which are added by user) and disable/add tabindex -1 for them.
* For undo only remove tabindex and disabled attribute for items found in the list of disabled items
* Added tests for checking loading state

## References
https://github.com/eBay/ebayui-core/issues/2328

## Screenshots
<img width="1098" alt="Screenshot 2025-03-11 at 4 04 19 PM" src="https://github.com/user-attachments/assets/85c1f9c9-a577-411e-b21b-647835e31696" />

