### PR TITLE
feat(skeleton): added example for grouped skeletons

### DIFF
--- a/.changeset/lemon-sides-rhyme.md
+++ b/.changeset/lemon-sides-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat(skeleton): added example for grouped skeletons

--- a/src/components/ebay-skeleton/examples/grouped-tile.marko
+++ b/src/components/ebay-skeleton/examples/grouped-tile.marko
@@ -1,9 +1,10 @@
 <style>
     .group-demo-tile-container{
         display: flex;
+        flex-wrap: wrap;
     }
     .demo-tile-container {
-        margin-right: 20px;
+        margin: 10px;
         width: 220px;
     }
     .custom-image {

--- a/src/components/ebay-skeleton/examples/grouped-tile.marko
+++ b/src/components/ebay-skeleton/examples/grouped-tile.marko
@@ -12,7 +12,8 @@
     }
 </style>
 
-<ebay-skeleton class="group-demo-tile-container">
+<!-- Example with localized a11y-text. "Laden" translates to "Loading" in German  -->
+<ebay-skeleton class="group-demo-tile-container" a11y-text="Laden">
     <div class="demo-tile-container">
         <ebay-skeleton-image class="custom-image"/>
         <ebay-skeleton-text size="large" multiline/>

--- a/src/components/ebay-skeleton/examples/grouped-tile.marko
+++ b/src/components/ebay-skeleton/examples/grouped-tile.marko
@@ -1,0 +1,32 @@
+<style>
+    .group-demo-tile-container{
+        display: flex;
+    }
+    .demo-tile-container {
+        margin-right: 20px;
+        width: 220px;
+    }
+    .custom-image {
+        height: 220px;
+        width: 220px;
+    }
+</style>
+
+<ebay-skeleton class="group-demo-tile-container">
+    <div class="demo-tile-container">
+        <ebay-skeleton-image class="custom-image"/>
+        <ebay-skeleton-text size="large" multiline/>
+    </div>
+    <div class="demo-tile-container">
+        <ebay-skeleton-image class="custom-image"/>
+        <ebay-skeleton-text size="large" multiline/>
+    </div>
+   <div class="demo-tile-container">
+        <ebay-skeleton-image class="custom-image"/>
+        <ebay-skeleton-text size="large" multiline/>
+    </div>
+   <div class="demo-tile-container">
+        <ebay-skeleton-image class="custom-image"/>
+        <ebay-skeleton-text size="large" multiline/>
+    </div>
+</ebay-skeleton>

