### PR TITLE
fix(carousel): ensure controlled index always updates scroll position

### DIFF
--- a/.changeset/orange-horses-film.md
+++ b/.changeset/orange-horses-film.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Fix carousel scrolling bug

--- a/src/components/ebay-carousel/carousel.stories.ts
+++ b/src/components/ebay-carousel/carousel.stories.ts
@@ -13,6 +13,8 @@ import preserveTabindexTemplate from "./examples/preserve-tabindex.marko";
 import preserveTabindexTemplateCode from "./examples/preserve-tabindex.marko?raw";
 import variableSizesTemplate from "./examples/variable-sizes.marko";
 import variableSizesTemplateCode from "./examples/variable-sizes.marko?raw";
+import controlledTemplate from "./examples/discrete-controlled.marko";
+import controlledTemplateCode from "./examples/discrete-controlled.marko?raw";
 
 export default {
     title: "navigation & disclosure/ebay-carousel",
@@ -226,4 +228,9 @@ export const preserveTabindex = buildExtensionTemplate(
 export const variableSizes = buildExtensionTemplate(
     variableSizesTemplate,
     variableSizesTemplateCode,
+);
+
+export const controlled = buildExtensionTemplate(
+    controlledTemplate,
+    controlledTemplateCode,
 );

--- a/src/components/ebay-carousel/component.ts
+++ b/src/components/ebay-carousel/component.ts
@@ -498,6 +498,7 @@ class Carousel extends Marko.Component<Input, State> {
             };
         });
 
+        this.skipScrolling = this.state && this.state.index === state.index;
         this.state = state;
     }
 

--- a/src/components/ebay-carousel/examples/discrete-controlled.marko
+++ b/src/components/ebay-carousel/examples/discrete-controlled.marko
@@ -1,4 +1,5 @@
 import type { Input as CarouselInput } from "<ebay-carousel>";
+import type { Input as TextboxInput } from "<ebay-textbox>";
 
 export interface Input {
     items: number;
@@ -22,6 +23,9 @@ class {
     }
     onMove: CarouselInput["on-move"] = ({visibleIndexes}) => {
         this.state.index = visibleIndexes[0];
+    }
+    handleChange: TextboxInput["on-input-change"] = ({ value }) => {
+        this.state.index = +value;
     }
 }
 
@@ -55,3 +59,5 @@ class {
     <@item style={ width: "400px" } class="demo2-card">Card 9</@item>
     <@item style={ width: "400px" } class="demo2-card">Card 10</@item>
 </ebay-carousel>
+
+<ebay-textbox type="number" value=0 onInput-change("handleChange")/>


### PR DESCRIPTION
- Fixes #2463 

## Description

- Carousel was breaking under certain circumstances related to controlled index
- In previous versions, receiving `index` from `input` stops effecting scroll after it has been changed rapidly multiple times in a row, or after the user manually uses the scrollbar to update index
- I added a story to carousel where controlled carousel can be tested