### PR TITLE
fix(listbox-button, menu-button): content collapse on button re focus

### DIFF
--- a/.changeset/fruity-lines-lose.md
+++ b/.changeset/fruity-lines-lose.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": minor
+---
+
+fix(listbox-button, menu-button): content collapse on button re focus

--- a/src/components/ebay-listbox-button/component.ts
+++ b/src/components/ebay-listbox-button/component.ts
@@ -123,6 +123,7 @@ class ListboxButton extends Marko.Component<Input, State> {
                 hostSelector: ".listbox-button__control",
                 expandedClass: "listbox-button--expanded",
                 focusManagement: "content",
+                collapseOnHostReFocus: true,
             });
 
             scrollKeyPreventer.add(this.getEl("button"));

--- a/src/components/ebay-menu-button/component.ts
+++ b/src/components/ebay-menu-button/component.ts
@@ -229,6 +229,7 @@ export default class extends MenuUtils<Input, MenuState> {
             expandOnClick: true,
             autoCollapse: true,
             alwaysDoFocusManagement: true,
+            collapseOnHostReFocus: true,
         });
 
         this.dropdownUtil = new DropdownUtil(

--- a/src/components/ebay-menu/component.ts
+++ b/src/components/ebay-menu/component.ts
@@ -208,7 +208,7 @@ export default class extends MenuUtils<Input, MenuState> {
 
         this.rovingTabindex = createLinear(this.contentEl, "div", {
             index: this.tabindexPosition,
-            autoReset: null,
+            autoReset: "interactive",
         });
 
         scrollKeyPreventer.add(this.contentEl);


### PR DESCRIPTION
<!-- Delete any sections below that are not relevant. -->

## Description
Fixes #1778, 
Fixes #2223

<!--- What are the changes? -->

## Context
- Updated [makeup-expander](https://github.com/makeup/makeup-js/pull/205) to handle closing expander on host re focus from content element.
- Exposed the option `collapseOnHostReFocus` on makeup to collapse content on re focus for listbox and menu button
- To reset the roving tab index after collapse, set menu `autoReset: interactive`