--- a/src/components/ebay-skeleton/index.marko
+++ b/src/components/ebay-skeleton/index.marko
@@ -9,7 +9,7 @@ static interface SkeletonInput extends Omit<Marko.HTML.Div, `on${string}`> {
 export interface Input extends WithNormalizedProps<SkeletonInput> {}
 
 $ const {
-    a11yText = "Loading...",
+    a11yText = "Loading",
     class: inputClass,
     ...htmlInput
 } = input;

--- a/src/components/ebay-skeleton/skeleton.stories.ts
+++ b/src/components/ebay-skeleton/skeleton.stories.ts
@@ -25,6 +25,8 @@ import withContentTemplate from "./examples/withContent.marko";
 import withContentCode from "./examples/withContent.marko?raw";
 import compositeTemplate from "./examples/composite.marko";
 import compositeCode from "./examples/composite.marko?raw";
+import groupedTileTemplate from "./examples/grouped-tile.marko";
+import groupedTileCode from "./examples/grouped-tile.marko?raw";
 import { Story } from "@storybook/marko";
 
 const Template: Story<Input> = (args) => ({
@@ -83,7 +85,7 @@ export default {
 export const Default = Template.bind({});
 Default.args = {
     style: "width: 220px",
-    renderBody: `<div class="skeleton__textbox" />` as any,
+    renderBody: `<div role="img" aria-label="Loading" class="skeleton__textbox" />` as any,
 };
 Default.parameters = {
     docs: {
@@ -124,3 +126,5 @@ export const withContent = buildExtensionTemplate(
     withContentTemplate,
     withContentCode,
 );
+
+export const GroupedTile = buildExtensionTemplate(groupedTileTemplate, groupedTileCode);

--- a/src/components/ebay-skeleton/skeleton.stories.ts
+++ b/src/components/ebay-skeleton/skeleton.stories.ts
@@ -85,7 +85,7 @@ export default {
 export const Default = Template.bind({});
 Default.args = {
     style: "width: 220px",
-    renderBody: `<div role="img" aria-label="Loading" class="skeleton__textbox" />` as any,
+    renderBody: `<div class="skeleton__textbox" />` as any,
 };
 Default.parameters = {
     docs: {

--- a/src/components/ebay-skeleton/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-skeleton/test/__snapshots__/test.server.js.snap
@@ -23,9 +23,7 @@ exports[`skeleton > renders default skeleton 1`] = `
     [33mstyle[39m=[32m"width: 220px"[39m
   [36m>[39m
     [36m<div[39m
-      [33maria-label[39m=[32m"Loading"[39m
       [33mclass[39m=[32m"skeleton__textbox"[39m
-      [33mrole[39m=[32m"img"[39m
     [36m/>[39m
   [36m</div>[39m
 [36m</DocumentFragment>[39m"

--- a/src/components/ebay-skeleton/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-skeleton/test/__snapshots__/test.server.js.snap
@@ -3,7 +3,7 @@
 exports[`skeleton > renders avatar 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
-    [33maria-label[39m=[32m"Loading..."[39m
+    [33maria-label[39m=[32m"Loading"[39m
     [33mclass[39m=[32m"skeleton"[39m
     [33mrole[39m=[32m"img"[39m
   [36m>[39m
@@ -17,13 +17,15 @@ exports[`skeleton > renders avatar 1`] = `
 exports[`skeleton > renders default skeleton 1`] = `
 "[36m<DocumentFragment>[39m
   [36m<div[39m
-    [33maria-label[39m=[32m"Loading..."[39m
+    [33maria-label[39m=[32m"Loading"[39m
     [33mclass[39m=[32m"skeleton"[39m
     [33mrole[39m=[32m"img"[39m
     [33mstyle[39m=[32m"width: 220px"[39m
   [36m>[39m
     [36m<div[39m
+      [33maria-label[39m=[32m"Loading"[39m
       [33mclass[39m=[32m"skeleton__textbox"[39m
+      [33mrole[39m=[32m"img"[39m
     [36m/>[39m
   [36m</div>[39m
 [36m</DocumentFragment>[39m"
@@ -35,7 +37,7 @@ exports[`skeleton > renders text 1`] = `
     [33mclass[39m=[32m"demo-text-container"[39m
   [36m>[39m
     [36m<div[39m
-      [33maria-label[39m=[32m"Loading..."[39m
+      [33maria-label[39m=[32m"Loading"[39m
       [33mclass[39m=[32m"skeleton"[39m
       [33mrole[39m=[32m"img"[39m
     [36m>[39m
@@ -53,7 +55,7 @@ exports[`skeleton > renders text multiLine 1`] = `
     [33mclass[39m=[32m"demo-text-container"[39m
   [36m>[39m
     [36m<div[39m
-      [33maria-label[39m=[32m"Loading..."[39m
+      [33maria-label[39m=[32m"Loading"[39m
       [33mclass[39m=[32m"skeleton"[39m
       [33mrole[39m=[32m"img"[39m
       [33mstyle[39m=[32m"width:220px"[39m
@@ -72,7 +74,7 @@ exports[`skeleton > renders tile 1`] = `
     [33mclass[39m=[32m"demo-tile-container"[39m
   [36m>[39m
     [36m<div[39m
-      [33maria-label[39m=[32m"Loading..."[39m
+      [33maria-label[39m=[32m"Loading"[39m
       [33mclass[39m=[32m"skeleton"[39m
       [33mrole[39m=[32m"img"[39m
     [36m>[39m


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- Added skeleton example for group tiles
- Removed un-necessary punctuation in `aria-label` to be consistent with docs.  


## References

Fixes #2416

## Screenshots

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/066a9bc3-b33f-44a3-962e-4c76d38bd1c7" />
