### PR TITLE
fix: hydration for ebay-accordion

### DIFF
--- a/.changeset/angry-lemons-stare.md
+++ b/.changeset/angry-lemons-stare.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Fix hydration for accordion

--- a/src/components/ebay-accordion/index.marko
+++ b/src/components/ebay-accordion/index.marko
@@ -1,7 +1,5 @@
 import { processHtmlAttributes } from "../../common/html-attributes";
 
-static function noop() {}
-
 $ const {
     class: inputClass,
     size,
@@ -10,8 +8,6 @@ $ const {
     a11yRoleDescription,
     ...htmlInput
 } = input;
-
-$ (input as any).toJSON = noop;
 
 <ul
     ...processHtmlAttributes(htmlInput)


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description

- The `toJSON` script should only be included for server components and split components. It causes client components to break on hydration if they are at the island boundary.
