### PR TITLE
fix: honor snackbar dialog input.open if type boolean

### DIFF
--- a/.changeset/dull-monkeys-post.md
+++ b/.changeset/dull-monkeys-post.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ebayui-core": patch
+---
+
+Fix: honor input.open for ebay-snackbar-dialog if boolean

--- a/src/components/ebay-snackbar-dialog/component.ts
+++ b/src/components/ebay-snackbar-dialog/component.ts
@@ -35,7 +35,12 @@ class SnackbarDialog extends Marko.Component<Input, State> {
     }
 
     onInput(input: Input) {
-        this.state = { open: input.open || this.state.open || false };
+        this.state = {
+            open:
+                typeof input.open === "boolean"
+                    ? input.open
+                    : this.state.open || false,
+        };
     }
 
     onMount() {


### PR DESCRIPTION
## Description
Fix logic for `ebay-snackbar-dialog` `onInput()` function to correctly update open state based on input

## Context
Updating `ebay-snackbar-dialog` open input to `false`, `<ebay-snackbar-dialog open=state.open />`, does not close the snackbar component. The current logic is overriding `input.open` to use `this.state.open` if `input.open` is falsy, preventing the snackbar from closing. This code change honors `input.open` if it's type boolean before falling back to `this.state.open`.

## References
Issue: https://github.com/eBay/evo-web/issues/7

## Screenshots
Before

https://github.com/user-attachments/assets/f7f58e6c-3fd4-45ff-9ecc-a502ff0ed002



After

https://github.com/user-attachments/assets/242c8e17-b86b-423f-b0ab-5151c62c1f9e

