### PR TITLE
feat: added item-tile, item-tile-group, and layout-grid

### DIFF
--- a/.changeset/slow-pets-melt.md
+++ b/.changeset/slow-pets-melt.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+feat: added item-tile, item-tile-group, and layout-grid

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -18,6 +18,7 @@ export const parameters = {
                 "dialogs",
                 "form input",
                 "graphics & icons",
+                "layout",
                 "media",
                 "navigation & disclosure",
                 "notices & tips",

--- a/src/components/ebay-file-preview-card-group/README.md
+++ b/src/components/ebay-file-preview-card-group/README.md
@@ -9,6 +9,10 @@
 
 Group of file preview cards, primarily used alongside `ebay-file-input`.
 
+## Compatibility
+
+This component only works on Marko 5 and later.
+
 ## Examples and Documentation
 
 - [Storybook](https://ebay.github.io/ebayui-core/?path=/story/media-ebay-file-preview-card-group)

--- a/src/components/ebay-file-preview-card/README.md
+++ b/src/components/ebay-file-preview-card/README.md
@@ -9,6 +9,10 @@
 
 Preview card for files, primarily used alongside `ebay-file-preview-card-group` and `ebay-file-input`.
 
+## Compatibility
+
+This component only works on Marko 5 and later.
+
 ## Examples and Documentation
 
 - [Storybook](https://ebay.github.io/ebayui-core/?path=/story/media-ebay-file-preview-card)

--- a/src/components/ebay-file-preview-card/component.ts
+++ b/src/components/ebay-file-preview-card/component.ts
@@ -13,20 +13,23 @@ export type FilePreviewCardMenuAction = {
     label: string;
 };
 
+export type FilePreviewCardFile =
+    | File
+    | {
+          name: string;
+          type?: File["type"];
+          src?: string;
+      };
 interface FilePreviewCardInput extends Omit<Marko.HTML.Div, `on${string}`> {
     "a11y-cancel-upload-text"?: AttrString;
     "delete-text"?: AttrString;
     as?: keyof Marko.NativeTags;
-    file?:
-        | File
-        | {
-              name: string;
-              type?: File["type"];
-              src?: string;
-          };
+    file?: FilePreviewCardFile;
     status?: "uploading";
+    href?: string;
     "info-text"?: AttrString;
     "menu-actions"?: FilePreviewCardMenuAction[];
+    action?: Marko.AttrTag<Marko.HTML.Button>;
     "see-more"?: number;
     "a11y-see-more-text"?: AttrString;
     "footer-title"?: AttrString;
@@ -34,6 +37,7 @@ interface FilePreviewCardInput extends Omit<Marko.HTML.Div, `on${string}`> {
     "on-menu-action"?: (name: string, event: MenuButtonEvent) => void;
     "on-see-more"?: () => void;
     "on-delete"?: () => void;
+    "on-action"?: () => void;
     "on-cancel"?: () => void;
 }
 

--- a/src/components/ebay-file-preview-card/index.marko
+++ b/src/components/ebay-file-preview-card/index.marko
@@ -1,3 +1,4 @@
+import { processHtmlAttributes } from "../../common/html-attributes";
 $ const {
     a11yCancelUploadText,
     deleteText,
@@ -9,6 +10,8 @@ $ const {
     a11ySeeMoreText,
     footerTitle,
     footerSubtitle,
+    action,
+    href,
     as: cardEl = "div",
     ...htmlInput
 } = input;
@@ -31,28 +34,30 @@ $ file.type = type;
 
 <${cardEl} class="file-preview-card" ...htmlInput>
     <div class="file-preview-card__body">
-        <if(status === "uploading")>
-            <ebay-progress-spinner
-                class="file-preview-card__asset"
-                size="large"
-            />
-        </if>
-        <else-if(file.type === "image")>
-            <img
-                class={
-                    "file-preview-card__asset": true,
-                    "file-preview-card__asset--fade": seeMore !== undefined,
-                }
-                src=file.src
-                alt=file.name
-            >
-        </else-if>
-        <else-if(file.type === "video")>
-            <video class="file-preview-card__asset" src=file.src/>
-        </else-if>
-        <else>
-            <ebay-file-24-icon class="file-preview-card__asset"/>
-        </else>
+        <${href ? "a" : null} href=href>
+            <if(status === "uploading")>
+                <ebay-progress-spinner
+                    class="file-preview-card__asset"
+                    size="large"
+                />
+            </if>
+            <else-if(file.type === "image")>
+                <img
+                    class={
+                        "file-preview-card__asset": true,
+                        "file-preview-card__asset--fade": seeMore !== undefined,
+                    }
+                    src=file.src
+                    alt=file.name
+                >
+            </else-if>
+            <else-if(file.type === "video")>
+                <video class="file-preview-card__asset" src=file.src/>
+            </else-if>
+            <else>
+                <ebay-file-24-icon class="file-preview-card__asset"/>
+            </else>
+        </>
         <if(seeMore)>
             <button
                 type="button"
@@ -90,7 +95,15 @@ $ file.type = type;
                         </for>
                     </ebay-menu-button>
                 </if>
-                <else>
+                <else-if(action)>
+                    <ebay-icon-button
+                        class="file-preview-card__action"
+                        onClick("emit", "action")
+                        ...processHtmlAttributes(action)>
+                        <${action} />
+                    </ebay-icon-button>
+                </else-if>
+                <else-if(deleteText)>
                     <ebay-icon-button
                         class="file-preview-card__action"
                         aria-label=deleteText
@@ -98,7 +111,7 @@ $ file.type = type;
                     >
                         <ebay-delete-16-icon/>
                     </ebay-icon-button>
-                </else>
+                </else-if>
             </else>
             <if(file.type !== "image")>
                 <div class="file-preview-card__info">

--- a/src/components/ebay-item-tile-group/README.md
+++ b/src/components/ebay-item-tile-group/README.md
@@ -1,0 +1,18 @@
+<h1 style="display: flex; justify-content: space-between; align-items: center;">
+    <span>
+        ebay-item-tile
+    </span>
+    <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
+        DS v1.0.0
+    </span>
+</h1>
+
+## Compatibility
+
+This component only works on Marko 5 and later.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/ebayui-core/?path=/story/structure-ebay-item-tile)
+- [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/structure-ebay-item-tile)
+- [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-item-tile/examples)

--- a/src/components/ebay-item-tile-group/browser.json
+++ b/src/components/ebay-item-tile-group/browser.json
@@ -1,0 +1,9 @@
+{
+    "requireRemap": [
+        {
+            "from": "./style",
+            "to": "../../common/empty",
+            "if-flag": "ebayui-no-skin"
+        }
+    ]
+}

--- a/src/components/ebay-item-tile-group/examples/default.marko
+++ b/src/components/ebay-item-tile-group/examples/default.marko
@@ -21,20 +21,16 @@ class {}
       <@subtitle>
           256GB Space Gray
       </@subtitle>
-    <@description>
-        <div class="price">
-        $29.99
-        <span class="clipped"> Was: </span>
-        <s class="list-price"> $68.99 </s>
-      </div>
-      <div class="buy-links">
-        <div>
-          <a href="https://ebay.com"> Buy it now </a>
-        </div>
-        <div>Free shipping</div>
-      </div>
-      <div class="sponsored">Sponsored</div>
-    </@description>
+      <@description class="price">
+          $29.99
+          <span class="clipped"> Was: </span>
+          <s class="list-price"> $68.99 </s>
+      </@description>
+      <@description>
+            <a href="https://ebay.com"> Buy it now </a>
+      </@description>
+      <@description>Free shipping</@description>
+      <@description>Sponsored</@description>
     </@item>
     <@item  href="https://ebay.com"
         file={
@@ -57,20 +53,48 @@ class {}
       <@subtitle>
           256GB Space Gray
       </@subtitle>
-    <@description>
-        <div class="price">
-        $29.99
-        <span class="clipped"> Was: </span>
-        <s class="list-price"> $68.99 </s>
-      </div>
-      <div class="buy-links">
-        <div>
-          <a href="https://ebay.com"> Buy it now </a>
-        </div>
-        <div>Free shipping</div>
-      </div>
-      <div class="sponsored">Sponsored</div>
-    </@description>
+      <@description class="price">
+          $29.99
+          <span class="clipped"> Was: </span>
+          <s class="list-price"> $68.99 </s>
+      </@description>
+      <@description>
+            <a href="https://ebay.com"> Buy it now </a>
+      </@description>
+      <@description>Free shipping</@description>
+      <@description>Sponsored</@description>
+    </@item>
+    <@item href="https://ebay.com"
+        file={
+            name: "file-name.jpg",
+            type: "image/jpeg",
+            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
+          }
+>
+    <@action aria-label="Add to watchlist">
+        <ebay-heart-16-icon/>
+    </@action>
+    <@supertitle>
+      <ebay-signal status="time-sensitive">
+        Time Sensitive
+      </ebay-signal>
+    </@supertitle>
+      <@title>
+          Apple iPhone 11 Pro Max
+      </@title>
+      <@subtitle>
+          256GB Space Gray
+      </@subtitle>
+      <@description class="price">
+          $29.99
+          <span class="clipped"> Was: </span>
+          <s class="list-price"> $68.99 </s>
+      </@description>
+      <@description>
+            <a href="https://ebay.com"> Buy it now </a>
+      </@description>
+      <@description>Free shipping</@description>
+      <@description>Sponsored</@description>
     </@item>
     <@item  href="https://ebay.com"
         file={
@@ -93,20 +117,16 @@ class {}
       <@subtitle>
           256GB Space Gray
       </@subtitle>
-    <@description>
-        <div class="price">
-        $29.99
-        <span class="clipped"> Was: </span>
-        <s class="list-price"> $68.99 </s>
-      </div>
-      <div class="buy-links">
-        <div>
-          <a href="https://ebay.com"> Buy it now </a>
-        </div>
-        <div>Free shipping</div>
-      </div>
-      <div class="sponsored">Sponsored</div>
-    </@description>
+      <@description class="price">
+          $29.99
+          <span class="clipped"> Was: </span>
+          <s class="list-price"> $68.99 </s>
+      </@description>
+      <@description>
+            <a href="https://ebay.com"> Buy it now </a>
+      </@description>
+      <@description>Free shipping</@description>
+      <@description>Sponsored</@description>
     </@item>
     <@item  href="https://ebay.com"
         file={
@@ -129,20 +149,16 @@ class {}
       <@subtitle>
           256GB Space Gray
       </@subtitle>
-    <@description>
-        <div class="price">
-        $29.99
-        <span class="clipped"> Was: </span>
-        <s class="list-price"> $68.99 </s>
-      </div>
-      <div class="buy-links">
-        <div>
-          <a href="https://ebay.com"> Buy it now </a>
-        </div>
-        <div>Free shipping</div>
-      </div>
-      <div class="sponsored">Sponsored</div>
-    </@description>
+      <@description class="price">
+          $29.99
+          <span class="clipped"> Was: </span>
+          <s class="list-price"> $68.99 </s>
+      </@description>
+      <@description>
+            <a href="https://ebay.com"> Buy it now </a>
+      </@description>
+      <@description>Free shipping</@description>
+      <@description>Sponsored</@description>
     </@item>
     <@item  href="https://ebay.com"
         file={
@@ -165,55 +181,15 @@ class {}
       <@subtitle>
           256GB Space Gray
       </@subtitle>
-    <@description>
-        <div class="price">
-        $29.99
-        <span class="clipped"> Was: </span>
-        <s class="list-price"> $68.99 </s>
-      </div>
-      <div class="buy-links">
-        <div>
-          <a href="https://ebay.com"> Buy it now </a>
-        </div>
-        <div>Free shipping</div>
-      </div>
-      <div class="sponsored">Sponsored</div>
-    </@description>
-    </@item>
-    <@item  href="https://ebay.com"
-        file={
-            name: "file-name.jpg",
-            type: "image/jpeg",
-            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
-          }
->
-    <@action aria-label="Add to watchlist">
-        <ebay-heart-16-icon/>
-    </@action>
-    <@supertitle>
-      <ebay-signal status="time-sensitive">
-        Time Sensitive
-      </ebay-signal>
-    </@supertitle>
-      <@title>
-          Apple iPhone 11 Pro Max
-      </@title>
-      <@subtitle>
-          256GB Space Gray
-      </@subtitle>
-    <@description>
-        <div class="price">
-        $29.99
-        <span class="clipped"> Was: </span>
-        <s class="list-price"> $68.99 </s>
-      </div>
-      <div class="buy-links">
-        <div>
-          <a href="https://ebay.com"> Buy it now </a>
-        </div>
-        <div>Free shipping</div>
-      </div>
-      <div class="sponsored">Sponsored</div>
-    </@description>
+      <@description class="price">
+          $29.99
+          <span class="clipped"> Was: </span>
+          <s class="list-price"> $68.99 </s>
+      </@description>
+      <@description>
+            <a href="https://ebay.com"> Buy it now </a>
+      </@description>
+      <@description>Free shipping</@description>
+      <@description>Sponsored</@description>
     </@item>
 </ebay-item-tile-group>

--- a/src/components/ebay-item-tile-group/examples/default.marko
+++ b/src/components/ebay-item-tile-group/examples/default.marko
@@ -1,0 +1,219 @@
+class {}
+<ebay-item-tile-group on-action("emit", "action") ...input>
+    <@item  href="https://ebay.com"
+        file={
+            name: "file-name.jpg",
+            type: "image/jpeg",
+            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
+          }
+>
+    <@action aria-label="Add to watchlist">
+        <ebay-heart-16-icon/>
+    </@action>
+    <@supertitle>
+      <ebay-signal status="time-sensitive">
+        Time Sensitive
+      </ebay-signal>
+    </@supertitle>
+      <@title>
+          Apple iPhone 11 Pro Max
+      </@title>
+      <@subtitle>
+          256GB Space Gray
+      </@subtitle>
+    <@description>
+        <div class="price">
+        $29.99
+        <span class="clipped"> Was: </span>
+        <s class="list-price"> $68.99 </s>
+      </div>
+      <div class="buy-links">
+        <div>
+          <a href="https://ebay.com"> Buy it now </a>
+        </div>
+        <div>Free shipping</div>
+      </div>
+      <div class="sponsored">Sponsored</div>
+    </@description>
+    </@item>
+    <@item  href="https://ebay.com"
+        file={
+            name: "file-name.jpg",
+            type: "image/jpeg",
+            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
+          }
+>
+    <@action aria-label="Add to watchlist">
+        <ebay-heart-16-icon/>
+    </@action>
+    <@supertitle>
+      <ebay-signal status="time-sensitive">
+        Time Sensitive
+      </ebay-signal>
+    </@supertitle>
+      <@title>
+          Apple iPhone 11 Pro Max
+      </@title>
+      <@subtitle>
+          256GB Space Gray
+      </@subtitle>
+    <@description>
+        <div class="price">
+        $29.99
+        <span class="clipped"> Was: </span>
+        <s class="list-price"> $68.99 </s>
+      </div>
+      <div class="buy-links">
+        <div>
+          <a href="https://ebay.com"> Buy it now </a>
+        </div>
+        <div>Free shipping</div>
+      </div>
+      <div class="sponsored">Sponsored</div>
+    </@description>
+    </@item>
+    <@item  href="https://ebay.com"
+        file={
+            name: "file-name.jpg",
+            type: "image/jpeg",
+            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
+          }
+>
+    <@action aria-label="Add to watchlist">
+        <ebay-heart-16-icon/>
+    </@action>
+    <@supertitle>
+      <ebay-signal status="time-sensitive">
+        Time Sensitive
+      </ebay-signal>
+    </@supertitle>
+      <@title>
+          Apple iPhone 11 Pro Max
+      </@title>
+      <@subtitle>
+          256GB Space Gray
+      </@subtitle>
+    <@description>
+        <div class="price">
+        $29.99
+        <span class="clipped"> Was: </span>
+        <s class="list-price"> $68.99 </s>
+      </div>
+      <div class="buy-links">
+        <div>
+          <a href="https://ebay.com"> Buy it now </a>
+        </div>
+        <div>Free shipping</div>
+      </div>
+      <div class="sponsored">Sponsored</div>
+    </@description>
+    </@item>
+    <@item  href="https://ebay.com"
+        file={
+            name: "file-name.jpg",
+            type: "image/jpeg",
+            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
+          }
+>
+    <@action aria-label="Add to watchlist">
+        <ebay-heart-16-icon/>
+    </@action>
+    <@supertitle>
+      <ebay-signal status="time-sensitive">
+        Time Sensitive
+      </ebay-signal>
+    </@supertitle>
+      <@title>
+          Apple iPhone 11 Pro Max
+      </@title>
+      <@subtitle>
+          256GB Space Gray
+      </@subtitle>
+    <@description>
+        <div class="price">
+        $29.99
+        <span class="clipped"> Was: </span>
+        <s class="list-price"> $68.99 </s>
+      </div>
+      <div class="buy-links">
+        <div>
+          <a href="https://ebay.com"> Buy it now </a>
+        </div>
+        <div>Free shipping</div>
+      </div>
+      <div class="sponsored">Sponsored</div>
+    </@description>
+    </@item>
+    <@item  href="https://ebay.com"
+        file={
+            name: "file-name.jpg",
+            type: "image/jpeg",
+            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
+          }
+>
+    <@action aria-label="Add to watchlist">
+        <ebay-heart-16-icon/>
+    </@action>
+    <@supertitle>
+      <ebay-signal status="time-sensitive">
+        Time Sensitive
+      </ebay-signal>
+    </@supertitle>
+      <@title>
+          Apple iPhone 11 Pro Max
+      </@title>
+      <@subtitle>
+          256GB Space Gray
+      </@subtitle>
+    <@description>
+        <div class="price">
+        $29.99
+        <span class="clipped"> Was: </span>
+        <s class="list-price"> $68.99 </s>
+      </div>
+      <div class="buy-links">
+        <div>
+          <a href="https://ebay.com"> Buy it now </a>
+        </div>
+        <div>Free shipping</div>
+      </div>
+      <div class="sponsored">Sponsored</div>
+    </@description>
+    </@item>
+    <@item  href="https://ebay.com"
+        file={
+            name: "file-name.jpg",
+            type: "image/jpeg",
+            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
+          }
+>
+    <@action aria-label="Add to watchlist">
+        <ebay-heart-16-icon/>
+    </@action>
+    <@supertitle>
+      <ebay-signal status="time-sensitive">
+        Time Sensitive
+      </ebay-signal>
+    </@supertitle>
+      <@title>
+          Apple iPhone 11 Pro Max
+      </@title>
+      <@subtitle>
+          256GB Space Gray
+      </@subtitle>
+    <@description>
+        <div class="price">
+        $29.99
+        <span class="clipped"> Was: </span>
+        <s class="list-price"> $68.99 </s>
+      </div>
+      <div class="buy-links">
+        <div>
+          <a href="https://ebay.com"> Buy it now </a>
+        </div>
+        <div>Free shipping</div>
+      </div>
+      <div class="sponsored">Sponsored</div>
+    </@description>
+    </@item>
+</ebay-item-tile-group>

--- a/src/components/ebay-item-tile-group/index.marko
+++ b/src/components/ebay-item-tile-group/index.marko
@@ -1,0 +1,35 @@
+import { processHtmlAttributes } from "../../common/html-attributes";
+import type { WithNormalizedProps } from '../../global';
+import type { ItemTileInput, ItemTileLayout } from "../ebay-item-tile/index.marko"
+import type { LayoutOptions } from "../ebay-layout-grid/index.marko"
+
+class {}
+
+static interface ItemTileGroupInput extends Omit<Marko.HTML.Div, `on${string}`> {
+    layout?: ItemTileLayout;
+    item?: Marko.AttrTag<ItemTileInput>;
+    columns?: LayoutOptions;
+    "on-action"?: () => void;
+}
+
+export interface Input extends WithNormalizedProps<ItemTileGroupInput> {}
+
+$ const {
+    class: inputClass,
+    item: items = [],
+    columns,
+    layout,
+    ...htmlInput
+} = input;
+
+<ebay-layout-grid class="item-tile-group"
+    columns=columns
+    ...processHtmlAttributes(htmlInput)
+>
+    <for|item, i| of=items>
+        <@item>
+            <ebay-item-tile on-action("emit", "action", i) layout=layout ...item/>
+        </@item>
+
+    </for>
+</ebay-layout-grid>

--- a/src/components/ebay-item-tile-group/index.marko
+++ b/src/components/ebay-item-tile-group/index.marko
@@ -1,14 +1,12 @@
 import { processHtmlAttributes } from "../../common/html-attributes";
 import type { WithNormalizedProps } from '../../global';
 import type { ItemTileInput, ItemTileLayout } from "../ebay-item-tile/index.marko"
-import type { LayoutOptions } from "../ebay-layout-grid/index.marko"
 
 class {}
 
 static interface ItemTileGroupInput extends Omit<Marko.HTML.Div, `on${string}`> {
     layout?: ItemTileLayout;
     item?: Marko.AttrTag<ItemTileInput>;
-    columns?: LayoutOptions;
     "on-action"?: () => void;
 }
 
@@ -17,13 +15,11 @@ export interface Input extends WithNormalizedProps<ItemTileGroupInput> {}
 $ const {
     class: inputClass,
     item: items = [],
-    columns,
     layout,
     ...htmlInput
 } = input;
 
 <ebay-layout-grid class="item-tile-group"
-    columns=columns
     ...processHtmlAttributes(htmlInput)
 >
     <for|item, i| of=items>

--- a/src/components/ebay-item-tile-group/item-tile-group.stories.ts
+++ b/src/components/ebay-item-tile-group/item-tile-group.stories.ts
@@ -27,18 +27,6 @@ export default {
             description:
                 "Item to be rendered inside the group. Arguments used are the same as for item-tile. See item-tile for more information.",
         },
-        columns: {
-            control: { type: "object" },
-            description:
-                "Number of columns per screen size. Object with keys: min, xs, sm, md, lg, xl, xl2, xl3, xl4",
-
-            table: {
-                defaultValue: {
-                    summary:
-                        "{ min: 1, xs: 2, sm: 3, md: 4, lg: 6, xl: 8, xl2: 10, xl3: 12, xl4: 14 }",
-                },
-            },
-        },
         layout: {
             control: { type: "select" },
             options: ["gallery", "list"],

--- a/src/components/ebay-item-tile-group/item-tile-group.stories.ts
+++ b/src/components/ebay-item-tile-group/item-tile-group.stories.ts
@@ -1,0 +1,65 @@
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import Component from "./index.marko";
+import Readme from "./README.md";
+import DefaultTemplate from "./examples/default.marko";
+import DefaultTemplateCode from "./examples/default.marko?raw";
+
+export default {
+    title: "layout/ebay-item-tile-group",
+    component: Component,
+    parameters: {
+        docs: {
+            description: {
+                component: Readme,
+            },
+        },
+    },
+
+    argTypes: {
+        renderBody: {
+            control: { type: "text" },
+        },
+        item: {
+            name: "@item",
+            table: {
+                category: "@attribute tags",
+            },
+            description:
+                "Item to be rendered inside the group. Arguments used are the same as for item-tile. See item-tile for more information.",
+        },
+        columns: {
+            control: { type: "object" },
+            description:
+                "Number of columns per screen size. Object with keys: min, xs, sm, md, lg, xl, xl2, xl3, xl4",
+
+            table: {
+                defaultValue: {
+                    summary:
+                        "{ min: 1, xs: 2, sm: 3, md: 4, lg: 6, xl: 8, xl2: 10, xl3: 12, xl4: 14 }",
+                },
+            },
+        },
+        layout: {
+            control: { type: "select" },
+            options: ["gallery", "list"],
+            description:
+                "The layout of the item-tile. The default is gallery. The list layout takes more horizontal space and is better for displaying more information.",
+        },
+        onAction: {
+            action: "on-action",
+            description:
+                "Triggered on action pressed. Index of item pressed is passed as a parameter.",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
+    },
+};
+
+export const Default = buildExtensionTemplate(
+    DefaultTemplate,
+    DefaultTemplateCode,
+);

--- a/src/components/ebay-item-tile-group/style.ts
+++ b/src/components/ebay-item-tile-group/style.ts
@@ -1,0 +1,1 @@
+import "@ebay/skin/item-tile";

--- a/src/components/ebay-item-tile-group/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-item-tile-group/test/__snapshots__/test.server.js.snap
@@ -1,0 +1,315 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ebay-item-tile-group > renders default 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"layout-grid item-tile-group"[39m
+  [36m>[39m
+    [36m<ul>[39m
+      [36m<li>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"item-tile"[39m
+        [36m>[39m
+          [36m<div[39m
+            [33mclass[39m=[32m"item-tile__header"[39m
+          [36m>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"file-preview-card"[39m
+            [36m>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"file-preview-card__body"[39m
+              [36m>[39m
+                [36m<a[39m
+                  [33mhref[39m=[32m"https://ebay.com"[39m
+                [36m>[39m
+                  [36m<img[39m
+                    [33malt[39m=[32m"file-name.jpg"[39m
+                    [33mclass[39m=[32m"file-preview-card__asset"[39m
+                    [33msrc[39m=[32m"https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg"[39m
+                  [36m/>[39m
+                [36m</a>[39m
+                [36m<button[39m
+                  [33mclass[39m=[32m"file-preview-card__action icon-btn"[39m
+                  [33mdata-ebayui[39m=[32m""[39m
+                  [33mtype[39m=[32m"button"[39m
+                [36m>[39m
+                  [36m<svg[39m
+                    [33maria-hidden[39m=[32m"true"[39m
+                    [33mclass[39m=[32m"icon icon--16"[39m
+                    [33mfocusable[39m=[32m"false"[39m
+                  [36m>[39m
+                    [36m<defs>[39m
+                      [36m<symbol[39m
+                        [33mid[39m=[32m"icon-heart-16"[39m
+                        [33mviewBox[39m=[32m"0 0 16 16"[39m
+                      [36m>[39m
+                        [36m<path[39m
+                          [33mclip-rule[39m=[32m"evenodd"[39m
+                          [33md[39m=[32m"M8 2.536a6.136 6.136 0 0 0-1.448-1.053A4.409 4.409 0 0 0 4.5 1c-1.55 0-2.709.634-3.461 1.554C.31 3.443 0 4.55 0 5.5c0 .918.348 1.711.704 2.292.36.586.77 1.023.978 1.237 4.193 4.327 4.91 5.011 5.624 5.691a.996.996 0 0 0 1.388 0c.714-.68 1.43-1.364 5.624-5.69a7.23 7.23 0 0 0 .978-1.238c.356-.58.704-1.374.704-2.292 0-.95-.312-2.057-1.039-2.946C14.21 1.634 13.05 1 11.5 1c-.625 0-1.311.107-2.052.483-.48.244-.96.588-1.448 1.053Zm-.778 2.093c-.635-.753-1.155-1.15-1.574-1.362A2.412 2.412 0 0 0 4.5 3c-.95 0-1.541.366-1.914.82A2.73 2.73 0 0 0 2 5.5c0 .415.161.842.409 1.246.245.398.535.711.71.891 2.97 3.065 4.183 4.289 4.881 4.974.698-.685 1.912-1.91 4.882-4.974.174-.18.464-.493.71-.891.247-.404.408-.83.408-1.246a2.73 2.73 0 0 0-.586-1.68C13.04 3.367 12.45 3 11.5 3c-.375 0-.739.06-1.148.267-.42.213-.94.609-1.574 1.362a.998.998 0 0 1-1.208.274.994.994 0 0 1-.348-.274Z"[39m
+                          [33mfill-rule[39m=[32m"evenodd"[39m
+                        [36m/>[39m
+                      [36m</symbol>[39m
+                    [36m</defs>[39m
+                    [36m<use[39m
+                      [33mhref[39m=[32m"#icon-heart-16"[39m
+                    [36m/>[39m
+                  [36m</svg>[39m
+                [36m</button>[39m
+              [36m</div>[39m
+            [36m</div>[39m
+          [36m</div>[39m
+          [36m<div[39m
+            [33mclass[39m=[32m"item-tile__body"[39m
+          [36m>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"item-tile__section-primary"[39m
+            [36m>[39m
+              [36m<span[39m
+                [33mclass[39m=[32m"signal signal--time-sensitive"[39m
+              [36m>[39m
+                [0mTime Sensitive[0m
+              [36m</span>[39m
+            [36m</div>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"item-tile__section-secondary"[39m
+            [36m>[39m
+              [36m<a[39m
+                [33mclass[39m=[32m"item-tile__title"[39m
+                [33mhref[39m=[32m"https://ebay.com"[39m
+              [36m>[39m
+                [0mApple iPhone 11 Pro Max[0m
+              [36m</a>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"item-tile__subtitle"[39m
+              [36m>[39m
+                [0m256GB Space Gray[0m
+              [36m</div>[39m
+            [36m</div>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"item-tile__section-tertiary"[39m
+            [36m>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"price"[39m
+              [36m>[39m
+                [0m$29.99 [0m
+                [36m<span[39m
+                  [33mclass[39m=[32m"clipped"[39m
+                [36m>[39m
+                  [0m Was: [0m
+                [36m</span>[39m
+                [36m<s[39m
+                  [33mclass[39m=[32m"list-price"[39m
+                [36m>[39m
+                  [0m $68.99 [0m
+                [36m</s>[39m
+              [36m</div>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"buy-links"[39m
+              [36m>[39m
+                [36m<div>[39m
+                  [36m<a[39m
+                    [33mhref[39m=[32m"https://ebay.com"[39m
+                  [36m>[39m
+                    [0m Buy it now [0m
+                  [36m</a>[39m
+                [36m</div>[39m
+                [36m<div>[39m
+                  [0mFree shipping[0m
+                [36m</div>[39m
+              [36m</div>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"sponsored"[39m
+              [36m>[39m
+                [0mSponsored[0m
+              [36m</div>[39m
+            [36m</div>[39m
+          [36m</div>[39m
+        [36m</div>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"item-tile"[39m
+        [36m>[39m
+          [36m<div[39m
+            [33mclass[39m=[32m"item-tile__header"[39m
+          [36m>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"file-preview-card"[39m
+            [36m>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"file-preview-card__body"[39m
+              [36m>[39m
+                [36m<a[39m
+                  [33mhref[39m=[32m"https://ebay.com"[39m
+                [36m>[39m
+                  [36m<img[39m
+                    [33malt[39m=[32m"file-name.jpg"[39m
+                    [33mclass[39m=[32m"file-preview-card__asset"[39m
+                    [33msrc[39m=[32m"https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg"[39m
+                  [36m/>[39m
+                [36m</a>[39m
+                [36m<button[39m
+                  [33mclass[39m=[32m"file-preview-card__action icon-btn"[39m
+                  [33mdata-ebayui[39m=[32m""[39m
+                  [33mtype[39m=[32m"button"[39m
+                [36m>[39m
+                  [36m<svg[39m
+                    [33maria-hidden[39m=[32m"..."
+`;
+
+exports[`ebay-item-tile-group > renders with layout=list 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"layout-grid item-tile-group"[39m
+  [36m>[39m
+    [36m<ul>[39m
+      [36m<li>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"item-tile item-tile--list-view"[39m
+        [36m>[39m
+          [36m<div[39m
+            [33mclass[39m=[32m"item-tile__header"[39m
+          [36m>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"file-preview-card"[39m
+            [36m>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"file-preview-card__body"[39m
+              [36m>[39m
+                [36m<a[39m
+                  [33mhref[39m=[32m"https://ebay.com"[39m
+                [36m>[39m
+                  [36m<img[39m
+                    [33malt[39m=[32m"file-name.jpg"[39m
+                    [33mclass[39m=[32m"file-preview-card__asset"[39m
+                    [33msrc[39m=[32m"https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg"[39m
+                  [36m/>[39m
+                [36m</a>[39m
+                [36m<button[39m
+                  [33mclass[39m=[32m"file-preview-card__action icon-btn"[39m
+                  [33mdata-ebayui[39m=[32m""[39m
+                  [33mtype[39m=[32m"button"[39m
+                [36m>[39m
+                  [36m<svg[39m
+                    [33maria-hidden[39m=[32m"true"[39m
+                    [33mclass[39m=[32m"icon icon--16"[39m
+                    [33mfocusable[39m=[32m"false"[39m
+                  [36m>[39m
+                    [36m<defs>[39m
+                      [36m<symbol[39m
+                        [33mid[39m=[32m"icon-heart-16"[39m
+                        [33mviewBox[39m=[32m"0 0 16 16"[39m
+                      [36m>[39m
+                        [36m<path[39m
+                          [33mclip-rule[39m=[32m"evenodd"[39m
+                          [33md[39m=[32m"M8 2.536a6.136 6.136 0 0 0-1.448-1.053A4.409 4.409 0 0 0 4.5 1c-1.55 0-2.709.634-3.461 1.554C.31 3.443 0 4.55 0 5.5c0 .918.348 1.711.704 2.292.36.586.77 1.023.978 1.237 4.193 4.327 4.91 5.011 5.624 5.691a.996.996 0 0 0 1.388 0c.714-.68 1.43-1.364 5.624-5.69a7.23 7.23 0 0 0 .978-1.238c.356-.58.704-1.374.704-2.292 0-.95-.312-2.057-1.039-2.946C14.21 1.634 13.05 1 11.5 1c-.625 0-1.311.107-2.052.483-.48.244-.96.588-1.448 1.053Zm-.778 2.093c-.635-.753-1.155-1.15-1.574-1.362A2.412 2.412 0 0 0 4.5 3c-.95 0-1.541.366-1.914.82A2.73 2.73 0 0 0 2 5.5c0 .415.161.842.409 1.246.245.398.535.711.71.891 2.97 3.065 4.183 4.289 4.881 4.974.698-.685 1.912-1.91 4.882-4.974.174-.18.464-.493.71-.891.247-.404.408-.83.408-1.246a2.73 2.73 0 0 0-.586-1.68C13.04 3.367 12.45 3 11.5 3c-.375 0-.739.06-1.148.267-.42.213-.94.609-1.574 1.362a.998.998 0 0 1-1.208.274.994.994 0 0 1-.348-.274Z"[39m
+                          [33mfill-rule[39m=[32m"evenodd"[39m
+                        [36m/>[39m
+                      [36m</symbol>[39m
+                    [36m</defs>[39m
+                    [36m<use[39m
+                      [33mhref[39m=[32m"#icon-heart-16"[39m
+                    [36m/>[39m
+                  [36m</svg>[39m
+                [36m</button>[39m
+              [36m</div>[39m
+            [36m</div>[39m
+          [36m</div>[39m
+          [36m<div[39m
+            [33mclass[39m=[32m"item-tile__body"[39m
+          [36m>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"item-tile__section-primary"[39m
+            [36m>[39m
+              [36m<span[39m
+                [33mclass[39m=[32m"signal signal--time-sensitive"[39m
+              [36m>[39m
+                [0mTime Sensitive[0m
+              [36m</span>[39m
+            [36m</div>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"item-tile__section-secondary"[39m
+            [36m>[39m
+              [36m<a[39m
+                [33mclass[39m=[32m"item-tile__title"[39m
+                [33mhref[39m=[32m"https://ebay.com"[39m
+              [36m>[39m
+                [0mApple iPhone 11 Pro Max[0m
+              [36m</a>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"item-tile__subtitle"[39m
+              [36m>[39m
+                [0m256GB Space Gray[0m
+              [36m</div>[39m
+            [36m</div>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"item-tile__section-tertiary"[39m
+            [36m>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"price"[39m
+              [36m>[39m
+                [0m$29.99 [0m
+                [36m<span[39m
+                  [33mclass[39m=[32m"clipped"[39m
+                [36m>[39m
+                  [0m Was: [0m
+                [36m</span>[39m
+                [36m<s[39m
+                  [33mclass[39m=[32m"list-price"[39m
+                [36m>[39m
+                  [0m $68.99 [0m
+                [36m</s>[39m
+              [36m</div>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"buy-links"[39m
+              [36m>[39m
+                [36m<div>[39m
+                  [36m<a[39m
+                    [33mhref[39m=[32m"https://ebay.com"[39m
+                  [36m>[39m
+                    [0m Buy it now [0m
+                  [36m</a>[39m
+                [36m</div>[39m
+                [36m<div>[39m
+                  [0mFree shipping[0m
+                [36m</div>[39m
+              [36m</div>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"sponsored"[39m
+              [36m>[39m
+                [0mSponsored[0m
+              [36m</div>[39m
+            [36m</div>[39m
+          [36m</div>[39m
+        [36m</div>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"item-tile item-tile--list-view"[39m
+        [36m>[39m
+          [36m<div[39m
+            [33mclass[39m=[32m"item-tile__header"[39m
+          [36m>[39m
+            [36m<div[39m
+              [33mclass[39m=[32m"file-preview-card"[39m
+            [36m>[39m
+              [36m<div[39m
+                [33mclass[39m=[32m"file-preview-card__body"[39m
+              [36m>[39m
+                [36m<a[39m
+                  [33mhref[39m=[32m"https://ebay.com"[39m
+                [36m>[39m
+                  [36m<img[39m
+                    [33malt[39m=[32m"file-name.jpg"[39m
+                    [33mclass[39m=[32m"file-preview-card__asset"[39m
+                    [33msrc[39m=[32m"https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg"[39m
+                  [36m/>[39m
+                [36m</a>[39m
+                [36m<button[39m
+                  [33mclass[39m=[32m"file-preview-card__action icon-btn"[39m
+                  [33mdata-ebayui[39m=[32m""[39m
+                  [33mtype[39m=[32m"button"[39m
+                [36m>[39m
+                  [36m<svg[39m
+      ..."
+`;

--- a/src/components/ebay-item-tile-group/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-item-tile-group/test/__snapshots__/test.server.js.snap
@@ -88,7 +88,7 @@ exports[`ebay-item-tile-group > renders default 1`] = `
             [36m<div[39m
               [33mclass[39m=[32m"item-tile__section-tertiary"[39m
             [36m>[39m
-              [36m<div[39m
+              [36m<p[39m
                 [33mclass[39m=[32m"price"[39m
               [36m>[39m
                 [0m$29.99 [0m
@@ -102,26 +102,20 @@ exports[`ebay-item-tile-group > renders default 1`] = `
                 [36m>[39m
                   [0m $68.99 [0m
                 [36m</s>[39m
-              [36m</div>[39m
-              [36m<div[39m
-                [33mclass[39m=[32m"buy-links"[39m
-              [36m>[39m
-                [36m<div>[39m
-                  [36m<a[39m
-                    [33mhref[39m=[32m"https://ebay.com"[39m
-                  [36m>[39m
-                    [0m Buy it now [0m
-                  [36m</a>[39m
-                [36m</div>[39m
-                [36m<div>[39m
-                  [0mFree shipping[0m
-                [36m</div>[39m
-              [36m</div>[39m
-              [36m<div[39m
-                [33mclass[39m=[32m"sponsored"[39m
-              [36m>[39m
+              [36m</p>[39m
+              [36m<p>[39m
+                [36m<a[39m
+                  [33mhref[39m=[32m"https://ebay.com"[39m
+                [36m>[39m
+                  [0m Buy it now [0m
+                [36m</a>[39m
+              [36m</p>[39m
+              [36m<p>[39m
+                [0mFree shipping[0m
+              [36m</p>[39m
+              [36m<p>[39m
                 [0mSponsored[0m
-              [36m</div>[39m
+              [36m</p>[39m
             [36m</div>[39m
           [36m</div>[39m
         [36m</div>[39m
@@ -154,7 +148,12 @@ exports[`ebay-item-tile-group > renders default 1`] = `
                   [33mtype[39m=[32m"button"[39m
                 [36m>[39m
                   [36m<svg[39m
-                    [33maria-hidden[39m=[32m"..."
+                    [33maria-hidden[39m=[32m"true"[39m
+                    [33mclass[39m=[32m"icon icon--16"[39m
+                    [33mfocusable[39m=[32m"false"[39m
+                  [36m>[39m
+                    [36m<use[39m
+                      [33mhref[39m=[32m"#icon-heart-16"..."
 `;
 
 exports[`ebay-item-tile-group > renders with layout=list 1`] = `
@@ -245,7 +244,7 @@ exports[`ebay-item-tile-group > renders with layout=list 1`] = `
             [36m<div[39m
               [33mclass[39m=[32m"item-tile__section-tertiary"[39m
             [36m>[39m
-              [36m<div[39m
+              [36m<p[39m
                 [33mclass[39m=[32m"price"[39m
               [36m>[39m
                 [0m$29.99 [0m
@@ -259,26 +258,20 @@ exports[`ebay-item-tile-group > renders with layout=list 1`] = `
                 [36m>[39m
                   [0m $68.99 [0m
                 [36m</s>[39m
-              [36m</div>[39m
-              [36m<div[39m
-                [33mclass[39m=[32m"buy-links"[39m
-              [36m>[39m
-                [36m<div>[39m
-                  [36m<a[39m
-                    [33mhref[39m=[32m"https://ebay.com"[39m
-                  [36m>[39m
-                    [0m Buy it now [0m
-                  [36m</a>[39m
-                [36m</div>[39m
-                [36m<div>[39m
-                  [0mFree shipping[0m
-                [36m</div>[39m
-              [36m</div>[39m
-              [36m<div[39m
-                [33mclass[39m=[32m"sponsored"[39m
-              [36m>[39m
+              [36m</p>[39m
+              [36m<p>[39m
+                [36m<a[39m
+                  [33mhref[39m=[32m"https://ebay.com"[39m
+                [36m>[39m
+                  [0m Buy it now [0m
+                [36m</a>[39m
+              [36m</p>[39m
+              [36m<p>[39m
+                [0mFree shipping[0m
+              [36m</p>[39m
+              [36m<p>[39m
                 [0mSponsored[0m
-              [36m</div>[39m
+              [36m</p>[39m
             [36m</div>[39m
           [36m</div>[39m
         [36m</div>[39m
@@ -311,5 +304,10 @@ exports[`ebay-item-tile-group > renders with layout=list 1`] = `
                   [33mtype[39m=[32m"button"[39m
                 [36m>[39m
                   [36m<svg[39m
-      ..."
+                    [33maria-hidden[39m=[32m"true"[39m
+                    [33mclass[39m=[32m"icon icon--16"[39m
+                    [33mfocusable[39m=[32m"false"[39m
+                  [36m>[39m
+                    [36m<use[39m
+                 ..."
 `;

--- a/src/components/ebay-item-tile-group/test/test.server.js
+++ b/src/components/ebay-item-tile-group/test/test.server.js
@@ -1,0 +1,17 @@
+import { it } from "vitest";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../item-tile-group.stories"; // import all stories from the stories file
+
+const { Default } = composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
+
+describe("ebay-item-tile-group", () => {
+    it("renders default", async () => {
+        await htmlSnap(Default);
+    });
+
+    it("renders with layout=list", async () => {
+        await htmlSnap(Default, { layout: "list" });
+    });
+});

--- a/src/components/ebay-item-tile/README.md
+++ b/src/components/ebay-item-tile/README.md
@@ -1,0 +1,18 @@
+<h1 style="display: flex; justify-content: space-between; align-items: center;">
+    <span>
+        ebay-item-tile
+    </span>
+    <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
+        DS v1.0.0
+    </span>
+</h1>
+
+## Compatibility
+
+This component only works on Marko 5 and later.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/ebayui-core/?path=/story/structure-ebay-item-tile)
+- [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/structure-ebay-item-tile)
+- [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-item-tile/examples)

--- a/src/components/ebay-item-tile/browser.json
+++ b/src/components/ebay-item-tile/browser.json
@@ -1,0 +1,9 @@
+{
+    "requireRemap": [
+        {
+            "from": "./style",
+            "to": "../../common/empty",
+            "if-flag": "ebayui-no-skin"
+        }
+    ]
+}

--- a/src/components/ebay-item-tile/examples/default.marko
+++ b/src/components/ebay-item-tile/examples/default.marko
@@ -1,0 +1,38 @@
+class {}
+<ebay-item-tile on-action("emit", "action") href="https://ebay.com"
+        file={
+            name: "file-name.jpg",
+            type: "image/jpeg",
+            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
+          }
+          ...input
+>
+    <@action aria-label="Add to watchlist">
+        <ebay-heart-16-icon/>
+    </@action>
+    <@supertitle>
+      <ebay-signal status="time-sensitive">
+        Time Sensitive
+      </ebay-signal>
+    </@supertitle>
+      <@title>
+          Apple iPhone 11 Pro Max
+      </@title>
+      <@subtitle>
+          256GB Space Gray
+      </@subtitle>
+    <@description>
+        <div class="price">
+        $29.99
+        <span class="clipped"> Was: </span>
+        <s class="list-price"> $68.99 </s>
+      </div>
+      <div class="buy-links">
+        <div>
+          <a href="https://ebay.com"> Buy it now </a>
+        </div>
+        <div>Free shipping</div>
+      </div>
+      <div class="sponsored">Sponsored</div>
+    </@description>
+</ebay-item-tile>

--- a/src/components/ebay-item-tile/examples/default.marko
+++ b/src/components/ebay-item-tile/examples/default.marko
@@ -21,18 +21,14 @@ class {}
       <@subtitle>
           256GB Space Gray
       </@subtitle>
-    <@description>
-        <div class="price">
+    <@description class="price">
         $29.99
         <span class="clipped"> Was: </span>
         <s class="list-price"> $68.99 </s>
-      </div>
-      <div class="buy-links">
-        <div>
-          <a href="https://ebay.com"> Buy it now </a>
-        </div>
-        <div>Free shipping</div>
-      </div>
-      <div class="sponsored">Sponsored</div>
     </@description>
+    <@description>
+          <a href="https://ebay.com"> Buy it now </a>
+    </@description>
+    <@description>Free shipping</@description>
+    <@description>Sponsored</@description>
 </ebay-item-tile>

--- a/src/components/ebay-item-tile/index.marko
+++ b/src/components/ebay-item-tile/index.marko
@@ -4,12 +4,16 @@ import type { FilePreviewCardFile } from '../ebay-file-preview-card/component';
 
 export type ItemTileLayout = "gallery" | "list";
 
+export interface ItemTileDescription extends Omit<Marko.HTML.P, `on${string}`> {
+    as?: string;
+};
+
 export interface ItemTileInput extends Omit<Marko.HTML.Div, 'title' | `on${string}`> {
     layout?: ItemTileLayout;
     supertitle?: Marko.AttrTag<Marko.Renderable>;
     title?: Marko.AttrTag<Marko.Renderable>;
     subtitle?: Marko.AttrTag<Marko.Renderable>;
-    description?: Marko.AttrTag<Marko.Renderable>;
+    description?: Marko.AttrTag<ItemTileDescription>;
     href?: string;
     file?: FilePreviewCardFile;
     action?: Marko.AttrTag<Marko.HTML.Button>;
@@ -65,8 +69,12 @@ $ const {
             </div>
         </if>
         <if(description)>
-            <div class="item-tile__section-tertiary" ...processHtmlAttributes(description)>
-                <${description}/>
+            <div class="item-tile__section-tertiary">
+                <for|desc, i| of=description>
+                    <${desc.as || 'p'} ...desc>
+                        <${desc}/>
+                    </>
+                </for>
             </div>
         </if>
     </div>

--- a/src/components/ebay-item-tile/index.marko
+++ b/src/components/ebay-item-tile/index.marko
@@ -1,0 +1,73 @@
+import { processHtmlAttributes } from "../../common/html-attributes";
+import type { WithNormalizedProps } from '../../global';
+import type { FilePreviewCardFile } from '../ebay-file-preview-card/component';
+
+export type ItemTileLayout = "gallery" | "list";
+
+export interface ItemTileInput extends Omit<Marko.HTML.Div, 'title' | `on${string}`> {
+    layout?: ItemTileLayout;
+    supertitle?: Marko.AttrTag<Marko.Renderable>;
+    title?: Marko.AttrTag<Marko.Renderable>;
+    subtitle?: Marko.AttrTag<Marko.Renderable>;
+    description?: Marko.AttrTag<Marko.Renderable>;
+    href?: string;
+    file?: FilePreviewCardFile;
+    action?: Marko.AttrTag<Marko.HTML.Button>;
+    "on-action"?: () => void;
+}
+
+export interface Input extends WithNormalizedProps<ItemTileInput> {}
+
+class {}
+
+$ const {
+    class: inputClass,
+    file,
+    supertitle,
+    title,
+    subtitle,
+    description,
+    href,
+    action,
+    layout,
+    ...htmlInput
+} = input;
+
+<div class=["item-tile", layout === "list" && 'item-tile--list-view',  inputClass] ...processHtmlAttributes(htmlInput)>
+    <if(file)>
+        <div class="item-tile__header">
+            <ebay-file-preview-card
+                onAction("emit", "action")
+                action=action
+                file=file
+                href=href>
+            </ebay-file-preview-card>
+        </div>
+    </if>
+    <div class="item-tile__body">
+        <if(supertitle)>
+            <div class="item-tile__section-primary" ...processHtmlAttributes(supertitle)>
+                <${supertitle}/>
+            </div>
+        </if>
+        <if(title || subtitle)>
+            <div class="item-tile__section-secondary">
+                <if(title)>
+                    <a href=href class="item-tile__title" ...processHtmlAttributes(title)>
+                        <${title}/>
+                    </a>
+                </if>
+                <if(subtitle)>
+                    <div class="item-tile__subtitle" ...processHtmlAttributes(subtitle)>
+                        <${subtitle}/>
+                    </div>
+                </if>
+            </div>
+        </if>
+        <if(description)>
+            <div class="item-tile__section-tertiary" ...processHtmlAttributes(description)>
+                <${description}/>
+            </div>
+        </if>
+    </div>
+</div>

--- a/src/components/ebay-item-tile/item-tile.stories.ts
+++ b/src/components/ebay-item-tile/item-tile.stories.ts
@@ -1,0 +1,92 @@
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import Component from "./index.marko";
+import Readme from "./README.md";
+import DefaultTemplate from "./examples/default.marko";
+import DefaultTemplateCode from "./examples/default.marko?raw";
+
+export default {
+    title: "layout/ebay-item-tile",
+    component: Component,
+    parameters: {
+        docs: {
+            description: {
+                component: Readme,
+            },
+        },
+    },
+
+    argTypes: {
+        renderBody: {
+            control: { type: "text" },
+        },
+        layout: {
+            control: { type: "select" },
+            options: ["gallery", "list"],
+            description:
+                "The layout of the item-tile. The default is gallery. The list layout takes more horizontal space and is better for displaying more information.",
+        },
+        href: {
+            control: { type: "text" },
+            description:
+                "The URL to navigate to when the item-tile is clicked. If not provided, the item will not be clickable.",
+        },
+        file: {
+            type: "object",
+            description:
+                "File object, can be raw platform `File` or an object containing `name`, `type`, and a `src` for the preview. Used to show the image in the header.",
+        },
+        action: {
+            name: "@action",
+            description:
+                "The icon to be used for the action button in the header. An aria-label is also required for accessibility. If not provided, the action button will not be rendered.",
+            table: {
+                category: "@attribute tags",
+            },
+        },
+        title: {
+            name: "@title",
+            description: "The title element of the item-tile",
+            table: {
+                category: "@attribute tags",
+            },
+        },
+        subtitle: {
+            name: "@subtitle",
+            description: "The subtitle element of the item-tile",
+            table: {
+                category: "@attribute tags",
+            },
+        },
+        supertitle: {
+            name: "@supertitle",
+            description:
+                "The supertitle element of the item-tile. This is generally used for signals rendered above the title.",
+            table: {
+                category: "@attribute tags",
+            },
+        },
+        description: {
+            name: "@description",
+            description:
+                "The description element of the item-tile. This is to render a description below the title.",
+            table: {
+                category: "@attribute tags",
+            },
+        },
+        onAction: {
+            action: "on-action",
+            description: "Triggered on action pressed",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
+    },
+};
+
+export const Default = buildExtensionTemplate(
+    DefaultTemplate,
+    DefaultTemplateCode,
+);

--- a/src/components/ebay-item-tile/item-tile.stories.ts
+++ b/src/components/ebay-item-tile/item-tile.stories.ts
@@ -68,7 +68,7 @@ export default {
         description: {
             name: "@description",
             description:
-                "The description element of the item-tile. This is to render a description below the title.",
+                "The description element of the item-tile. This is to render a description below the title in tertiary element. Defaults to <p> tag (use \"as\" attribute to change).",
             table: {
                 category: "@attribute tags",
             },

--- a/src/components/ebay-item-tile/style.ts
+++ b/src/components/ebay-item-tile/style.ts
@@ -1,0 +1,1 @@
+import "@ebay/skin/item-tile";

--- a/src/components/ebay-item-tile/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-item-tile/test/__snapshots__/test.server.js.snap
@@ -1,0 +1,247 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ebay-item-tile > renders default 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"item-tile"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"item-tile__header"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"file-preview-card"[39m
+      [36m>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"file-preview-card__body"[39m
+        [36m>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"https://ebay.com"[39m
+          [36m>[39m
+            [36m<img[39m
+              [33malt[39m=[32m"file-name.jpg"[39m
+              [33mclass[39m=[32m"file-preview-card__asset"[39m
+              [33msrc[39m=[32m"https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg"[39m
+            [36m/>[39m
+          [36m</a>[39m
+          [36m<button[39m
+            [33mclass[39m=[32m"file-preview-card__action icon-btn"[39m
+            [33mdata-ebayui[39m=[32m""[39m
+            [33mtype[39m=[32m"button"[39m
+          [36m>[39m
+            [36m<svg[39m
+              [33maria-hidden[39m=[32m"true"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
+              [33mfocusable[39m=[32m"false"[39m
+            [36m>[39m
+              [36m<defs>[39m
+                [36m<symbol[39m
+                  [33mid[39m=[32m"icon-heart-16"[39m
+                  [33mviewBox[39m=[32m"0 0 16 16"[39m
+                [36m>[39m
+                  [36m<path[39m
+                    [33mclip-rule[39m=[32m"evenodd"[39m
+                    [33md[39m=[32m"M8 2.536a6.136 6.136 0 0 0-1.448-1.053A4.409 4.409 0 0 0 4.5 1c-1.55 0-2.709.634-3.461 1.554C.31 3.443 0 4.55 0 5.5c0 .918.348 1.711.704 2.292.36.586.77 1.023.978 1.237 4.193 4.327 4.91 5.011 5.624 5.691a.996.996 0 0 0 1.388 0c.714-.68 1.43-1.364 5.624-5.69a7.23 7.23 0 0 0 .978-1.238c.356-.58.704-1.374.704-2.292 0-.95-.312-2.057-1.039-2.946C14.21 1.634 13.05 1 11.5 1c-.625 0-1.311.107-2.052.483-.48.244-.96.588-1.448 1.053Zm-.778 2.093c-.635-.753-1.155-1.15-1.574-1.362A2.412 2.412 0 0 0 4.5 3c-.95 0-1.541.366-1.914.82A2.73 2.73 0 0 0 2 5.5c0 .415.161.842.409 1.246.245.398.535.711.71.891 2.97 3.065 4.183 4.289 4.881 4.974.698-.685 1.912-1.91 4.882-4.974.174-.18.464-.493.71-.891.247-.404.408-.83.408-1.246a2.73 2.73 0 0 0-.586-1.68C13.04 3.367 12.45 3 11.5 3c-.375 0-.739.06-1.148.267-.42.213-.94.609-1.574 1.362a.998.998 0 0 1-1.208.274.994.994 0 0 1-.348-.274Z"[39m
+                    [33mfill-rule[39m=[32m"evenodd"[39m
+                  [36m/>[39m
+                [36m</symbol>[39m
+              [36m</defs>[39m
+              [36m<use[39m
+                [33mhref[39m=[32m"#icon-heart-16"[39m
+              [36m/>[39m
+            [36m</svg>[39m
+          [36m</button>[39m
+        [36m</div>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"item-tile__body"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"item-tile__section-primary"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"signal signal--time-sensitive"[39m
+        [36m>[39m
+          [0mTime Sensitive[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"item-tile__section-secondary"[39m
+      [36m>[39m
+        [36m<a[39m
+          [33mclass[39m=[32m"item-tile__title"[39m
+          [33mhref[39m=[32m"https://ebay.com"[39m
+        [36m>[39m
+          [0mApple iPhone 11 Pro Max[0m
+        [36m</a>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"item-tile__subtitle"[39m
+        [36m>[39m
+          [0m256GB Space Gray[0m
+        [36m</div>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"item-tile__section-tertiary"[39m
+      [36m>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"price"[39m
+        [36m>[39m
+          [0m$29.99 [0m
+          [36m<span[39m
+            [33mclass[39m=[32m"clipped"[39m
+          [36m>[39m
+            [0m Was: [0m
+          [36m</span>[39m
+          [36m<s[39m
+            [33mclass[39m=[32m"list-price"[39m
+          [36m>[39m
+            [0m $68.99 [0m
+          [36m</s>[39m
+        [36m</div>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"buy-links"[39m
+        [36m>[39m
+          [36m<div>[39m
+            [36m<a[39m
+              [33mhref[39m=[32m"https://ebay.com"[39m
+            [36m>[39m
+              [0m Buy it now [0m
+            [36m</a>[39m
+          [36m</div>[39m
+          [36m<div>[39m
+            [0mFree shipping[0m
+          [36m</div>[39m
+        [36m</div>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"sponsored"[39m
+        [36m>[39m
+          [0mSponsored[0m
+        [36m</div>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m"
+`;
+
+exports[`ebay-item-tile > renders with layout=list 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"item-tile item-tile--list-view"[39m
+  [36m>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"item-tile__header"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"file-preview-card"[39m
+      [36m>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"file-preview-card__body"[39m
+        [36m>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"https://ebay.com"[39m
+          [36m>[39m
+            [36m<img[39m
+              [33malt[39m=[32m"file-name.jpg"[39m
+              [33mclass[39m=[32m"file-preview-card__asset"[39m
+              [33msrc[39m=[32m"https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg"[39m
+            [36m/>[39m
+          [36m</a>[39m
+          [36m<button[39m
+            [33mclass[39m=[32m"file-preview-card__action icon-btn"[39m
+            [33mdata-ebayui[39m=[32m""[39m
+            [33mtype[39m=[32m"button"[39m
+          [36m>[39m
+            [36m<svg[39m
+              [33maria-hidden[39m=[32m"true"[39m
+              [33mclass[39m=[32m"icon icon--16"[39m
+              [33mfocusable[39m=[32m"false"[39m
+            [36m>[39m
+              [36m<defs>[39m
+                [36m<symbol[39m
+                  [33mid[39m=[32m"icon-heart-16"[39m
+                  [33mviewBox[39m=[32m"0 0 16 16"[39m
+                [36m>[39m
+                  [36m<path[39m
+                    [33mclip-rule[39m=[32m"evenodd"[39m
+                    [33md[39m=[32m"M8 2.536a6.136 6.136 0 0 0-1.448-1.053A4.409 4.409 0 0 0 4.5 1c-1.55 0-2.709.634-3.461 1.554C.31 3.443 0 4.55 0 5.5c0 .918.348 1.711.704 2.292.36.586.77 1.023.978 1.237 4.193 4.327 4.91 5.011 5.624 5.691a.996.996 0 0 0 1.388 0c.714-.68 1.43-1.364 5.624-5.69a7.23 7.23 0 0 0 .978-1.238c.356-.58.704-1.374.704-2.292 0-.95-.312-2.057-1.039-2.946C14.21 1.634 13.05 1 11.5 1c-.625 0-1.311.107-2.052.483-.48.244-.96.588-1.448 1.053Zm-.778 2.093c-.635-.753-1.155-1.15-1.574-1.362A2.412 2.412 0 0 0 4.5 3c-.95 0-1.541.366-1.914.82A2.73 2.73 0 0 0 2 5.5c0 .415.161.842.409 1.246.245.398.535.711.71.891 2.97 3.065 4.183 4.289 4.881 4.974.698-.685 1.912-1.91 4.882-4.974.174-.18.464-.493.71-.891.247-.404.408-.83.408-1.246a2.73 2.73 0 0 0-.586-1.68C13.04 3.367 12.45 3 11.5 3c-.375 0-.739.06-1.148.267-.42.213-.94.609-1.574 1.362a.998.998 0 0 1-1.208.274.994.994 0 0 1-.348-.274Z"[39m
+                    [33mfill-rule[39m=[32m"evenodd"[39m
+                  [36m/>[39m
+                [36m</symbol>[39m
+              [36m</defs>[39m
+              [36m<use[39m
+                [33mhref[39m=[32m"#icon-heart-16"[39m
+              [36m/>[39m
+            [36m</svg>[39m
+          [36m</button>[39m
+        [36m</div>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+    [36m<div[39m
+      [33mclass[39m=[32m"item-tile__body"[39m
+    [36m>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"item-tile__section-primary"[39m
+      [36m>[39m
+        [36m<span[39m
+          [33mclass[39m=[32m"signal signal--time-sensitive"[39m
+        [36m>[39m
+          [0mTime Sensitive[0m
+        [36m</span>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"item-tile__section-secondary"[39m
+      [36m>[39m
+        [36m<a[39m
+          [33mclass[39m=[32m"item-tile__title"[39m
+          [33mhref[39m=[32m"https://ebay.com"[39m
+        [36m>[39m
+          [0mApple iPhone 11 Pro Max[0m
+        [36m</a>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"item-tile__subtitle"[39m
+        [36m>[39m
+          [0m256GB Space Gray[0m
+        [36m</div>[39m
+      [36m</div>[39m
+      [36m<div[39m
+        [33mclass[39m=[32m"item-tile__section-tertiary"[39m
+      [36m>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"price"[39m
+        [36m>[39m
+          [0m$29.99 [0m
+          [36m<span[39m
+            [33mclass[39m=[32m"clipped"[39m
+          [36m>[39m
+            [0m Was: [0m
+          [36m</span>[39m
+          [36m<s[39m
+            [33mclass[39m=[32m"list-price"[39m
+          [36m>[39m
+            [0m $68.99 [0m
+          [36m</s>[39m
+        [36m</div>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"buy-links"[39m
+        [36m>[39m
+          [36m<div>[39m
+            [36m<a[39m
+              [33mhref[39m=[32m"https://ebay.com"[39m
+            [36m>[39m
+              [0m Buy it now [0m
+            [36m</a>[39m
+          [36m</div>[39m
+          [36m<div>[39m
+            [0mFree shipping[0m
+          [36m</div>[39m
+        [36m</div>[39m
+        [36m<div[39m
+          [33mclass[39m=[32m"sponsored"[39m
+        [36m>[39m
+          [0mSponsored[0m
+        [36m</div>[39m
+      [36m</div>[39m
+    [36m</div>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m"
+`;

--- a/src/components/ebay-item-tile/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-item-tile/test/__snapshots__/test.server.js.snap
@@ -83,7 +83,7 @@ exports[`ebay-item-tile > renders default 1`] = `
       [36m<div[39m
         [33mclass[39m=[32m"item-tile__section-tertiary"[39m
       [36m>[39m
-        [36m<div[39m
+        [36m<p[39m
           [33mclass[39m=[32m"price"[39m
         [36m>[39m
           [0m$29.99 [0m
@@ -97,26 +97,20 @@ exports[`ebay-item-tile > renders default 1`] = `
           [36m>[39m
             [0m $68.99 [0m
           [36m</s>[39m
-        [36m</div>[39m
-        [36m<div[39m
-          [33mclass[39m=[32m"buy-links"[39m
-        [36m>[39m
-          [36m<div>[39m
-            [36m<a[39m
-              [33mhref[39m=[32m"https://ebay.com"[39m
-            [36m>[39m
-              [0m Buy it now [0m
-            [36m</a>[39m
-          [36m</div>[39m
-          [36m<div>[39m
-            [0mFree shipping[0m
-          [36m</div>[39m
-        [36m</div>[39m
-        [36m<div[39m
-          [33mclass[39m=[32m"sponsored"[39m
-        [36m>[39m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"https://ebay.com"[39m
+          [36m>[39m
+            [0m Buy it now [0m
+          [36m</a>[39m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mFree shipping[0m
+        [36m</p>[39m
+        [36m<p>[39m
           [0mSponsored[0m
-        [36m</div>[39m
+        [36m</p>[39m
       [36m</div>[39m
     [36m</div>[39m
   [36m</div>[39m
@@ -206,7 +200,7 @@ exports[`ebay-item-tile > renders with layout=list 1`] = `
       [36m<div[39m
         [33mclass[39m=[32m"item-tile__section-tertiary"[39m
       [36m>[39m
-        [36m<div[39m
+        [36m<p[39m
           [33mclass[39m=[32m"price"[39m
         [36m>[39m
           [0m$29.99 [0m
@@ -220,26 +214,20 @@ exports[`ebay-item-tile > renders with layout=list 1`] = `
           [36m>[39m
             [0m $68.99 [0m
           [36m</s>[39m
-        [36m</div>[39m
-        [36m<div[39m
-          [33mclass[39m=[32m"buy-links"[39m
-        [36m>[39m
-          [36m<div>[39m
-            [36m<a[39m
-              [33mhref[39m=[32m"https://ebay.com"[39m
-            [36m>[39m
-              [0m Buy it now [0m
-            [36m</a>[39m
-          [36m</div>[39m
-          [36m<div>[39m
-            [0mFree shipping[0m
-          [36m</div>[39m
-        [36m</div>[39m
-        [36m<div[39m
-          [33mclass[39m=[32m"sponsored"[39m
-        [36m>[39m
+        [36m</p>[39m
+        [36m<p>[39m
+          [36m<a[39m
+            [33mhref[39m=[32m"https://ebay.com"[39m
+          [36m>[39m
+            [0m Buy it now [0m
+          [36m</a>[39m
+        [36m</p>[39m
+        [36m<p>[39m
+          [0mFree shipping[0m
+        [36m</p>[39m
+        [36m<p>[39m
           [0mSponsored[0m
-        [36m</div>[39m
+        [36m</p>[39m
       [36m</div>[39m
     [36m</div>[39m
   [36m</div>[39m

--- a/src/components/ebay-item-tile/test/test.server.js
+++ b/src/components/ebay-item-tile/test/test.server.js
@@ -1,0 +1,17 @@
+import { it } from "vitest";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../item-tile.stories"; // import all stories from the stories file
+
+const { Default } = composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
+
+describe("ebay-item-tile", () => {
+    it("renders default", async () => {
+        await htmlSnap(Default);
+    });
+
+    it("renders with layout=list", async () => {
+        await htmlSnap(Default, { layout: "list" });
+    });
+});

--- a/src/components/ebay-layout-grid/README.md
+++ b/src/components/ebay-layout-grid/README.md
@@ -1,0 +1,18 @@
+<h1 style="display: flex; justify-content: space-between; align-items: center;">
+    <span>
+        ebay-layout-grid
+    </span>
+    <span style="font-weight: normal; font-size: medium; margin-bottom: -15px;">
+        DS v1.0.0
+    </span>
+</h1>
+
+## Compatibility
+
+This component only works on Marko 5 and later.
+
+## Examples and Documentation
+
+- [Storybook](https://ebay.github.io/ebayui-core/?path=/story/building-blocks-ebay-layout-grid)
+- [Storybook Docs](https://ebay.github.io/ebayui-core/?path=/docs/building-blocks-ebay-layout-grid)
+- [Code Examples](https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-layout-grid/examples)

--- a/src/components/ebay-layout-grid/browser.json
+++ b/src/components/ebay-layout-grid/browser.json
@@ -1,0 +1,9 @@
+{
+    "requireRemap": [
+        {
+            "from": "./style",
+            "to": "../../common/empty",
+            "if-flag": "ebayui-no-skin"
+        }
+    ]
+}

--- a/src/components/ebay-layout-grid/examples/default.marko
+++ b/src/components/ebay-layout-grid/examples/default.marko
@@ -1,0 +1,26 @@
+<ebay-layout-grid ...input>
+    <@item>
+        <ebay-button fluid>Button 1</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 2</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 3</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 4</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 5</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 6</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 7</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 8</ebay-button>
+    </@item>
+</ebay-layout-grid>

--- a/src/components/ebay-layout-grid/examples/with-custom-columns.marko
+++ b/src/components/ebay-layout-grid/examples/with-custom-columns.marko
@@ -1,0 +1,34 @@
+<ebay-layout-grid
+    columns={
+        min: 2,
+        xs: 3,
+        sm: 4,
+        md: 6,
+        lg: 8
+    }
+    ...input>
+    <@item>
+        <ebay-button fluid>Button 1</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 2</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 3</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 4</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 5</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 6</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 7</ebay-button>
+    </@item>
+    <@item>
+        <ebay-button fluid>Button 8</ebay-button>
+    </@item>
+</ebay-layout-grid>

--- a/src/components/ebay-layout-grid/index.marko
+++ b/src/components/ebay-layout-grid/index.marko
@@ -1,0 +1,48 @@
+import { processHtmlAttributes } from "../../common/html-attributes";
+import type { WithNormalizedProps } from '../../global';
+
+export interface LayoutOptions  {
+    min?: number;
+    xs?: number;
+    sm?: number;
+    md?: number;
+    lg?: number;
+    xl?: number;
+    xl2?: number;
+    xl3?: number;
+    xl4?: number;
+}
+
+static interface LayoutGridInput extends Omit<Marko.HTML.Div, `on${string}`> {
+    item?: Marko.AttrTag<Marko.Renderable>
+    columns?: LayoutOptions
+}
+
+export interface Input extends WithNormalizedProps<LayoutGridInput> {}
+
+$ const {
+    item: items = [],
+    class: inputClass,
+    columns = {},
+    ...htmlInput
+} = input;
+
+<div class=["layout-grid", inputClass]
+    data-columns-min=columns.min
+    data-columns-xs=columns.xs
+    data-columns-sm=columns.sm
+    data-columns-md=columns.md
+    data-columns-lg=columns.lg
+    data-columns-xl=columns.xl
+    data-columns-xl2=columns.xl2
+    data-columns-xl3=columns.xl3
+    data-columns-xl4=columns.xl4
+>
+    <ul ...processHtmlAttributes(htmlInput)>
+        <for|item| of=items>
+            <li>
+                <${item}/>
+            </li>
+        </for>
+    </ul>
+</div>

--- a/src/components/ebay-layout-grid/layout-button.stories.ts
+++ b/src/components/ebay-layout-grid/layout-button.stories.ts
@@ -1,0 +1,69 @@
+import { buildExtensionTemplate } from "../../common/storybook/utils";
+import Component from "./index.marko";
+import Readme from "./README.md";
+import DefaultTemplate from "./examples/default.marko";
+import DefaultTemplateCode from "./examples/default.marko?raw";
+import WithCustomColumnsTemplate from "./examples/with-custom-columns.marko";
+import WithCustomColumnsTemplateCode from "./examples/with-custom-columns.marko?raw";
+
+export default {
+    title: "layout/ebay-layout-grid",
+    component: Component,
+    parameters: {
+        docs: {
+            description: {
+                component: Readme,
+            },
+        },
+    },
+
+    argTypes: {
+        renderBody: {
+            control: { type: "text" },
+        },
+        columns: {
+            control: { type: "object" },
+            description:
+                "Number of columns per screen size. Object with keys: min, xs, sm, md, lg, xl, xl2, xl3, xl4",
+
+            table: {
+                defaultValue: {
+                    summary:
+                        "{ min: 1, xs: 2, sm: 3, md: 4, lg: 6, xl: 8, xl2: 10, xl3: 12, xl4: 14 }",
+                },
+            },
+        },
+    },
+};
+
+export const Default = buildExtensionTemplate(
+    DefaultTemplate,
+    DefaultTemplateCode,
+    {
+        columns: {
+            min: 1,
+            xs: 2,
+            sm: 3,
+            md: 4,
+            lg: 6,
+            xl: 8,
+            xl2: 10,
+            xl3: 12,
+            xl4: 14,
+        },
+    },
+);
+
+export const WithCustomColumns = buildExtensionTemplate(
+    WithCustomColumnsTemplate,
+    WithCustomColumnsTemplateCode,
+    {
+        columns: {
+            min: 2,
+            xs: 3,
+            sm: 4,
+            md: 6,
+            lg: 8,
+        },
+    },
+);

--- a/src/components/ebay-layout-grid/style.ts
+++ b/src/components/ebay-layout-grid/style.ts
@@ -1,0 +1,1 @@
+import "@ebay/skin/layout-grid";

--- a/src/components/ebay-layout-grid/test/__snapshots__/test.server.js.snap
+++ b/src/components/ebay-layout-grid/test/__snapshots__/test.server.js.snap
@@ -1,0 +1,197 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ebay-layout-grid > renders default 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"layout-grid"[39m
+    [33mdata-columns-lg[39m=[32m"6"[39m
+    [33mdata-columns-md[39m=[32m"4"[39m
+    [33mdata-columns-min[39m=[32m"1"[39m
+    [33mdata-columns-sm[39m=[32m"3"[39m
+    [33mdata-columns-xl[39m=[32m"8"[39m
+    [33mdata-columns-xl2[39m=[32m"10"[39m
+    [33mdata-columns-xl3[39m=[32m"12"[39m
+    [33mdata-columns-xl4[39m=[32m"14"[39m
+    [33mdata-columns-xs[39m=[32m"2"[39m
+  [36m>[39m
+    [36m<ul>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[0]-1 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[0]-1 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[0]-1 false\\",\\"onblur\\":\\"handleBlur s0-0-3[0]-1 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 1[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[1]-2 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[1]-2 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[1]-2 false\\",\\"onblur\\":\\"handleBlur s0-0-3[1]-2 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 2[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[2]-3 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[2]-3 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[2]-3 false\\",\\"onblur\\":\\"handleBlur s0-0-3[2]-3 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 3[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[3]-4 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[3]-4 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[3]-4 false\\",\\"onblur\\":\\"handleBlur s0-0-3[3]-4 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 4[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[4]-5 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[4]-5 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[4]-5 false\\",\\"onblur\\":\\"handleBlur s0-0-3[4]-5 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 5[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[5]-6 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[5]-6 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[5]-6 false\\",\\"onblur\\":\\"handleBlur s0-0-3[5]-6 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 6[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[6]-7 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[6]-7 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[6]-7 false\\",\\"onblur\\":\\"handleBlur s0-0-3[6]-7 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 7[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[7]-8 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[7]-8 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[7]-8 false\\",\\"onblur\\":\\"handleBlur s0-0-3[7]-8 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 8[0m
+        [36m</button>[39m
+      [36m</li>[39m
+    [36m</ul>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m"
+`;
+
+exports[`ebay-layout-grid > renders with custom columns 1`] = `
+"[36m<DocumentFragment>[39m
+  [36m<div[39m
+    [33mclass[39m=[32m"layout-grid"[39m
+    [33mdata-columns-lg[39m=[32m"8"[39m
+    [33mdata-columns-md[39m=[32m"6"[39m
+    [33mdata-columns-min[39m=[32m"2"[39m
+    [33mdata-columns-sm[39m=[32m"4"[39m
+    [33mdata-columns-xs[39m=[32m"3"[39m
+  [36m>[39m
+    [36m<ul>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[0]-1 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[0]-1 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[0]-1 false\\",\\"onblur\\":\\"handleBlur s0-0-3[0]-1 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 1[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[1]-2 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[1]-2 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[1]-2 false\\",\\"onblur\\":\\"handleBlur s0-0-3[1]-2 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 2[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[2]-3 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[2]-3 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[2]-3 false\\",\\"onblur\\":\\"handleBlur s0-0-3[2]-3 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 3[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[3]-4 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[3]-4 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[3]-4 false\\",\\"onblur\\":\\"handleBlur s0-0-3[3]-4 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 4[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[4]-5 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[4]-5 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[4]-5 false\\",\\"onblur\\":\\"handleBlur s0-0-3[4]-5 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 5[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[5]-6 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[5]-6 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[5]-6 false\\",\\"onblur\\":\\"handleBlur s0-0-3[5]-6 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 6[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[6]-7 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[6]-7 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[6]-7 false\\",\\"onblur\\":\\"handleBlur s0-0-3[6]-7 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 7[0m
+        [36m</button>[39m
+      [36m</li>[39m
+      [36m<li>[39m
+        [36m<button[39m
+          [33mclass[39m=[32m"btn btn--fluid btn--secondary"[39m
+          [33mdata-ebayui[39m=[32m""[39m
+          [33mdata-marko[39m=[32m"{\\"onclick\\":\\"handleClick s0-0-3[7]-8 false\\",\\"onkeydown\\":\\"handleKeydown s0-0-3[7]-8 false\\",\\"onfocus\\":\\"handleFocus s0-0-3[7]-8 false\\",\\"onblur\\":\\"handleBlur s0-0-3[7]-8 false\\"}"[39m
+          [33mtype[39m=[32m"button"[39m
+        [36m>[39m
+          [0mButton 8[0m
+        [36m</button>[39m
+      [36m</li>[39m
+    [36m</ul>[39m
+  [36m</div>[39m
+[36m</DocumentFragment>[39m"
+`;

--- a/src/components/ebay-layout-grid/test/test.server.js
+++ b/src/components/ebay-layout-grid/test/test.server.js
@@ -1,0 +1,17 @@
+import { it } from "vitest";
+import { composeStories } from "@storybook/marko";
+import { snapshotHTML } from "../../../common/test-utils/snapshots";
+import * as stories from "../layout-button.stories"; // import all stories from the stories file
+
+const { Default, WithCustomColumns } = composeStories(stories);
+const htmlSnap = snapshotHTML(__dirname);
+
+describe("ebay-layout-grid", () => {
+    it("renders default", async () => {
+        await htmlSnap(Default);
+    });
+
+    it("renders with custom columns", async () => {
+        await htmlSnap(WithCustomColumns);
+    });
+});


### PR DESCRIPTION
## Description
* Added item-tile
* Added item-tile-group
* Added layout-grid 
* Modified file-preview-card to allow custom icon-button actions and href

## Context
* I added a requirement for marko 5 for these new components. Since marko 4 is deprecated and adding support for it would be extra tech debt, any new components will be marko 5 or greater.  (This is why we dont have a marko-tag.json)
* Formatter for marko files is broken currently. Even if we merge as is, when we do the final release, we run prettier on the whole project, so those will be fixed.
* Added a new `layout` section in storybook where item-tile and item-tile-group as well as layout-grid is located

## Structure
The structure I ended up going with (seemed the simpliest but also offering the most flexibility) was:

```
<ebay-item-tile on-action("emit", "action") href="https://ebay.com"
        file={
            name: "file-name.jpg",
            type: "image/jpeg",
            src: "https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-real-square-pic.jpg",
          }
          ...input
>
    <@action aria-label="Add to watchlist">
        <ebay-heart-16-icon/>
    </@action>
    <@supertitle>
      <ebay-signal status="time-sensitive">
        Time Sensitive
      </ebay-signal>
    </@supertitle>
      <@title>
          Apple iPhone 11 Pro Max
      </@title>
      <@subtitle>
          256GB Space Gray
      </@subtitle>
    <@description>
        <div class="price">
        $29.99
        <span class="clipped"> Was: </span>
        <s class="list-price"> $68.99 </s>
      </div>
    </@description>
</ebay-item-tile>
```
Happy to change it around as needed, but please offer suggestions if you do not like it (and rationale)

## References
https://github.com/eBay/ebayui-core/issues/2473

## Screenshots
<img width="1152" alt="Screenshot 2025-04-03 at 10 07 43 AM" src="https://github.com/user-attachments/assets/3e4859eb-6eeb-46cc-9819-a01357fd1290" />
<br/>
<img width="426" alt="Screenshot 2025-04-03 at 10 11 24 AM" src="https://github.com/user-attachments/assets/e0b72875-605a-44ef-8816-9e004c52982b" />
<br/>
<img width="289" alt="Screenshot 2025-04-03 at 10 12 44 AM" src="https://github.com/user-attachments/assets/39706ac0-25b2-4345-a7ce-c99bdf1f1464" />
